### PR TITLE
Add side panel layout option for ticket forms

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -68,6 +68,7 @@ const App: React.FC = () => {
   const [selectedJobSummary, setSelectedJobSummary] = useState<Job | null>(null);
   const [showMarkup, setShowMarkup] = useState<Job | null>(null);
   const [editingTicket, setEditingTicket] = useState<DigTicket | null>(null);
+  const [editFromMap, setEditFromMap] = useState(false);
   const [editingJob, setEditingJob] = useState<Job | null>(null);
   const [noShowTicket, setNoShowTicket] = useState<DigTicket | null>(null);
   const [notesTicket, setNotesTicket] = useState<DigTicket | null>(null);
@@ -1073,7 +1074,7 @@ const App: React.FC = () => {
                 {(!isInboundEnabled || ticketMode === 'regular') && <MapView
                   tickets={activeTicketsList}
                   isDarkMode={isDarkMode}
-                  onEditTicket={isAdmin ? setEditingTicket : undefined}
+                  onEditTicket={isAdmin ? (ticket) => { setEditFromMap(true); setEditingTicket(ticket); } : undefined}
                   onViewTicket={setViewingDocUrl}
                   onTicketGeocoded={(id, lat, lng) => {
                     setTickets(prev => prev.map(t => t.id === id ? { ...t, lat, lng } : t));
@@ -1114,7 +1115,7 @@ const App: React.FC = () => {
       </nav>
 
       {/* ── MODALS ── */}
-      {(showTicketForm || editingTicket) && <TicketForm onSave={handleSaveTicket} onDelete={editingTicket ? handleDeleteTicket : undefined} onClose={() => { setShowTicketForm(false); setEditingTicket(null); }} initialData={editingTicket} isDarkMode={isDarkMode} existingTickets={tickets} />}
+      {(showTicketForm || editingTicket) && <TicketForm onSave={handleSaveTicket} onDelete={editingTicket ? handleDeleteTicket : undefined} onClose={() => { setShowTicketForm(false); setEditingTicket(null); setEditFromMap(false); }} initialData={editingTicket} isDarkMode={isDarkMode} existingTickets={tickets} sidePanel={editFromMap} />}
       {(showJobForm || editingJob) && <JobForm onSave={async (data) => { const job: Job = editingJob ? { ...editingJob, ...data } : { ...data, id: crypto.randomUUID(), companyId: sessionUser.companyId, createdAt: Date.now(), isComplete: false }; const saved = await apiService.saveJob(job); setJobs(prev => [...prev.filter(j => j.id !== saved.id), saved]); setShowJobForm(false); setEditingJob(null); }} onClose={() => { setShowJobForm(false); setEditingJob(null); }} initialData={editingJob || undefined} isDarkMode={isDarkMode} />}
       {selectedJobSummary && <JobSummaryModal job={selectedJobSummary} onClose={() => setSelectedJobSummary(null)} onEdit={() => { setEditingJob(selectedJobSummary); setShowJobForm(true); setSelectedJobSummary(null); }} onDelete={() => { apiService.deleteJob(selectedJobSummary.id).then(() => initApp()); setSelectedJobSummary(null); }} onToggleComplete={async () => { await apiService.saveJob({ ...selectedJobSummary, isComplete: !selectedJobSummary.isComplete }); initApp(); }} onViewMedia={() => { setMediaFolderFilter(selectedJobSummary.jobNumber); handleNavigate('photos'); }} onViewMarkup={() => { setShowMarkup(selectedJobSummary); setSelectedJobSummary(null); }} isDarkMode={isDarkMode} />}
       {showMarkup && <JobPrintMarkup job={showMarkup} isAdmin={isAdmin} sessionUser={sessionUser} onClose={() => setShowMarkup(null)} isDarkMode={isDarkMode} />}

--- a/components/InboundMapView.tsx
+++ b/components/InboundMapView.tsx
@@ -300,6 +300,7 @@ const InboundMapView: React.FC<InboundMapViewProps> = ({
           sessionUser={sessionUser}
           isAdmin={isAdmin}
           isDarkMode={dm}
+          sidePanel
           onClose={() => setDetailTicket(null)}
           onTicketUpdated={updated => {
             setTickets(prev => prev.map(t => t.id === updated.id ? updated : t));

--- a/components/InboundTicketDetail.tsx
+++ b/components/InboundTicketDetail.tsx
@@ -21,6 +21,7 @@ interface InboundTicketDetailProps {
   sessionUser: User;
   isAdmin:     boolean;
   isDarkMode?: boolean;
+  sidePanel?:  boolean;
   onClose:     () => void;
   onTicketUpdated: (ticket: InboundTicket) => void;
   onTicketDeleted: (id: string) => void;
@@ -225,6 +226,7 @@ const InboundTicketDetail: React.FC<InboundTicketDetailProps> = ({
   sessionUser,
   isAdmin,
   isDarkMode,
+  sidePanel = false,
   onClose,
   onTicketUpdated,
   onTicketDeleted,
@@ -397,11 +399,15 @@ const InboundTicketDetail: React.FC<InboundTicketDetailProps> = ({
     }`;
 
   return (
-    <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-md z-[200] flex items-center justify-center p-4">
+    <div className={sidePanel
+      ? 'fixed inset-y-0 right-0 z-[200] flex'
+      : 'fixed inset-0 bg-slate-950/80 backdrop-blur-md z-[200] flex items-center justify-center p-4'
+    }>
       <div
-        className={`w-full max-w-2xl rounded-[2rem] shadow-2xl border overflow-hidden flex flex-col max-h-[92vh] ${
-          dm ? 'bg-[#0b1629] border-white/10' : 'bg-white border-slate-200'
-        }`}
+        className={sidePanel
+          ? `w-[420px] max-w-[90vw] h-full border-l overflow-hidden flex flex-col shadow-2xl ${dm ? 'bg-[#0b1629] border-white/10' : 'bg-white border-slate-200'}`
+          : `w-full max-w-2xl rounded-[2rem] shadow-2xl border overflow-hidden flex flex-col max-h-[92vh] ${dm ? 'bg-[#0b1629] border-white/10' : 'bg-white border-slate-200'}`
+        }
       >
         {/* Header */}
         <div className={`flex items-start justify-between px-7 py-5 border-b shrink-0 ${dm ? 'border-white/[0.06]' : 'border-slate-100'}`}>

--- a/components/TicketForm.tsx
+++ b/components/TicketForm.tsx
@@ -23,6 +23,7 @@ interface TicketFormProps {
   initialData?: DigTicket | null;
   isDarkMode?: boolean;
   existingTickets?: DigTicket[];
+  sidePanel?: boolean;
 }
 
 const normalizeDateStr = (date: string) => {
@@ -42,7 +43,7 @@ const getSafeMimeType = (file: File): string => {
   }
 };
 
-export const TicketForm: React.FC<TicketFormProps> = ({ onSave, onDelete, onClose, initialData, isDarkMode, existingTickets }) => {
+export const TicketForm: React.FC<TicketFormProps> = ({ onSave, onDelete, onClose, initialData, isDarkMode, existingTickets, sidePanel = false }) => {
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [isSubmittingManual, setIsSubmittingManual] = useState(false);
   const [isSavingAll, setIsSavingAll] = useState(false);
@@ -326,12 +327,18 @@ export const TicketForm: React.FC<TicketFormProps> = ({ onSave, onDelete, onClos
   };
 
   return (
-    <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-md z-[160] flex items-center justify-center p-4 overflow-y-auto">
-      <div 
+    <div className={sidePanel
+      ? 'fixed inset-y-0 right-0 z-[160] flex'
+      : 'fixed inset-0 bg-slate-950/80 backdrop-blur-md z-[160] flex items-center justify-center p-4 overflow-y-auto'
+    }>
+      <div
         onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
         onDragLeave={() => setIsDragging(false)}
         onDrop={(e) => { e.preventDefault(); setIsDragging(false); handleFileUpload(e as any); }}
-        className={`w-full max-w-2xl rounded-[2.5rem] shadow-2xl overflow-hidden border transition-all duration-300 my-auto flex flex-col max-h-[calc(100vh-2rem)] ${isDragging ? 'scale-105 ring-4 ring-brand/50' : ''} ${isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'}`}
+        className={sidePanel
+          ? `w-[500px] max-w-[90vw] h-full border-l overflow-hidden flex flex-col shadow-2xl transition-all duration-300 ${isDragging ? 'ring-4 ring-brand/50' : ''} ${isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'}`
+          : `w-full max-w-2xl rounded-[2.5rem] shadow-2xl overflow-hidden border transition-all duration-300 my-auto flex flex-col max-h-[calc(100vh-2rem)] ${isDragging ? 'scale-105 ring-4 ring-brand/50' : ''} ${isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'}`
+        }
       >
         <div className="px-10 py-6 border-b flex justify-between items-center bg-black/5">
           <div className="flex-1">


### PR DESCRIPTION
## Summary
This PR adds support for displaying ticket forms and details in a side panel layout instead of the default centered modal. This provides a better UX when editing tickets from the map view, allowing users to see both the map and the form simultaneously.

## Key Changes
- Added `sidePanel` prop to `TicketForm` and `InboundTicketDetail` components to conditionally render as a right-aligned side panel instead of a centered modal
- Updated styling to support side panel layout:
  - Side panel uses full viewport height with fixed width (500px for TicketForm, 420px for InboundTicketDetail)
  - Removed rounded corners, backdrop blur, and centering when in side panel mode
  - Maintained dark mode support for both layouts
- Modified `App.tsx` to track when editing is initiated from the map view via new `editFromMap` state
- Updated map view ticket edit handler to set `editFromMap` flag and pass `sidePanel` prop to TicketForm
- Updated `InboundMapView` to always render InboundTicketDetail as a side panel

## Implementation Details
- The side panel layout uses `fixed inset-y-0 right-0` positioning to anchor to the right edge of the viewport
- Both components maintain their existing functionality and styling logic, with conditional className application based on the `sidePanel` prop
- The `editFromMap` state is properly reset when closing the form to ensure correct layout on subsequent opens

https://claude.ai/code/session_01LFEjZKZikghtUNFxeQCEUL