### PR TITLE
Add CSV/spreadsheet import for equipment and materials lists

### DIFF
--- a/components/scheduling/CsvImportModal.tsx
+++ b/components/scheduling/CsvImportModal.tsx
@@ -1,0 +1,270 @@
+import { useRef, useState } from 'react';
+import * as XLSX from 'xlsx';
+import { X, FileSpreadsheet, CheckCircle, AlertCircle } from 'lucide-react';
+import { scheduleService } from '../../services/scheduleService.ts';
+
+type ImportType = 'equipment' | 'materials';
+
+interface CsvImportModalProps {
+  type: ImportType;
+  companyId: string;
+  isDarkMode?: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}
+
+type EquipmentDraft = { name: string; hourlyRate: number };
+type MaterialDraft  = { name: string; unitPrice: number | null };
+
+function norm(s: string) { return s.toLowerCase().replace(/[\s_\-\/]/g, ''); }
+
+function findKey(keys: string[], candidates: string[]): string | undefined {
+  return keys.find(k => candidates.includes(norm(k)));
+}
+
+async function parseSpreadsheet(file: File): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const data = new Uint8Array(e.target!.result as ArrayBuffer);
+        const wb = XLSX.read(data, { type: 'array' });
+        const ws = wb.Sheets[wb.SheetNames[0]];
+        resolve(XLSX.utils.sheet_to_json<Record<string, unknown>>(ws, { defval: '' }));
+      } catch (err) { reject(err); }
+    };
+    reader.onerror = reject;
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+function toEquipmentRows(raw: Record<string, unknown>[]): EquipmentDraft[] {
+  return raw.map(row => {
+    const keys = Object.keys(row);
+    const nameKey = findKey(keys, ['name', 'equipment', 'item', 'description', 'equipmentname']) ?? keys[0];
+    const rateKey = findKey(keys, ['hourlyrate', 'rate', 'hr', 'hourlycost', 'costperhr', 'costperhour', 'hourlyrental']) ?? keys[1];
+    const rawRate = String(row[rateKey ?? ''] ?? '').replace(/[^0-9.]/g, '');
+    return {
+      name: String(row[nameKey ?? ''] ?? '').trim(),
+      hourlyRate: rawRate ? parseFloat(rawRate) : 0,
+    };
+  }).filter(r => r.name);
+}
+
+function toMaterialRows(raw: Record<string, unknown>[]): MaterialDraft[] {
+  return raw.map(row => {
+    const keys = Object.keys(row);
+    const nameKey = findKey(keys, ['name', 'material', 'item', 'description', 'materialname']) ?? keys[0];
+    const priceKey = findKey(keys, ['unitprice', 'price', 'cost', 'unitcost', 'priceperunit', 'rate']) ?? keys[1];
+    const rawPrice = priceKey ? String(row[priceKey] ?? '').replace(/[^0-9.]/g, '') : '';
+    return {
+      name: String(row[nameKey ?? ''] ?? '').trim(),
+      unitPrice: rawPrice ? parseFloat(rawPrice) : null,
+    };
+  }).filter(r => r.name);
+}
+
+function downloadTemplate(type: ImportType) {
+  const header  = type === 'equipment' ? 'name,hourlyRate' : 'name,unitPrice';
+  const example = type === 'equipment'
+    ? 'Excavator,75\nDump Truck,50\nCompactor,40'
+    : 'Concrete (cu yd),120\nRebar (ton),850\nConduit (ft),3.50';
+  const blob = new Blob([`${header}\n${example}`], { type: 'text/csv' });
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement('a');
+  a.href     = url;
+  a.download = `${type}-template.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function CsvImportModal({ type, companyId, isDarkMode, onClose, onImported }: CsvImportModalProps) {
+  const [isDragging,   setIsDragging]   = useState(false);
+  const [equipRows,    setEquipRows]    = useState<EquipmentDraft[] | null>(null);
+  const [matRows,      setMatRows]      = useState<MaterialDraft[]  | null>(null);
+  const [parseError,   setParseError]   = useState<string | null>(null);
+  const [importing,    setImporting]    = useState(false);
+  const [importError,  setImportError]  = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const label = type === 'equipment' ? 'Equipment' : 'Materials';
+  const rows  = (type === 'equipment' ? equipRows : matRows) as (EquipmentDraft | MaterialDraft)[] | null;
+  const count = rows?.length ?? 0;
+
+  const overlay  = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+  const card     = isDarkMode ? 'bg-slate-800 border-slate-700 text-slate-100' : 'bg-white border-slate-200 text-slate-900';
+  const subtext  = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const dropZone = [
+    'border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition',
+    isDragging
+      ? 'border-brand bg-brand/5'
+      : isDarkMode ? 'border-slate-600 hover:border-slate-400' : 'border-slate-300 hover:border-slate-400',
+  ].join(' ');
+  const thCls = `px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide border-b ${isDarkMode ? 'text-slate-400 border-slate-700' : 'text-slate-500 border-slate-200'}`;
+  const tdCls = `px-3 py-1.5 border-b text-sm ${isDarkMode ? 'border-slate-700 text-slate-200' : 'border-slate-100 text-slate-700'}`;
+
+  const clearRows = () => { setEquipRows(null); setMatRows(null); setParseError(null); };
+
+  const processFile = async (file: File) => {
+    clearRows();
+    try {
+      const raw = await parseSpreadsheet(file);
+      if (type === 'equipment') setEquipRows(toEquipmentRows(raw));
+      else setMatRows(toMaterialRows(raw));
+    } catch {
+      setParseError('Could not parse this file. Make sure it is a valid CSV or Excel spreadsheet.');
+    }
+  };
+
+  const handleFiles = (files: FileList | null) => { if (files?.length) processFile(files[0]); };
+
+  const doImport = async () => {
+    if (!rows?.length) return;
+    setImporting(true);
+    setImportError(null);
+    try {
+      if (type === 'equipment') {
+        await scheduleService.bulkCreateEquipment(companyId, equipRows!);
+      } else {
+        await scheduleService.bulkCreateMaterial(companyId, matRows!);
+      }
+      onImported();
+      onClose();
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : 'Import failed. Please try again.');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <div className={overlay} onClick={onClose}>
+      <div
+        className={`w-full max-w-lg mx-4 rounded-2xl border shadow-2xl ${card} p-6`}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-bold">Import {label} List</h2>
+          <button onClick={onClose} className={`${subtext} hover:text-rose-500 transition`}><X size={20} /></button>
+        </div>
+
+        {/* Drop zone (shown until a file is parsed) */}
+        {!rows && (
+          <>
+            <div
+              className={dropZone}
+              onDragOver={e => { e.preventDefault(); setIsDragging(true); }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={e => { e.preventDefault(); setIsDragging(false); handleFiles(e.dataTransfer.files); }}
+              onClick={() => fileRef.current?.click()}
+            >
+              <FileSpreadsheet size={40} className="mx-auto mb-3 text-brand opacity-80" />
+              <p className="font-semibold">Drop your spreadsheet here</p>
+              <p className={`text-sm mt-1 ${subtext}`}>or click to browse — CSV, XLSX, or XLS</p>
+              <input
+                ref={fileRef}
+                type="file"
+                className="hidden"
+                accept=".csv,.xlsx,.xls"
+                onChange={e => handleFiles(e.target.files)}
+              />
+            </div>
+
+            <div className={`mt-3 text-xs ${subtext} text-center`}>
+              Expected columns:{' '}
+              <code className="font-mono">name</code>,{' '}
+              <code className="font-mono">{type === 'equipment' ? 'hourlyRate' : 'unitPrice'}</code>
+              {' · '}
+              <button
+                className="underline hover:opacity-75"
+                onClick={e => { e.stopPropagation(); downloadTemplate(type); }}
+              >
+                Download template
+              </button>
+            </div>
+
+            {parseError && (
+              <div className="flex items-start gap-2 p-3 mt-3 rounded-lg bg-rose-50 border border-rose-200 text-rose-700 text-sm">
+                <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                <span>{parseError}</span>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Preview table */}
+        {rows && rows.length > 0 && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <CheckCircle size={16} className="text-emerald-500 shrink-0" />
+              <span className="text-sm font-medium">{count} row{count !== 1 ? 's' : ''} ready to import</span>
+              <button onClick={clearRows} className={`ml-auto text-xs underline ${subtext}`}>Change file</button>
+            </div>
+
+            <div className={`overflow-auto max-h-56 rounded-lg border ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
+              <table className="w-full">
+                <thead className={isDarkMode ? 'bg-slate-900' : 'bg-slate-50'}>
+                  <tr>
+                    <th className={thCls}>Name</th>
+                    <th className={`${thCls} text-right`}>{type === 'equipment' ? 'Rate / hr' : 'Unit Price'}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r, i) => (
+                    <tr key={i}>
+                      <td className={tdCls}>{r.name}</td>
+                      <td className={`${tdCls} text-right`}>
+                        {type === 'equipment'
+                          ? `$${(r as EquipmentDraft).hourlyRate.toFixed(2)}/hr`
+                          : (r as MaterialDraft).unitPrice != null
+                            ? `$${(r as MaterialDraft).unitPrice!.toFixed(2)}`
+                            : <span className={subtext}>—</span>}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {importError && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-rose-50 border border-rose-200 text-rose-700 text-sm">
+                <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                <span>{importError}</span>
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className={`flex-1 py-2 rounded-lg border text-sm font-semibold transition ${isDarkMode ? 'border-slate-600 hover:bg-slate-700' : 'border-slate-300 hover:bg-slate-50'}`}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={doImport}
+                disabled={importing}
+                className="flex-1 py-2 rounded-lg bg-brand text-white text-sm font-semibold disabled:opacity-60 transition"
+              >
+                {importing ? 'Importing…' : `Import ${count} item${count !== 1 ? 's' : ''}`}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Empty parse result */}
+        {rows && rows.length === 0 && (
+          <div className={`text-sm text-center py-6 space-y-2 ${subtext}`}>
+            <p>No valid rows found. Make sure the file has a header row with:</p>
+            <p>
+              <code className="font-mono text-xs">name</code>
+              {', '}
+              <code className="font-mono text-xs">{type === 'equipment' ? 'hourlyRate' : 'unitPrice'}</code>
+            </p>
+            <button className="underline text-xs mt-1" onClick={clearRows}>Try another file</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/scheduling/ResourcesManager.tsx
+++ b/components/scheduling/ResourcesManager.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Plus, Trash2, Users, Wrench, Package } from 'lucide-react';
+import { Plus, Trash2, Users, Wrench, Package, Upload } from 'lucide-react';
 import { scheduleService } from '../../services/scheduleService.ts';
 import { Employee, Equipment, Material } from '../../services/schedulingTypes.ts';
+import CsvImportModal from './CsvImportModal.tsx';
 
 type ResourceTab = 'employees' | 'equipment' | 'materials';
 
@@ -23,6 +24,7 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
   const [equipment, setEquipment] = useState<Equipment[]>([]);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [loading, setLoading] = useState(true);
+  const [csvModal, setCsvModal] = useState<'equipment' | 'materials' | null>(null);
 
   // New-row drafts
   const [empDraft, setEmpDraft] = useState({ name: '', role: '', hourlyRate: '' });
@@ -155,13 +157,23 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
               ))}
               {equipment.length === 0 && <p className={subtext}>No equipment yet.</p>}
               {isAdmin && (
-                <div className="flex flex-col sm:flex-row gap-2 pt-3">
-                  <input className={input} placeholder="Name" value={eqDraft.name} onChange={e => setEqDraft({ ...eqDraft, name: e.target.value })} />
-                  <input className={input} placeholder="Rate/hr" type="number" value={eqDraft.hourlyRate} onChange={e => setEqDraft({ ...eqDraft, hourlyRate: e.target.value })} />
-                  <button onClick={addEquipment} className="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap">
-                    <Plus size={16} />Add
-                  </button>
-                </div>
+                <>
+                  <div className="flex flex-col sm:flex-row gap-2 pt-3">
+                    <input className={input} placeholder="Name" value={eqDraft.name} onChange={e => setEqDraft({ ...eqDraft, name: e.target.value })} />
+                    <input className={input} placeholder="Rate/hr" type="number" value={eqDraft.hourlyRate} onChange={e => setEqDraft({ ...eqDraft, hourlyRate: e.target.value })} />
+                    <button onClick={addEquipment} className="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap">
+                      <Plus size={16} />Add
+                    </button>
+                  </div>
+                  <div className="pt-1">
+                    <button
+                      onClick={() => setCsvModal('equipment')}
+                      className={`flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-lg border transition ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+                    >
+                      <Upload size={14} />Import CSV / Spreadsheet
+                    </button>
+                  </div>
+                </>
               )}
             </div>
           )}
@@ -182,17 +194,37 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
               ))}
               {materials.length === 0 && <p className={subtext}>No materials yet.</p>}
               {isAdmin && (
-                <div className="flex flex-col sm:flex-row gap-2 pt-3">
-                  <input className={input} placeholder="Name" value={matDraft.name} onChange={e => setMatDraft({ ...matDraft, name: e.target.value })} />
-                  <input className={input} placeholder="Unit price (blank = unlisted)" type="number" value={matDraft.unitPrice} onChange={e => setMatDraft({ ...matDraft, unitPrice: e.target.value })} />
-                  <button onClick={addMaterial} className="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap">
-                    <Plus size={16} />Add
-                  </button>
-                </div>
+                <>
+                  <div className="flex flex-col sm:flex-row gap-2 pt-3">
+                    <input className={input} placeholder="Name" value={matDraft.name} onChange={e => setMatDraft({ ...matDraft, name: e.target.value })} />
+                    <input className={input} placeholder="Unit price (blank = unlisted)" type="number" value={matDraft.unitPrice} onChange={e => setMatDraft({ ...matDraft, unitPrice: e.target.value })} />
+                    <button onClick={addMaterial} className="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap">
+                      <Plus size={16} />Add
+                    </button>
+                  </div>
+                  <div className="pt-1">
+                    <button
+                      onClick={() => setCsvModal('materials')}
+                      className={`flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-lg border transition ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+                    >
+                      <Upload size={14} />Import CSV / Spreadsheet
+                    </button>
+                  </div>
+                </>
               )}
             </div>
           )}
         </div>
+      )}
+
+      {csvModal && (
+        <CsvImportModal
+          type={csvModal}
+          companyId={companyId}
+          isDarkMode={isDarkMode}
+          onClose={() => setCsvModal(null)}
+          onImported={reload}
+        />
       )}
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lucide-react": "^0.546.0",
     "pdfjs-dist": "4.4.168",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/react": "^19.2.3",

--- a/services/scheduleService.ts
+++ b/services/scheduleService.ts
@@ -191,6 +191,20 @@ export const scheduleService = {
     if (error) throw error;
   },
 
+  async bulkCreateEquipment(companyId: string, items: Omit<Equipment, 'id' | 'companyId'>[]): Promise<Equipment[]> {
+    const rows = items.map(e => ({ company_id: companyId, name: e.name, hourly_rate: e.hourlyRate }));
+    const { data, error } = await supabase.from('equipment').insert(rows).select();
+    if (error) throw error;
+    return (data ?? []).map(r => mapEquipment(r as Record<string, unknown>));
+  },
+
+  async bulkCreateMaterial(companyId: string, items: Omit<Material, 'id' | 'companyId'>[]): Promise<Material[]> {
+    const rows = items.map(m => ({ company_id: companyId, name: m.name, unit_price: m.unitPrice }));
+    const { data, error } = await supabase.from('materials').insert(rows).select();
+    if (error) throw error;
+    return (data ?? []).map(r => mapMaterial(r as Record<string, unknown>));
+  },
+
   // ── Service jobs (billing entity, with nested work logs) ────────────────────
   async getServiceJobs(): Promise<ServiceJob[]> {
     const { data, error } = await supabase


### PR DESCRIPTION
Adds an "Import CSV / Spreadsheet" button in the Equipment and Materials
tabs of ResourcesManager. Clicking it opens a modal where admins can
drop or browse for a .csv, .xlsx, or .xls file, preview the parsed rows,
then bulk-import them in one step.

- New CsvImportModal component: drag-and-drop upload zone, flexible column
  header matching (name/rate/price in common variations), preview table,
  downloadable template, and import progress/error handling
- bulkCreateEquipment / bulkCreateMaterial added to scheduleService for
  single-round-trip batch inserts
- xlsx (SheetJS) added as a dependency for CSV and Excel parsing