### PR TITLE
fix: apply DB migration and repair CSV equipment field extrapolation

### DIFF
--- a/components/scheduling/CsvImportModal.tsx
+++ b/components/scheduling/CsvImportModal.tsx
@@ -23,7 +23,7 @@ type EquipmentDraft = {
 };
 type MaterialDraft  = { name: string; unitPrice: number | null };
 
-function norm(s: string) { return s.toLowerCase().replace(/[\s_\-\/]/g, ''); }
+function norm(s: string) { return s.toLowerCase().replace(/[\s_\-\/\.#()]/g, ''); }
 
 function findKey(keys: string[], candidates: string[]): string | undefined {
   return keys.find(k => candidates.includes(norm(k)));

--- a/services/scheduleService.ts
+++ b/services/scheduleService.ts
@@ -162,8 +162,13 @@ export const scheduleService = {
 
   async updateEquipment(id: string, updates: Partial<Omit<Equipment, 'id' | 'companyId'>>): Promise<void> {
     const db: Record<string, unknown> = {};
-    if (updates.name       !== undefined) db.name        = updates.name;
-    if (updates.hourlyRate !== undefined) db.hourly_rate = updates.hourlyRate;
+    if (updates.name          !== undefined) db.name           = updates.name;
+    if (updates.hourlyRate    !== undefined) db.hourly_rate    = updates.hourlyRate;
+    if (updates.unitNumber    !== undefined) db.unit_number    = updates.unitNumber;
+    if (updates.equipmentType !== undefined) db.equipment_type = updates.equipmentType;
+    if (updates.year          !== undefined) db.year           = updates.year;
+    if (updates.make          !== undefined) db.make           = updates.make;
+    if (updates.model         !== undefined) db.model          = updates.model;
     const { error } = await supabase.from('inventory_items').update(db).eq('id', id);
     if (error) throw error;
   },


### PR DESCRIPTION
- Applied the add_equipment_detail_fields migration directly to the
  database (unit_number, equipment_type, year, make, model columns were
  missing from inventory_items, so bulk inserts silently dropped them).
- Widen norm() to also strip dots and common punctuation (.#()) so
  real-world column headers like "Model No." and "Unit #" resolve to
  the correct candidates.
- Fix updateEquipment() to persist unit_number, equipment_type, year,
  make, and model; previously those fields were overwritten with NULL
  whenever any equipment record was edited.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Kz2mQHk3AciCqvGuN19Ft