### PR TITLE
Redesign scheduler dispatch board for a more professional UI/UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 dist/
 package-lock.json
+
+# Throwaway Scheduler preview build artifacts
+preview-dist/
+DigTrackPro-Scheduler-Preview.html

--- a/components/scheduling/CsvImportModal.tsx
+++ b/components/scheduling/CsvImportModal.tsx
@@ -111,7 +111,7 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
   const rows  = (type === 'equipment' ? equipRows : matRows) as (EquipmentDraft | MaterialDraft)[] | null;
   const count = rows?.length ?? 0;
 
-  const overlay  = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+  const overlay  = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4';
   const card     = isDarkMode ? 'bg-slate-800 border-slate-700 text-slate-100' : 'bg-white border-slate-200 text-slate-900';
   const subtext  = isDarkMode ? 'text-slate-400' : 'text-slate-500';
   const dropZone = [
@@ -166,13 +166,18 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
   return (
     <div className={overlay} onClick={onClose}>
       <div
-        className={`w-full max-w-2xl mx-4 rounded-2xl border shadow-2xl ${card} p-6`}
+        className={`w-full max-w-2xl rounded-2xl border shadow-2xl ${card} p-6`}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-lg font-bold">Import {label} List</h2>
-          <button onClick={onClose} className={`${subtext} hover:text-rose-500 transition`}><X size={20} /></button>
+          <div className="flex items-center gap-2.5">
+            <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-brand/10 text-brand">
+              <FileSpreadsheet size={16} />
+            </span>
+            <h2 className="text-lg font-bold">Import {label} List</h2>
+          </div>
+          <button onClick={onClose} className={`w-8 h-8 flex items-center justify-center rounded-lg ${subtext} hover:text-rose-500 hover:bg-rose-500/10 transition`}><X size={18} /></button>
         </div>
 
         {/* Drop zone (shown until a file is parsed) */}

--- a/components/scheduling/InvoiceView.tsx
+++ b/components/scheduling/InvoiceView.tsx
@@ -66,7 +66,9 @@ export default function InvoiceView({ companyId, companyName, isAdmin, isDarkMod
   const card    = isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-slate-200';
   const text    = isDarkMode ? 'text-slate-100' : 'text-slate-900';
   const subtext = isDarkMode ? 'text-slate-400' : 'text-slate-500';
-  const input   = `px-3 py-2 rounded-lg border text-sm w-full ${isDarkMode ? 'bg-slate-900 border-slate-600 text-slate-100' : 'bg-white border-slate-300 text-slate-900'}`;
+  const input   = `px-3 py-2 rounded-lg border text-sm w-full transition focus:outline-none focus:ring-2 focus:ring-brand/20 focus:border-brand ${isDarkMode ? 'bg-slate-900 border-slate-600 text-slate-100' : 'bg-white border-slate-300 text-slate-900'}`;
+  const rowCls  = isDarkMode ? 'border-slate-700/70 hover:bg-slate-700/40' : 'border-slate-100 hover:bg-slate-50';
+  const ghostBtn = `flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-200 hover:bg-slate-700' : 'border-slate-300 text-slate-700 hover:bg-slate-50'}`;
 
   const downloadFor = (job: ServiceJob, existing?: Invoice) => {
     const totals = existing
@@ -118,66 +120,77 @@ export default function InvoiceView({ companyId, companyName, isAdmin, isDarkMod
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h3 className={`text-base font-bold ${text}`}>Invoices</h3>
+        <div className="flex items-center gap-2.5">
+          <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-brand/10 text-brand">
+            <Receipt size={16} />
+          </span>
+          <h3 className={`text-base font-bold ${text}`}>Invoices</h3>
+        </div>
         {isAdmin && (
-          <button onClick={() => setShowSettings(s => !s)} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm border ${card} ${text}`}>
+          <button onClick={() => setShowSettings(s => !s)} className={ghostBtn}>
             <Settings size={15} />Invoice settings
           </button>
         )}
       </div>
 
       {showSettings && (
-        <div className={`rounded-xl border ${card} p-4 grid grid-cols-1 sm:grid-cols-2 gap-3`}>
+        <div className={`rounded-2xl border ${card} p-4 sm:p-5 shadow-sm grid grid-cols-1 sm:grid-cols-2 gap-3`}>
+          <p className={`sm:col-span-2 text-[10px] font-bold uppercase tracking-widest ${subtext}`}>Invoice branding</p>
           <input className={input} placeholder="Company name" value={draft.companyName} onChange={e => setDraft({ ...draft, companyName: e.target.value })} />
           <input className={input} placeholder="Company email" value={draft.companyEmail} onChange={e => setDraft({ ...draft, companyEmail: e.target.value })} />
           <input className={input} placeholder="Address" value={draft.companyAddress} onChange={e => setDraft({ ...draft, companyAddress: e.target.value })} />
           <input className={input} placeholder="Phone" value={draft.companyPhone} onChange={e => setDraft({ ...draft, companyPhone: e.target.value })} />
           <input className={`${input} sm:col-span-2`} placeholder="Payment terms" value={draft.paymentTerms} onChange={e => setDraft({ ...draft, paymentTerms: e.target.value })} />
-          <label className={`flex items-center gap-2 text-sm ${subtext}`}>Header <input type="color" value={draft.headerColor} onChange={e => setDraft({ ...draft, headerColor: e.target.value })} /></label>
-          <label className={`flex items-center gap-2 text-sm ${subtext}`}>Accent <input type="color" value={draft.accentColor} onChange={e => setDraft({ ...draft, accentColor: e.target.value })} /></label>
-          <button onClick={saveSettings} className="sm:col-span-2 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold">Save settings</button>
+          <label className={`flex items-center justify-between gap-2 text-sm px-3 py-2 rounded-lg border ${isDarkMode ? 'border-slate-600' : 'border-slate-300'} ${subtext}`}>Header color <input type="color" className="w-9 h-6 rounded cursor-pointer bg-transparent" value={draft.headerColor} onChange={e => setDraft({ ...draft, headerColor: e.target.value })} /></label>
+          <label className={`flex items-center justify-between gap-2 text-sm px-3 py-2 rounded-lg border ${isDarkMode ? 'border-slate-600' : 'border-slate-300'} ${subtext}`}>Accent color <input type="color" className="w-9 h-6 rounded cursor-pointer bg-transparent" value={draft.accentColor} onChange={e => setDraft({ ...draft, accentColor: e.target.value })} /></label>
+          <button onClick={saveSettings} className="sm:col-span-2 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold transition-all hover:opacity-90 shadow-sm">Save settings</button>
         </div>
       )}
 
-      {loading ? <p className={subtext}>Loading…</p> : (
+      {loading ? (
+        <div className={`rounded-2xl border ${card} p-8 flex items-center justify-center gap-2 ${subtext} text-sm shadow-sm`}>
+          <span className="w-4 h-4 rounded-full border-2 border-slate-300 border-t-brand animate-spin" />
+          Loading invoices…
+        </div>
+      ) : (
         <>
           {/* Generate from a job */}
-          <div className={`rounded-xl border ${card} p-4`}>
-            <h4 className={`text-sm font-bold mb-2 ${text}`}>Generate from job</h4>
-            {jobs.length === 0 && <p className={subtext}>No service jobs yet. Add jobs and work logs first.</p>}
+          <div className={`rounded-2xl border ${card} p-4 sm:p-5 shadow-sm`}>
+            <h4 className={`text-[10px] font-bold uppercase tracking-widest mb-3 ${subtext}`}>Generate from job</h4>
+            {jobs.length === 0 && <p className={`text-sm ${subtext}`}>No service jobs yet. Add jobs and work logs first.</p>}
             {jobs.map(job => {
               const t = computeTotals(job.logs, materials);
               return (
-                <div key={job.id} className={`flex items-center gap-3 py-2 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-100'}`}>
-                  <div className="flex-1">
+                <div key={job.id} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border-b last:border-b-0 transition-colors ${rowCls}`}>
+                  <div className="flex-1 min-w-0">
                     <span className={`font-semibold text-sm ${text}`}>{job.jobNumber || job.jobName || `Job ${job.id}`}</span>
-                    <span className={`block text-xs ${subtext}`}>{job.customerName} · {(job.logs ?? []).length} logs</span>
+                    <span className={`block text-xs ${subtext}`}>{job.customerName || '—'} · {(job.logs ?? []).length} logs</span>
                   </div>
-                  <span className={`font-mono text-sm ${text}`}>${t.grand.toFixed(2)}</span>
-                  <button onClick={() => downloadFor(job)} className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs border ${card} ${text}`}><FileDown size={14} />Preview</button>
-                  {isAdmin && <button onClick={() => generateInvoice(job)} className="px-3 py-1.5 rounded-lg bg-brand text-white text-xs font-semibold">Create invoice</button>}
+                  <span className={`font-mono tabular-nums text-sm font-semibold ${text}`}>${t.grand.toFixed(2)}</span>
+                  <button onClick={() => downloadFor(job)} className={ghostBtn}><FileDown size={14} />Preview</button>
+                  {isAdmin && <button onClick={() => generateInvoice(job)} className="px-3 py-1.5 rounded-lg bg-brand text-white text-xs font-semibold transition-all hover:opacity-90 shadow-sm whitespace-nowrap">Create invoice</button>}
                 </div>
               );
             })}
           </div>
 
           {/* Saved invoices */}
-          <div className={`rounded-xl border ${card} p-4`}>
-            <h4 className={`text-sm font-bold mb-2 ${text} flex items-center gap-1.5`}><Receipt size={15} />Saved invoices</h4>
-            {invoices.length === 0 && <p className={subtext}>No invoices created yet.</p>}
+          <div className={`rounded-2xl border ${card} p-4 sm:p-5 shadow-sm`}>
+            <h4 className={`text-[10px] font-bold uppercase tracking-widest mb-3 ${subtext} flex items-center gap-1.5`}><Receipt size={13} />Saved invoices</h4>
+            {invoices.length === 0 && <p className={`text-sm ${subtext}`}>No invoices created yet.</p>}
             {invoices.map(inv => {
               const job = jobs.find(j => j.id === inv.jobId);
               return (
-                <div key={inv.id} className={`flex items-center gap-3 py-2 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-100'}`}>
+                <div key={inv.id} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border-b last:border-b-0 transition-colors ${rowCls}`}>
                   <span className={`flex-1 text-sm font-mono ${text}`}>{inv.invoiceNumber}</span>
                   {isAdmin ? (
-                    <select className={`text-xs rounded px-1.5 py-1 ${statusColor(inv.status)}`} value={inv.status} onChange={e => scheduleService.updateInvoiceStatus(inv.id, e.target.value as Invoice['status']).then(reload)}>
+                    <select className={`text-xs font-semibold capitalize rounded-full px-2.5 py-1 border-0 cursor-pointer ${statusColor(inv.status)}`} value={inv.status} onChange={e => scheduleService.updateInvoiceStatus(inv.id, e.target.value as Invoice['status']).then(reload)}>
                       <option value="draft">draft</option><option value="sent">sent</option><option value="paid">paid</option>
                     </select>
-                  ) : <span className={`text-xs px-2 py-1 rounded ${statusColor(inv.status)}`}>{inv.status}</span>}
-                  <span className={`w-24 text-right font-mono text-sm ${text}`}>${inv.grandTotal.toFixed(2)}</span>
-                  {job && <button onClick={() => downloadFor(job, inv)} className="text-brand hover:opacity-80"><FileDown size={16} /></button>}
-                  {isAdmin && <button onClick={() => scheduleService.deleteInvoice(inv.id).then(reload)} className="text-rose-500 hover:text-rose-600"><Trash2 size={15} /></button>}
+                  ) : <span className={`text-xs font-semibold capitalize px-2.5 py-1 rounded-full ${statusColor(inv.status)}`}>{inv.status}</span>}
+                  <span className={`w-24 text-right font-mono tabular-nums text-sm font-semibold ${text}`}>${inv.grandTotal.toFixed(2)}</span>
+                  {job && <button onClick={() => downloadFor(job, inv)} className="text-slate-400 hover:text-brand transition-colors" aria-label="Download invoice"><FileDown size={16} /></button>}
+                  {isAdmin && <button onClick={() => scheduleService.deleteInvoice(inv.id).then(reload)} className="text-slate-400 hover:text-rose-600 transition-colors" aria-label="Delete invoice"><Trash2 size={15} /></button>}
                 </div>
               );
             })}

--- a/components/scheduling/ResourcesManager.tsx
+++ b/components/scheduling/ResourcesManager.tsx
@@ -54,8 +54,15 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
   const card    = isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-slate-200';
   const text    = isDarkMode ? 'text-slate-100' : 'text-slate-900';
   const subtext = isDarkMode ? 'text-slate-400' : 'text-slate-500';
-  const input   = `px-3 py-2 rounded-lg border text-sm w-full ${isDarkMode ? 'bg-slate-900 border-slate-600 text-slate-100' : 'bg-white border-slate-300 text-slate-900'}`;
-  const rowCls  = isDarkMode ? 'border-slate-700' : 'border-slate-100';
+  const input   = `px-3 py-2 rounded-lg border text-sm w-full transition focus:outline-none focus:ring-2 focus:ring-brand/20 focus:border-brand ${isDarkMode ? 'bg-slate-900 border-slate-600 text-slate-100' : 'bg-white border-slate-300 text-slate-900'}`;
+  const rowCls  = isDarkMode ? 'border-slate-700/70 hover:bg-slate-700/40' : 'border-slate-100 hover:bg-slate-50';
+  const addBtn  = 'flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap transition-all hover:opacity-90 hover:-translate-y-px shadow-sm';
+  const label   = `text-[10px] font-bold uppercase tracking-widest ${subtext}`;
+  const TAB_META: Record<ResourceTab, { count: number }> = {
+    employees: { count: employees.length },
+    equipment: { count: equipment.length },
+    materials: { count: materials.length },
+  };
 
   const addEmployee = async () => {
     if (!empDraft.name.trim()) return;
@@ -95,48 +102,83 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2">
-        {TABS.map(t => (
-          <button
-            key={t.id}
-            onClick={() => setTab(t.id)}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition ${
-              tab === t.id ? 'bg-brand text-white' : `${card} ${text} border`
-            }`}
-          >
-            {t.icon}{t.label}
-          </button>
-        ))}
+      <div
+        className={`inline-flex items-center gap-1 p-1 rounded-xl border ${
+          isDarkMode ? 'bg-slate-800/60 border-slate-700' : 'bg-slate-100/70 border-slate-200'
+        }`}
+      >
+        {TABS.map(t => {
+          const active = tab === t.id;
+          return (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
+                active
+                  ? 'bg-brand text-white shadow-sm'
+                  : isDarkMode
+                    ? 'text-slate-300 hover:text-white hover:bg-white/5'
+                    : 'text-slate-500 hover:text-slate-900 hover:bg-white'
+              }`}
+            >
+              {t.icon}{t.label}
+              <span
+                className={`ml-0.5 min-w-[20px] px-1.5 py-0.5 rounded-full text-[10px] font-bold leading-none ${
+                  active ? 'bg-white/25 text-white' : isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-slate-200 text-slate-500'
+                }`}
+              >
+                {TAB_META[t.id].count}
+              </span>
+            </button>
+          );
+        })}
       </div>
 
       {loading ? (
-        <p className={subtext}>Loading…</p>
+        <div className={`rounded-2xl border ${card} p-8 flex items-center justify-center gap-2 ${subtext} text-sm shadow-sm`}>
+          <span className="w-4 h-4 rounded-full border-2 border-slate-300 border-t-brand animate-spin" />
+          Loading resources…
+        </div>
       ) : (
-        <div className={`rounded-xl border ${card} p-4`}>
+        <div className={`rounded-2xl border ${card} p-4 sm:p-5 shadow-sm`}>
           {/* EMPLOYEES */}
           {tab === 'employees' && (
-            <div className="space-y-2">
+            <div className="space-y-1">
+              <div className="flex items-center gap-3 px-3 pb-2">
+                <span className={`flex-1 ${label}`}>Name</span>
+                <span className={`flex-1 ${label}`}>Role</span>
+                <span className={`w-24 text-right ${label}`}>Rate / hr</span>
+                {isAdmin && <span className="w-6 shrink-0" />}
+              </div>
               {employees.map(e => (
-                <div key={e.id} className={`flex items-center gap-3 py-2 border-b ${rowCls}`}>
+                <div key={e.id} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border-b last:border-b-0 transition-colors ${rowCls}`}>
                   <span className={`flex-1 font-medium ${text}`}>{e.name}</span>
                   <span className={`flex-1 ${subtext}`}>{e.role || '—'}</span>
-                  <span className={`w-24 text-right ${text}`}>${e.hourlyRate.toFixed(2)}/hr</span>
+                  <span className={`w-24 text-right font-mono tabular-nums text-sm ${text}`}>${e.hourlyRate.toFixed(2)}</span>
                   {isAdmin && (
-                    <button onClick={() => scheduleService.deleteEmployee(e.id).then(reload)} className="text-rose-500 hover:text-rose-600">
+                    <button onClick={() => scheduleService.deleteEmployee(e.id).then(reload)} className="w-6 shrink-0 flex justify-center text-slate-400 hover:text-rose-600 transition-colors" aria-label={`Delete ${e.name}`}>
                       <Trash2 size={16} />
                     </button>
                   )}
                 </div>
               ))}
-              {employees.length === 0 && <p className={subtext}>No employees yet.</p>}
+              {employees.length === 0 && (
+                <div className={`text-center py-8 ${subtext} text-sm`}>
+                  <Users size={22} className="mx-auto mb-2 opacity-40" />
+                  No employees yet.
+                </div>
+              )}
               {isAdmin && (
-                <div className="flex flex-col sm:flex-row gap-2 pt-3">
-                  <input className={input} placeholder="Name" value={empDraft.name} onChange={e => setEmpDraft({ ...empDraft, name: e.target.value })} />
-                  <input className={input} placeholder="Role" value={empDraft.role} onChange={e => setEmpDraft({ ...empDraft, role: e.target.value })} />
-                  <input className={input} placeholder="Rate/hr" type="number" value={empDraft.hourlyRate} onChange={e => setEmpDraft({ ...empDraft, hourlyRate: e.target.value })} />
-                  <button onClick={addEmployee} className="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap">
-                    <Plus size={16} />Add
-                  </button>
+                <div className={`mt-3 pt-3 border-t ${isDarkMode ? 'border-slate-700' : 'border-slate-100'} space-y-2`}>
+                  <p className={label}>Add employee</p>
+                  <div className="flex flex-col sm:flex-row gap-2">
+                    <input className={input} placeholder="Name" value={empDraft.name} onChange={e => setEmpDraft({ ...empDraft, name: e.target.value })} />
+                    <input className={input} placeholder="Role" value={empDraft.role} onChange={e => setEmpDraft({ ...empDraft, role: e.target.value })} />
+                    <input className={input} placeholder="Rate/hr" type="number" value={empDraft.hourlyRate} onChange={e => setEmpDraft({ ...empDraft, hourlyRate: e.target.value })} />
+                    <button onClick={addEmployee} className={addBtn}>
+                      <Plus size={16} />Add
+                    </button>
+                  </div>
                 </div>
               )}
             </div>
@@ -144,74 +186,92 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
 
           {/* EQUIPMENT */}
           {tab === 'equipment' && (
-            <div className="space-y-2">
+            <div className="space-y-1">
+              <div className="flex items-center gap-3 px-3 pb-2">
+                <span className={`flex-1 ${label}`}>Name</span>
+                <span className={`w-24 text-right ${label}`}>Rate / hr</span>
+                {isAdmin && <span className="w-6 shrink-0" />}
+              </div>
               {equipment.map(e => (
-                <div key={e.id} className={`flex items-center gap-3 py-2 border-b ${rowCls}`}>
+                <div key={e.id} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border-b last:border-b-0 transition-colors ${rowCls}`}>
                   <span className={`flex-1 font-medium ${text}`}>{e.name}</span>
-                  <span className={`w-24 text-right ${text}`}>${e.hourlyRate.toFixed(2)}/hr</span>
+                  <span className={`w-24 text-right font-mono tabular-nums text-sm ${text}`}>${e.hourlyRate.toFixed(2)}</span>
                   {isAdmin && (
-                    <button onClick={() => scheduleService.deleteEquipment(e.id).then(reload)} className="text-rose-500 hover:text-rose-600">
+                    <button onClick={() => scheduleService.deleteEquipment(e.id).then(reload)} className="w-6 shrink-0 flex justify-center text-slate-400 hover:text-rose-600 transition-colors" aria-label={`Delete ${e.name}`}>
                       <Trash2 size={16} />
                     </button>
                   )}
                 </div>
               ))}
-              {equipment.length === 0 && <p className={subtext}>No equipment yet.</p>}
+              {equipment.length === 0 && (
+                <div className={`text-center py-8 ${subtext} text-sm`}>
+                  <Wrench size={22} className="mx-auto mb-2 opacity-40" />
+                  No equipment yet.
+                </div>
+              )}
               {isAdmin && (
-                <>
-                  <div className="flex flex-col sm:flex-row gap-2 pt-3">
+                <div className={`mt-3 pt-3 border-t ${isDarkMode ? 'border-slate-700' : 'border-slate-100'} space-y-2`}>
+                  <p className={label}>Add equipment</p>
+                  <div className="flex flex-col sm:flex-row gap-2">
                     <input className={input} placeholder="Name" value={eqDraft.name} onChange={e => setEqDraft({ ...eqDraft, name: e.target.value })} />
                     <input className={input} placeholder="Rate/hr" type="number" value={eqDraft.hourlyRate} onChange={e => setEqDraft({ ...eqDraft, hourlyRate: e.target.value })} />
-                    <button onClick={addEquipment} className="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap">
+                    <button onClick={addEquipment} className={addBtn}>
                       <Plus size={16} />Add
                     </button>
                   </div>
-                  <div className="pt-1">
-                    <button
-                      onClick={() => setCsvModal('equipment')}
-                      className={`flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-lg border transition ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
-                    >
-                      <Upload size={14} />Import CSV / Spreadsheet
-                    </button>
-                  </div>
-                </>
+                  <button
+                    onClick={() => setCsvModal('equipment')}
+                    className={`flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-lg border transition ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+                  >
+                    <Upload size={14} />Import CSV / Spreadsheet
+                  </button>
+                </div>
               )}
             </div>
           )}
 
           {/* MATERIALS */}
           {tab === 'materials' && (
-            <div className="space-y-2">
+            <div className="space-y-1">
+              <div className="flex items-center gap-3 px-3 pb-2">
+                <span className={`flex-1 ${label}`}>Name</span>
+                <span className={`w-24 text-right ${label}`}>Unit price</span>
+                {isAdmin && <span className="w-6 shrink-0" />}
+              </div>
               {materials.map(m => (
-                <div key={m.id} className={`flex items-center gap-3 py-2 border-b ${rowCls}`}>
+                <div key={m.id} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border-b last:border-b-0 transition-colors ${rowCls}`}>
                   <span className={`flex-1 font-medium ${text}`}>{m.name}</span>
-                  <span className={`w-24 text-right ${text}`}>{m.unitPrice != null ? `$${m.unitPrice.toFixed(2)}` : '—'}</span>
+                  <span className={`w-24 text-right font-mono tabular-nums text-sm ${text}`}>{m.unitPrice != null ? `$${m.unitPrice.toFixed(2)}` : '—'}</span>
                   {isAdmin && (
-                    <button onClick={() => scheduleService.deleteMaterial(m.id).then(reload)} className="text-rose-500 hover:text-rose-600">
+                    <button onClick={() => scheduleService.deleteMaterial(m.id).then(reload)} className="w-6 shrink-0 flex justify-center text-slate-400 hover:text-rose-600 transition-colors" aria-label={`Delete ${m.name}`}>
                       <Trash2 size={16} />
                     </button>
                   )}
                 </div>
               ))}
-              {materials.length === 0 && <p className={subtext}>No materials yet.</p>}
+              {materials.length === 0 && (
+                <div className={`text-center py-8 ${subtext} text-sm`}>
+                  <Package size={22} className="mx-auto mb-2 opacity-40" />
+                  No materials yet.
+                </div>
+              )}
               {isAdmin && (
-                <>
-                  <div className="flex flex-col sm:flex-row gap-2 pt-3">
+                <div className={`mt-3 pt-3 border-t ${isDarkMode ? 'border-slate-700' : 'border-slate-100'} space-y-2`}>
+                  <p className={label}>Add material</p>
+                  <div className="flex flex-col sm:flex-row gap-2">
                     <input className={input} placeholder="Name" value={matDraft.name} onChange={e => setMatDraft({ ...matDraft, name: e.target.value })} />
                     <input className={input} placeholder="Unit price (blank = unlisted)" type="number" value={matDraft.unitPrice} onChange={e => setMatDraft({ ...matDraft, unitPrice: e.target.value })} />
-                    <button onClick={addMaterial} className="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold whitespace-nowrap">
+                    <button onClick={addMaterial} className={addBtn}>
                       <Plus size={16} />Add
                     </button>
                   </div>
-                  <div className="pt-1">
-                    <button
-                      onClick={() => setCsvModal('materials')}
-                      className={`flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-lg border transition ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
-                    >
-                      <Upload size={14} />Import CSV / Spreadsheet
-                    </button>
-                  </div>
-                </>
+                  <button
+                    onClick={() => setCsvModal('materials')}
+                    className={`flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-lg border transition ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+                  >
+                    <Upload size={14} />Import CSV / Spreadsheet
+                  </button>
+                </div>
               )}
             </div>
           )}

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -46,17 +46,20 @@ export interface ScheduleBlock {
 // CONSTANTS
 // ═══════════════════════════════════════════════════════════════════════════════
 
-const CREW_COL_W    = 176; // px – sticky left column
-const ROW_HEIGHT    = 72;  // px per crew row
-const BLOCK_MARGIN  = 5;   // px gap between block edge and row edge
-const HEADER_MONTH_H = 26; // px
-const HEADER_DAY_H   = 32; // px
+const CREW_COL_W    = 208; // px – sticky left column
+const ROW_HEIGHT    = 78;  // px per crew row
+const BLOCK_MARGIN  = 6;   // px gap between block edge and row edge
+const HEADER_MONTH_H = 30; // px
+const HEADER_DAY_H   = 40; // px
 
+// Refined, harmonious crew palette — slightly desaturated jewel tones that read
+// as professional rather than primary-bright. Each entry pairs a base color
+// (block fill) with a soft tint (sidebar accent backgrounds).
 const CREW_COLORS: string[] = [
-  '#2563eb', // blue-600
-  '#16a34a', // green-600
-  '#ea580c', // orange-600
-  '#9333ea', // purple-600
+  '#4f46e5', // indigo-600
+  '#0d9488', // teal-600
+  '#d97706', // amber-600
+  '#7c3aed', // violet-600
   '#0891b2', // cyan-600
   '#e11d48', // rose-600
 ];
@@ -309,10 +312,12 @@ const EquipmentTray = ({
   <div
     role="toolbar"
     aria-label="Equipment palette — drag items onto job blocks"
-    className="flex items-center gap-2 px-4 py-2 border-b border-slate-200 bg-slate-50 shrink-0 overflow-x-auto"
-    style={{ minHeight: 48, touchAction: 'pan-x' }}
+    className="flex items-center gap-2 px-5 py-2.5 border-b border-slate-200 bg-gradient-to-b from-slate-50 to-white shrink-0 overflow-x-auto no-scrollbar"
+    style={{ minHeight: 52, touchAction: 'pan-x' }}
   >
-    <span className="text-xs font-semibold text-slate-500 shrink-0 mr-1">Equipment:</span>
+    <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-slate-400 shrink-0 mr-1">
+      <Wrench className="w-3 h-3" /> Equipment
+    </span>
     {equipment.length === 0 && (
       <span className="text-xs text-slate-400 italic">No equipment loaded</span>
     )}
@@ -323,22 +328,24 @@ const EquipmentTray = ({
         onDragStart={e => onDragStart(e, eq.id)}
         onTouchStart={onTouchStart ? e => onTouchStart(e, eq.id) : undefined}
         title={eq.hourly_rate ? `$${eq.hourly_rate}/hr — drag to assign` : 'Drag to assign'}
-        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium select-none shrink-0 transition-colors ${
+        className={`flex items-center gap-1.5 pl-2.5 pr-3 py-1.5 rounded-lg border text-xs font-semibold select-none shrink-0 transition-all ${
           activeTouchId === eq.id
             ? 'border-brand bg-brand/10 text-brand opacity-60'
-            : 'border-slate-300 bg-white text-slate-700 hover:border-brand hover:text-brand hover:bg-brand/10 active:opacity-70'
+            : 'border-slate-200 bg-white text-slate-700 shadow-sm hover:border-brand/40 hover:text-brand hover:bg-brand/10 hover:-translate-y-px active:opacity-70'
         } ${editMode ? 'cursor-grab' : 'cursor-default'}`}
         style={{ userSelect: 'none', touchAction: editMode ? 'none' : 'pan-x' }}
       >
-        <Wrench className="w-3 h-3 shrink-0" />
+        <span className="flex items-center justify-center w-4 h-4 rounded-md bg-slate-100 text-slate-400 shrink-0">
+          <Wrench className="w-2.5 h-2.5" />
+        </span>
         {eq.name}
         {eq.hourly_rate !== undefined && (
-          <span className="text-slate-400 font-normal">${eq.hourly_rate}/hr</span>
+          <span className="text-slate-400 font-medium">${eq.hourly_rate}/hr</span>
         )}
       </div>
     ))}
-    {!editMode && (
-      <span className="text-xs text-slate-400 italic ml-1 shrink-0">Edit mode to drag</span>
+    {!editMode && equipment.length > 0 && (
+      <span className="text-[11px] text-slate-400 italic ml-1 shrink-0">Enable edit mode to drag</span>
     )}
   </div>
 );
@@ -1275,7 +1282,7 @@ const JobBlock = ({
   onResizeStart, onResizeTouchStart,
 }: JobBlockProps) => {
   const isDelay   = block.type === 'delay';
-  const bgColor   = isDelay ? '#6b7280' : color;
+  const bgColor   = isDelay ? '#64748b' : color;
   const blockW    = Math.max(width - BLOCK_MARGIN * 2, 24);
   const blockH    = ROW_HEIGHT - BLOCK_MARGIN * 2;
 
@@ -1320,10 +1327,10 @@ const JobBlock = ({
         height: blockH,
         backgroundColor: bgColor,
         backgroundImage: isDelay
-          ? 'repeating-linear-gradient(45deg, transparent, transparent 6px, rgba(0,0,0,0.15) 6px, rgba(0,0,0,0.15) 12px)'
-          : undefined,
-        opacity: isDragging ? 0.35 : 1,
-        borderRadius: 8,
+          ? 'repeating-linear-gradient(45deg, transparent, transparent 7px, rgba(255,255,255,0.10) 7px, rgba(255,255,255,0.10) 14px)'
+          : 'linear-gradient(160deg, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.05) 42%, rgba(0,0,0,0.14) 100%)',
+        opacity: isDragging ? 0.4 : 1,
+        borderRadius: 10,
         cursor: editMode ? 'grab' : 'default',
         userSelect: 'none',
         touchAction: editMode ? 'none' : 'auto',
@@ -1331,21 +1338,34 @@ const JobBlock = ({
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
-        padding: '0 8px',
+        padding: '0 10px 0 13px',
         boxSizing: 'border-box',
         boxShadow: isEquipDragOver
-          ? `0 0 0 2px #fff, 0 0 0 4px #3b82f6`
-          : isDragging ? 'none' : '0 2px 8px rgba(0,0,0,0.2)',
-        transition: 'opacity 0.12s, box-shadow 0.1s',
+          ? '0 0 0 2px #fff, 0 0 0 4px var(--brand-primary, #3b82f6)'
+          : isDragging
+            ? 'none'
+            : 'inset 0 1px 0 rgba(255,255,255,0.22), 0 1px 2px rgba(15,23,42,0.20), 0 4px 10px rgba(15,23,42,0.12)',
+        transform: isDragging ? 'scale(0.98)' : undefined,
+        transition: 'opacity 0.12s, box-shadow 0.12s, transform 0.12s',
         zIndex: 5,
       }}
     >
+      {/* Left accent strip — adds visual structure / a "tab" feel */}
+      <div
+        style={{
+          position: 'absolute', left: 0, top: 0, bottom: 0, width: 4,
+          background: isDelay
+            ? 'rgba(255,255,255,0.35)'
+            : 'linear-gradient(180deg, rgba(255,255,255,0.65), rgba(255,255,255,0.25))',
+          pointerEvents: 'none',
+        }}
+      />
       {/* Extended dashed border */}
       {block.extended && !isDelay && (
         <div
           style={{
-            position: 'absolute', inset: 0, borderRadius: 8,
-            border: '2px dashed rgba(251,191,36,0.8)',
+            position: 'absolute', inset: 0, borderRadius: 10,
+            border: '2px dashed rgba(251,191,36,0.85)',
             pointerEvents: 'none',
           }}
         />
@@ -1469,16 +1489,16 @@ const JobBlock = ({
       )}
 
       {/* Label */}
-      <div style={{ color: '#fff', fontSize: 11, fontWeight: 700, lineHeight: 1.2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+      <div style={{ color: '#fff', fontSize: 11.5, fontWeight: 700, lineHeight: 1.2, letterSpacing: '0.01em', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 2px rgba(0,0,0,0.28)' }}>
         {block.jobNumber}
       </div>
       {!isDelay && job && blockW > 64 && (
-        <div style={{ color: 'rgba(255,255,255,0.72)', fontSize: 9, marginTop: 2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+        <div style={{ color: 'rgba(255,255,255,0.82)', fontSize: 9.5, marginTop: 2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 1px rgba(0,0,0,0.2)' }}>
           {job.location}
         </div>
       )}
       {blockW > 40 && (
-        <div style={{ color: 'rgba(255,255,255,0.6)', fontSize: 9, marginTop: 1 }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', alignSelf: 'flex-start', marginTop: 4, padding: '1px 6px', borderRadius: 999, background: 'rgba(255,255,255,0.20)', color: 'rgba(255,255,255,0.95)', fontSize: 9, fontWeight: 600, lineHeight: 1.3, backdropFilter: 'blur(2px)' }}>
           {block.durationDays}d
         </div>
       )}
@@ -2185,23 +2205,43 @@ export default function Scheduler({
   // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
-    <div className="flex flex-col h-full bg-slate-50 select-none" style={{ minHeight: 0 }}>
+    <div className="flex flex-col h-full bg-white select-none rounded-2xl border border-slate-200 overflow-hidden shadow-sm" style={{ minHeight: 0 }}>
       {/* ─── Toolbar ─── */}
       <div
-        className="flex items-center gap-2 px-4 py-3 border-b border-white/10 shrink-0 flex-wrap"
-        style={{ background: '#0a142d' }}
+        className="flex items-center gap-x-3 gap-y-2.5 px-5 py-3.5 shrink-0 flex-wrap"
+        style={{
+          background: 'linear-gradient(120deg, #0a142d 0%, #11244f 100%)',
+          borderBottom: '1px solid rgba(255,255,255,0.08)',
+          boxShadow: 'inset 0 -1px 0 rgba(255,255,255,0.04)',
+        }}
       >
-        <Calendar className="w-5 h-5 text-brand shrink-0" />
-        <h2 className="text-white font-bold text-base tracking-tight mr-2">Job Scheduler</h2>
+        {/* Branded title block */}
+        <div className="flex items-center gap-3 mr-1">
+          <div
+            className="flex items-center justify-center w-9 h-9 rounded-xl shrink-0"
+            style={{
+              background: 'linear-gradient(135deg, color-mix(in srgb, var(--brand-primary) 90%, white), var(--brand-primary))',
+              boxShadow: '0 4px 14px var(--brand-shadow), inset 0 1px 0 rgba(255,255,255,0.25)',
+            }}
+          >
+            <Calendar className="w-[18px] h-[18px] text-white" />
+          </div>
+          <div className="leading-tight">
+            <h2 className="font-display text-white font-bold text-[15px] tracking-tight">Dispatch Board</h2>
+            <p className="text-[10px] text-slate-400 font-medium">Crew &amp; job scheduling</p>
+          </div>
+        </div>
 
-        {/* View toggle */}
-        <div className="flex rounded-lg overflow-hidden border border-white/20">
+        {/* View toggle — segmented control */}
+        <div className="flex items-center gap-0.5 p-0.5 rounded-lg bg-black/25 border border-white/10">
           {(['week', 'month'] as const).map(v => (
             <button
               key={v}
               onClick={() => setView(v)}
-              className={`px-3 py-1.5 text-xs font-semibold capitalize transition-colors ${
-                view === v ? 'bg-brand text-white' : 'text-slate-300 hover:bg-white/10'
+              className={`px-3.5 py-1.5 text-xs font-semibold capitalize rounded-md transition-all ${
+                view === v
+                  ? 'bg-brand text-white shadow-sm'
+                  : 'text-slate-300 hover:text-white hover:bg-white/5'
               }`}
             >
               {v}
@@ -2209,29 +2249,32 @@ export default function Scheduler({
           ))}
         </div>
 
-        {/* Navigation */}
-        <div className="flex items-center gap-1">
+        {/* Navigation cluster */}
+        <div className="flex items-center gap-0.5 p-0.5 rounded-lg bg-black/25 border border-white/10">
           <button
             onClick={() => setViewOffset(v => v - (view === 'week' ? 14 : 30))}
-            className="w-7 h-7 flex items-center justify-center rounded-lg text-slate-300 hover:bg-white/10 hover:text-white transition-colors"
+            aria-label="Previous"
+            className="w-7 h-7 flex items-center justify-center rounded-md text-slate-300 hover:bg-white/10 hover:text-white transition-colors"
           >
             <ChevronLeft className="w-4 h-4" />
           </button>
           <button
             onClick={() => setViewOffset(0)}
-            className="px-2.5 py-1 text-xs font-semibold text-slate-300 hover:bg-white/10 hover:text-white rounded-lg transition-colors"
+            className="px-3 py-1 text-xs font-semibold text-slate-200 hover:bg-white/10 hover:text-white rounded-md transition-colors"
           >
             Today
           </button>
           <button
             onClick={() => setViewOffset(v => v + (view === 'week' ? 14 : 30))}
-            className="w-7 h-7 flex items-center justify-center rounded-lg text-slate-300 hover:bg-white/10 hover:text-white transition-colors"
+            aria-label="Next"
+            className="w-7 h-7 flex items-center justify-center rounded-md text-slate-300 hover:bg-white/10 hover:text-white transition-colors"
           >
             <ChevronRight className="w-4 h-4" />
           </button>
         </div>
 
-        <span className="text-slate-500 text-xs">
+        {/* Visible date range */}
+        <span className="hidden sm:inline-flex items-center px-2.5 py-1 rounded-md bg-white/5 text-slate-300 text-xs font-medium tabular-nums">
           {fmtShort(viewStart)} – {fmtShort(addDays(viewStart, totalDays - 1))}
         </span>
 
@@ -2242,9 +2285,9 @@ export default function Scheduler({
             aria-pressed={editMode}
             aria-label={editMode ? 'Exit edit mode' : 'Enter edit mode to drag blocks'}
             title={editMode ? 'Exit edit mode' : 'Edit: drag blocks to reschedule'}
-            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors border ${
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-all border ${
               editMode
-                ? 'bg-yellow-400 text-slate-900 border-yellow-300'
+                ? 'bg-amber-400 text-slate-900 border-amber-300 shadow-sm'
                 : 'bg-white/10 hover:bg-white/20 text-slate-200 border-white/10'
             }`}
           >
@@ -2266,6 +2309,10 @@ export default function Scheduler({
               <RotateCcw className="w-3.5 h-3.5" /> Undo
             </button>
           )}
+
+          {/* Divider */}
+          {isAdmin && <span className="w-px h-5 bg-white/10 mx-0.5" aria-hidden="true" />}
+
           {isAdmin && (
             <>
               <button
@@ -2288,7 +2335,7 @@ export default function Scheduler({
             aria-label="Toggle equipment tray"
             className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors border ${
               showEquipTray
-                ? 'bg-amber-500 text-white border-amber-400'
+                ? 'bg-amber-500 text-white border-amber-400 shadow-sm'
                 : 'bg-white/10 hover:bg-white/20 text-slate-200 border-white/10'
             }`}
           >
@@ -2296,7 +2343,7 @@ export default function Scheduler({
           </button>
           <button
             onClick={() => setShowAddModal(true)}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-brand hover:opacity-90 text-white text-xs font-semibold rounded-lg transition-colors"
+            className="flex items-center gap-1.5 px-3.5 py-1.5 bg-brand hover:opacity-90 text-white text-xs font-semibold rounded-lg transition-all shadow-brand/20 hover:-translate-y-px"
           >
             <Plus className="w-3.5 h-3.5" /> Add Job
           </button>
@@ -2322,16 +2369,17 @@ export default function Scheduler({
             style={{
               height: HEADER_MONTH_H,
               position: 'sticky', top: 0, zIndex: 30,
-              background: '#0a142d',
+              background: '#ffffff',
+              borderBottom: '1px solid #eef2f7',
             }}
           >
             <div
               style={{
                 width: CREW_COL_W, minWidth: CREW_COL_W, height: HEADER_MONTH_H,
-                borderRight: '1px solid rgba(255,255,255,0.08)',
+                borderRight: '1px solid #e8edf3',
                 flexShrink: 0,
                 position: 'sticky', left: 0, zIndex: 31,
-                background: '#0a142d',
+                background: '#ffffff',
               }}
             />
             <div style={{ position: 'relative', width: totalGridWidth, height: HEADER_MONTH_H }}>
@@ -2344,10 +2392,10 @@ export default function Scheduler({
                     width: ml.span * dayWidth,
                     height: HEADER_MONTH_H,
                     display: 'flex', alignItems: 'center',
-                    paddingLeft: 8, boxSizing: 'border-box',
-                    borderRight: '1px solid rgba(255,255,255,0.08)',
-                    color: '#93c5fd',
-                    fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase',
+                    paddingLeft: 10, boxSizing: 'border-box',
+                    borderRight: '1px solid #eef2f7',
+                    color: '#64748b',
+                    fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase',
                   }}
                 >
                   {ml.label}
@@ -2362,21 +2410,22 @@ export default function Scheduler({
             style={{
               height: HEADER_DAY_H,
               position: 'sticky', top: HEADER_MONTH_H, zIndex: 30,
-              background: '#0d1b38',
+              background: '#f8fafc',
+              borderBottom: '1px solid #e2e8f0',
             }}
           >
             <div
               style={{
                 width: CREW_COL_W, minWidth: CREW_COL_W, height: HEADER_DAY_H,
-                borderRight: '1px solid rgba(255,255,255,0.08)',
+                borderRight: '1px solid #e8edf3',
                 display: 'flex', alignItems: 'center',
-                paddingLeft: 12, flexShrink: 0,
+                paddingLeft: 14, flexShrink: 0,
                 position: 'sticky', left: 0, zIndex: 31,
-                background: '#0d1b38',
+                background: '#f8fafc',
               }}
             >
-              <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: '#334155' }}>
-                Crew
+              <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: '#94a3b8' }}>
+                Crews
               </span>
             </div>
             <div style={{ position: 'relative', width: totalGridWidth, height: HEADER_DAY_H }}>
@@ -2392,19 +2441,35 @@ export default function Scheduler({
                       position: 'absolute',
                       left: i * dayWidth, width: dayWidth, height: HEADER_DAY_H,
                       display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
-                      borderRight: '1px solid rgba(255,255,255,0.04)',
-                      backgroundColor: isToday ? 'rgba(59,130,246,0.22)' : undefined,
+                      gap: 1,
+                      borderRight: '1px solid #eef2f7',
+                      backgroundColor: isToday ? 'var(--brand-ring)' : isWeekend ? 'rgba(148,163,184,0.06)' : undefined,
                       boxSizing: 'border-box',
                     }}
                   >
                     {showLabel && (
                       <>
-                        <span style={{ fontSize: 9, color: isToday ? '#93c5fd' : isWeekend ? '#475569' : '#64748b', fontWeight: isToday ? 700 : 400 }}>
+                        <span style={{ fontSize: 9, color: isToday ? 'var(--brand-primary)' : isWeekend ? '#cbd5e1' : '#94a3b8', fontWeight: isToday ? 700 : 500, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
                           {d.toLocaleDateString('en-US', { weekday: 'narrow' })}
                         </span>
-                        <span style={{ fontSize: 10, color: isToday ? '#60a5fa' : isWeekend ? '#334155' : '#94a3b8', fontWeight: isToday ? 700 : 500 }}>
-                          {d.getDate()}
-                        </span>
+                        {isToday ? (
+                          <span
+                            style={{
+                              display: 'flex', alignItems: 'center', justifyContent: 'center',
+                              minWidth: 18, height: 18, padding: '0 5px',
+                              borderRadius: 999,
+                              background: 'var(--brand-primary)',
+                              color: '#fff', fontSize: 10, fontWeight: 700,
+                              boxShadow: '0 2px 6px var(--brand-shadow)',
+                            }}
+                          >
+                            {d.getDate()}
+                          </span>
+                        ) : (
+                          <span style={{ fontSize: 11, color: isWeekend ? '#cbd5e1' : '#475569', fontWeight: 600 }}>
+                            {d.getDate()}
+                          </span>
+                        )}
                       </>
                     )}
                   </div>
@@ -2425,17 +2490,30 @@ export default function Scheduler({
                   style={{
                     width: CREW_COL_W, minWidth: CREW_COL_W, height: ROW_HEIGHT,
                     position: 'sticky', left: 0, zIndex: 20,
-                    background: ci % 2 === 0 ? '#0d1b38' : '#0a142d',
-                    borderRight: '1px solid rgba(255,255,255,0.06)',
-                    borderBottom: '1px solid rgba(255,255,255,0.04)',
+                    background: ci % 2 === 0 ? '#ffffff' : '#fbfcfe',
+                    borderRight: '1px solid #e8edf3',
+                    borderBottom: '1px solid #eef2f7',
                     display: 'flex', alignItems: 'center',
-                    padding: '0 8px 0 12px', gap: 6,
+                    padding: '0 10px 0 14px', gap: 10,
                     flexShrink: 0,
                   }}
                 >
-                  <div style={{ width: 4, height: 32, borderRadius: 2, backgroundColor: color, flexShrink: 0 }} />
+                  {/* Crew avatar chip */}
+                  <div
+                    style={{
+                      width: 36, height: 36, borderRadius: 10, flexShrink: 0,
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      background: `${color}14`,
+                      border: `1px solid ${color}33`,
+                      color,
+                      fontSize: 14, fontWeight: 700,
+                      fontFamily: "'Space Grotesk', 'Inter', sans-serif",
+                    }}
+                  >
+                    {crew.name.trim().charAt(0).toUpperCase() || '?'}
+                  </div>
                   <div style={{ minWidth: 0, flex: 1 }}>
-                    <div style={{ color: '#e2e8f0', fontSize: 13, fontWeight: 600, lineHeight: 1.2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+                    <div style={{ color: '#1e293b', fontSize: 13, fontWeight: 600, lineHeight: 1.2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
                       {crew.name}
                     </div>
                     {(() => {
@@ -2447,12 +2525,13 @@ export default function Scheduler({
                       const workerCount = crew.memberIds.length || crew.size;
                       return (
                         <>
-                          <div style={{ color: '#475569', fontSize: 10, marginTop: 2 }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#94a3b8', fontSize: 10, fontWeight: 500, marginTop: 2 }}>
+                            <Users style={{ width: 10, height: 10, flexShrink: 0 }} />
                             {workerCount} {workerCount === 1 ? 'worker' : 'workers'}
                           </div>
                           {memberNames.length > 0 && (
                             <div
-                              style={{ color: '#64748b', fontSize: 9, marginTop: 1, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+                              style={{ color: '#94a3b8', fontSize: 9, marginTop: 1, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
                               title={memberNames.join(', ')}
                             >
                               {memberNames.slice(0, 2).join(', ')}{memberNames.length > 2 ? ` +${memberNames.length - 2}` : ''}
@@ -2471,18 +2550,18 @@ export default function Scheduler({
                     aria-label={`Add delay to ${crew.name}'s schedule`}
                     style={{
                       flexShrink: 0,
-                      width: 22, height: 22,
-                      borderRadius: 6,
-                      background: hoverDelayCrewId === crew.id ? 'rgba(245,158,11,0.25)' : 'rgba(255,255,255,0.06)',
-                      border: '1px solid rgba(255,255,255,0.12)',
+                      width: 24, height: 24,
+                      borderRadius: 7,
+                      background: hoverDelayCrewId === crew.id ? 'rgba(245,158,11,0.14)' : '#f1f5f9',
+                      border: `1px solid ${hoverDelayCrewId === crew.id ? 'rgba(245,158,11,0.4)' : '#e2e8f0'}`,
                       cursor: 'pointer',
                       display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      color: hoverDelayCrewId === crew.id ? '#fbbf24' : '#94a3b8',
+                      color: hoverDelayCrewId === crew.id ? '#d97706' : '#94a3b8',
                       padding: 0,
-                      transition: 'background 0.15s, color 0.15s',
+                      transition: 'background 0.15s, color 0.15s, border-color 0.15s',
                     }}
                   >
-                    <Clock style={{ width: 11, height: 11 }} />
+                    <Clock style={{ width: 12, height: 12 }} />
                   </button>
                 </div>
 
@@ -2491,15 +2570,16 @@ export default function Scheduler({
                   style={{
                     position: 'relative',
                     width: totalGridWidth, height: ROW_HEIGHT,
-                    background: ci % 2 === 0 ? '#f8fafc' : '#f1f5f9',
-                    borderBottom: '1px solid #e2e8f0',
+                    background: ci % 2 === 0 ? '#ffffff' : '#fafbfd',
+                    borderBottom: '1px solid #eef2f7',
                   }}
                   onDragOver={editMode ? handleDragOver : undefined}
                   onDrop={editMode ? e => handleDrop(e, crew.id) : undefined}
                 >
-                  {/* Day cells (grid lines + weekend shading) */}
+                  {/* Day cells (grid lines + weekend shading + today column) */}
                   {days.map((day, i) => {
                     const isWeekend = [0, 6].includes(parseDate(day).getDay());
+                    const isToday   = day === todayISO;
                     return (
                       <div
                         key={day}
@@ -2507,8 +2587,10 @@ export default function Scheduler({
                           position: 'absolute',
                           left: i * dayWidth, top: 0,
                           width: dayWidth, height: ROW_HEIGHT,
-                          borderRight: '1px solid #e2e8f0',
-                          backgroundColor: isWeekend ? 'rgba(148,163,184,0.07)' : undefined,
+                          borderRight: '1px solid #eef2f7',
+                          backgroundColor: isToday
+                            ? 'var(--brand-ring)'
+                            : isWeekend ? 'rgba(148,163,184,0.05)' : undefined,
                           boxSizing: 'border-box',
                           pointerEvents: 'none',
                         }}
@@ -2522,7 +2604,8 @@ export default function Scheduler({
                       style={{
                         position: 'absolute', left: todayOffset,
                         top: 0, width: 2, height: ROW_HEIGHT,
-                        backgroundColor: '#ef4444',
+                        background: 'linear-gradient(180deg, #f43f5e, #e11d48)',
+                        boxShadow: '0 0 6px rgba(244,63,94,0.5)',
                         zIndex: 8, pointerEvents: 'none',
                       }}
                     />

--- a/components/scheduling/SchedulingView.tsx
+++ b/components/scheduling/SchedulingView.tsx
@@ -50,17 +50,21 @@ export default function SchedulingView({ sessionUser, jobs, companyName, isDarkM
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2">
+      <div
+        className={`inline-flex items-center gap-1 p-1 rounded-xl border ${
+          isDarkMode ? 'bg-slate-800/60 border-slate-700' : 'bg-slate-100/70 border-slate-200'
+        }`}
+      >
         {TABS.map(t => (
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition border ${
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
               tab === t.id
-                ? 'bg-brand text-white border-transparent'
+                ? 'bg-brand text-white shadow-sm'
                 : isDarkMode
-                  ? 'bg-slate-800 text-slate-100 border-slate-700'
-                  : 'bg-white text-slate-900 border-slate-200'
+                  ? 'text-slate-300 hover:text-white hover:bg-white/5'
+                  : 'text-slate-500 hover:text-slate-900 hover:bg-white'
             }`}
           >
             {t.icon}{t.label}

--- a/components/scheduling/WorkLogEditor.tsx
+++ b/components/scheduling/WorkLogEditor.tsx
@@ -58,7 +58,8 @@ export default function WorkLogEditor({ companyId, isAdmin, isDarkMode }: WorkLo
   const card    = isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-slate-200';
   const text    = isDarkMode ? 'text-slate-100' : 'text-slate-900';
   const subtext = isDarkMode ? 'text-slate-400' : 'text-slate-500';
-  const input   = `px-2.5 py-1.5 rounded-lg border text-sm ${isDarkMode ? 'bg-slate-900 border-slate-600 text-slate-100' : 'bg-white border-slate-300 text-slate-900'}`;
+  const input   = `px-2.5 py-1.5 rounded-lg border text-sm transition focus:outline-none focus:ring-2 focus:ring-brand/20 focus:border-brand ${isDarkMode ? 'bg-slate-900 border-slate-600 text-slate-100' : 'bg-white border-slate-300 text-slate-900'}`;
+  const ghostBtn = `flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-200 hover:bg-slate-700' : 'border-slate-300 text-slate-700 hover:bg-slate-50'}`;
 
   const createJob = async () => {
     if (!jobDraft.jobNumber.trim() && !jobDraft.jobName.trim()) return;
@@ -113,66 +114,82 @@ export default function WorkLogEditor({ companyId, isAdmin, isDarkMode }: WorkLo
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
       {/* Jobs list */}
-      <div className={`rounded-xl border ${card} p-3 space-y-2`}>
-        <div className="flex items-center justify-between">
-          <h3 className={`text-sm font-bold ${text}`}>Jobs</h3>
+      <div className={`rounded-2xl border ${card} p-3 space-y-2 shadow-sm self-start`}>
+        <div className="flex items-center justify-between px-1">
+          <h3 className={`text-[10px] font-bold uppercase tracking-widest ${subtext}`}>Jobs</h3>
           {isAdmin && (
-            <button onClick={() => setShowJobForm(s => !s)} className="text-brand hover:opacity-80">
+            <button
+              onClick={() => setShowJobForm(s => !s)}
+              aria-label={showJobForm ? 'Cancel new job' : 'New job'}
+              className="w-6 h-6 flex items-center justify-center rounded-lg text-brand hover:bg-brand/10 transition-colors"
+            >
               {showJobForm ? <X size={16} /> : <Plus size={16} />}
             </button>
           )}
         </div>
         {showJobForm && (
-          <div className="space-y-1.5 pb-2 border-b border-slate-700/30">
+          <div className={`space-y-1.5 p-2.5 rounded-xl ${isDarkMode ? 'bg-slate-900/50' : 'bg-slate-50'}`}>
             <input className={`${input} w-full`} placeholder="Job number" value={jobDraft.jobNumber} onChange={e => setJobDraft({ ...jobDraft, jobNumber: e.target.value })} />
             <input className={`${input} w-full`} placeholder="Job name" value={jobDraft.jobName} onChange={e => setJobDraft({ ...jobDraft, jobName: e.target.value })} />
             <input className={`${input} w-full`} placeholder="Customer" value={jobDraft.customerName} onChange={e => setJobDraft({ ...jobDraft, customerName: e.target.value })} />
             <input className={`${input} w-full`} placeholder="Address" value={jobDraft.address} onChange={e => setJobDraft({ ...jobDraft, address: e.target.value })} />
-            <button onClick={createJob} className="w-full px-3 py-1.5 rounded-lg bg-brand text-white text-sm font-semibold">Create job</button>
+            <button onClick={createJob} className="w-full px-3 py-1.5 rounded-lg bg-brand text-white text-sm font-semibold transition-all hover:opacity-90 shadow-sm">Create job</button>
           </div>
         )}
-        {loading ? <p className={subtext}>Loading…</p> : jobs.map(j => (
-          <button
-            key={j.id}
-            onClick={() => setSelectedId(j.id)}
-            className={`w-full text-left px-3 py-2 rounded-lg text-sm transition ${
-              selectedId === j.id ? 'bg-brand text-white' : isDarkMode ? 'hover:bg-slate-700 text-slate-200' : 'hover:bg-slate-100 text-slate-700'
-            }`}
-          >
-            <span className="font-semibold">{j.jobNumber || j.jobName || `Job ${j.id}`}</span>
-            <span className="block text-xs opacity-70">{j.customerName}</span>
-          </button>
-        ))}
-        {!loading && jobs.length === 0 && <p className={subtext}>No jobs yet.</p>}
+        {loading ? (
+          <p className={`px-3 py-2 text-sm ${subtext}`}>Loading…</p>
+        ) : jobs.map(j => {
+          const active = selectedId === j.id;
+          return (
+            <button
+              key={j.id}
+              onClick={() => setSelectedId(j.id)}
+              className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-all border ${
+                active
+                  ? 'bg-brand text-white border-transparent shadow-sm'
+                  : isDarkMode
+                    ? 'border-transparent hover:bg-slate-700 text-slate-200'
+                    : 'border-transparent hover:bg-slate-50 hover:border-slate-200 text-slate-700'
+              }`}
+            >
+              <span className="font-semibold">{j.jobNumber || j.jobName || `Job ${j.id}`}</span>
+              <span className="block text-xs opacity-70">{j.customerName || '—'}</span>
+            </button>
+          );
+        })}
+        {!loading && jobs.length === 0 && <p className={`px-3 py-2 text-sm ${subtext}`}>No jobs yet.</p>}
       </div>
 
       {/* Selected job logs + editor */}
       <div className="lg:col-span-2 space-y-4">
         {!selected ? (
-          <div className={`rounded-xl border ${card} p-6 ${subtext}`}>Select or create a job to log work.</div>
+          <div className={`rounded-2xl border ${card} p-10 text-center shadow-sm ${subtext}`}>
+            <FileStack size={26} className="mx-auto mb-2 opacity-40" />
+            <p className="text-sm">Select or create a job to log work.</p>
+          </div>
         ) : (
           <>
             {/* Existing logs */}
-            <div className={`rounded-xl border ${card} p-4`}>
-              <h3 className={`text-sm font-bold mb-2 ${text}`}>Daily logs — {selected.jobNumber || selected.jobName}</h3>
+            <div className={`rounded-2xl border ${card} p-4 sm:p-5 shadow-sm`}>
+              <h3 className={`text-sm font-bold mb-3 ${text}`}>Daily logs — {selected.jobNumber || selected.jobName}</h3>
               {(selected.logs ?? []).length === 0 && <p className={subtext}>No logs recorded yet.</p>}
               {(selected.logs ?? []).map(log => {
                 const t = computeTotals([log], materials);
                 return (
-                  <div key={log.id} className={`flex items-center gap-3 py-2 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-100'}`}>
-                    <span className={`flex-1 text-sm ${text}`}>{new Date(log.date).toLocaleDateString('en-US')}</span>
+                  <div key={log.id} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border-b last:border-b-0 transition-colors ${isDarkMode ? 'border-slate-700/70 hover:bg-slate-700/40' : 'border-slate-100 hover:bg-slate-50'}`}>
+                    <span className={`flex-1 text-sm font-medium ${text}`}>{new Date(log.date).toLocaleDateString('en-US')}</span>
                     <span className={`text-xs ${subtext}`}>
                       {log.data.employees.length} labor · {log.data.equipment.length} equip · {log.data.materials.length} mat
                     </span>
-                    <span className={`w-24 text-right font-mono text-sm ${text}`}>${t.grand.toFixed(2)}</span>
-                    <button onClick={() => scheduleService.deleteWorkLog(log.id).then(reload)} className="text-rose-500 hover:text-rose-600"><Trash2 size={15} /></button>
+                    <span className={`w-24 text-right font-mono tabular-nums text-sm ${text}`}>${t.grand.toFixed(2)}</span>
+                    <button onClick={() => scheduleService.deleteWorkLog(log.id).then(reload)} className="text-slate-400 hover:text-rose-600 transition-colors" aria-label="Delete log"><Trash2 size={15} /></button>
                   </div>
                 );
               })}
             </div>
 
             {/* New log editor */}
-            <div className={`rounded-xl border ${card} p-4 space-y-3`}>
+            <div className={`rounded-2xl border ${card} p-4 sm:p-5 space-y-3 shadow-sm`}>
               <div className="flex items-center justify-between gap-2">
                 <h3 className={`text-sm font-bold ${text}`}>Add daily log</h3>
                 <div className="flex items-center gap-2">
@@ -238,11 +255,14 @@ export default function WorkLogEditor({ companyId, isAdmin, isDarkMode }: WorkLo
 
               <input className={`${input} w-full`} placeholder="Notes" value={notes} onChange={e => setNotes(e.target.value)} />
 
-              <div className="flex items-center justify-between pt-1">
-                <span className={`font-mono text-sm ${text}`}>Total: ${totals.grand.toFixed(2)}</span>
+              <div className={`flex flex-wrap items-center justify-between gap-2 pt-3 border-t ${isDarkMode ? 'border-slate-700' : 'border-slate-100'}`}>
+                <div className="flex items-baseline gap-2">
+                  <span className={`text-[10px] font-bold uppercase tracking-widest ${subtext}`}>Total</span>
+                  <span className={`font-mono tabular-nums text-lg font-bold ${text}`}>${totals.grand.toFixed(2)}</span>
+                </div>
                 <div className="flex gap-2">
-                  <button onClick={saveTemplate} className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm border ${card} ${text}`}><FileStack size={15} />Save as template</button>
-                  <button onClick={saveLog} className="flex items-center gap-1 px-4 py-1.5 rounded-lg bg-brand text-white text-sm font-semibold"><Save size={15} />Save log</button>
+                  <button onClick={saveTemplate} className={ghostBtn}><FileStack size={15} />Save as template</button>
+                  <button onClick={saveLog} className="flex items-center gap-1 px-4 py-1.5 rounded-lg bg-brand text-white text-sm font-semibold transition-all hover:opacity-90 hover:-translate-y-px shadow-sm"><Save size={15} />Save log</button>
                 </div>
               </div>
             </div>
@@ -257,8 +277,15 @@ function Section({ title, onAdd, disabled, text, children }: { title: string; on
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <span className={`text-xs font-bold uppercase tracking-wide ${text} opacity-70`}>{title}</span>
-        <button onClick={onAdd} disabled={disabled} className="text-brand disabled:opacity-30"><Plus size={15} /></button>
+        <span className={`text-[10px] font-bold uppercase tracking-widest ${text} opacity-60`}>{title}</span>
+        <button
+          onClick={onAdd}
+          disabled={disabled}
+          aria-label={`Add ${title.toLowerCase()}`}
+          className="flex items-center justify-center w-6 h-6 rounded-md text-brand hover:bg-brand/10 transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
+        >
+          <Plus size={15} />
+        </button>
       </div>
       {children}
     </div>

--- a/preview/index.html
+++ b/preview/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DigTrackPro — Scheduler Preview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/preview/main.tsx
+++ b/preview/main.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { CalendarRange, Boxes, ClipboardList, Receipt } from 'lucide-react';
+import Scheduler, { Crew, JobOption, ScheduleBlock } from '../components/scheduling/Scheduler.tsx';
+import '../index.css';
+
+// ── Date helpers (relative to "today" so the board always looks populated) ──
+const toISO = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+const addDays = (n: number) => {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  return toISO(d);
+};
+
+const crews: Crew[] = [
+  { id: 'c1', name: 'Alpha Crew',   size: 4, memberIds: [] },
+  { id: 'c2', name: 'Bravo Crew',   size: 3, memberIds: [] },
+  { id: 'c3', name: 'Charlie Crew', size: 5, memberIds: [] },
+  { id: 'c4', name: 'Delta Crew',   size: 2, memberIds: [] },
+  { id: 'c5', name: 'Echo Crew',    size: 3, memberIds: [] },
+];
+
+const jobs: JobOption[] = [
+  { jobNumber: 'J-2041', location: '1180 Riverside Dr, Austin',     estimatedDays: 5 },
+  { jobNumber: 'J-2042', location: '95 Industrial Pkwy, Round Rock', estimatedDays: 3 },
+  { jobNumber: 'J-2043', location: '400 Lakeway Blvd, Lakeway',      estimatedDays: 7 },
+  { jobNumber: 'J-2044', location: '77 Commerce St, Pflugerville',   estimatedDays: 4 },
+  { jobNumber: 'J-2045', location: '2300 Oltorf St, Austin',         estimatedDays: 6 },
+  { jobNumber: 'J-2046', location: '8 Quarry Rd, Cedar Park',        estimatedDays: 2 },
+];
+
+const blocks: ScheduleBlock[] = [
+  { id: 'b1', crewId: 'c1', jobNumber: 'J-2041', startDate: addDays(-3), durationDays: 5, type: 'job', extended: false, equipmentIds: ['e1', 'e2'] },
+  { id: 'b2', crewId: 'c1', jobNumber: 'J-2042', startDate: addDays(3),  durationDays: 3, type: 'job', extended: false },
+  { id: 'b3', crewId: 'c2', jobNumber: 'J-2043', startDate: addDays(-1), durationDays: 7, type: 'job', extended: true },
+  { id: 'b4', crewId: 'c2', jobNumber: 'J-2044', startDate: addDays(8),  durationDays: 4, type: 'job', extended: false, equipmentIds: ['e3'] },
+  { id: 'd1', crewId: 'c3', jobNumber: 'Delay – 2 days', startDate: addDays(0), durationDays: 2, type: 'delay', extended: false },
+  { id: 'b5', crewId: 'c3', jobNumber: 'J-2045', startDate: addDays(2),  durationDays: 6, type: 'job', extended: false, equipmentIds: ['e1', 'e4', 'e2'] },
+  { id: 'b6', crewId: 'c4', jobNumber: 'J-2046', startDate: addDays(1),  durationDays: 2, type: 'job', extended: false },
+  { id: 'b7', crewId: 'c4', jobNumber: 'J-2042', startDate: addDays(5),  durationDays: 3, type: 'job', extended: false },
+  { id: 'b8', crewId: 'c5', jobNumber: 'J-2043', startDate: addDays(-2), durationDays: 4, type: 'job', extended: false, equipmentIds: ['e5'] },
+  { id: 'b9', crewId: 'c5', jobNumber: 'J-2041', startDate: addDays(4),  durationDays: 5, type: 'job', extended: false },
+];
+
+const TABS = [
+  { id: 'board',     label: 'Dispatch Board', icon: <CalendarRange size={16} />, active: true },
+  { id: 'resources', label: 'Resources',      icon: <Boxes size={16} />,         active: false },
+  { id: 'logs',      label: 'Work Logs',      icon: <ClipboardList size={16} />, active: false },
+  { id: 'invoices',  label: 'Invoices',       icon: <Receipt size={16} />,       active: false },
+];
+
+function Preview() {
+  return (
+    <div style={{ minHeight: '100vh', background: '#f1f5f9', padding: '28px 24px' }}>
+      <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+        <div style={{ marginBottom: 8 }}>
+          <h1 className="font-display" style={{ fontSize: 22, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em' }}>
+            Scheduling &amp; Field Ops
+          </h1>
+          <p style={{ fontSize: 13, color: '#64748b', marginTop: 2 }}>
+            Redesign preview · mock data · fully interactive (try the Edit toggle)
+          </p>
+        </div>
+
+        {/* Module tab bar — same segmented control used in SchedulingView */}
+        <div className="inline-flex items-center gap-1 p-1 rounded-xl border bg-slate-100/70 border-slate-200" style={{ margin: '14px 0' }}>
+          {TABS.map(t => (
+            <button
+              key={t.id}
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
+                t.active ? 'bg-brand text-white shadow-sm' : 'text-slate-500 hover:text-slate-900 hover:bg-white'
+              }`}
+            >
+              {t.icon}{t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* The redesigned board */}
+        <div style={{ height: 620 }}>
+          <Scheduler
+            crews={crews}
+            jobs={jobs}
+            initialBlocks={blocks}
+            userRole="admin"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Preview />
+  </React.StrictMode>,
+);

--- a/preview/main.tsx
+++ b/preview/main.tsx
@@ -1,17 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { CalendarRange, Boxes, ClipboardList, Receipt } from 'lucide-react';
 import Scheduler, { Crew, JobOption, ScheduleBlock } from '../components/scheduling/Scheduler.tsx';
+import ResourcesManager from '../components/scheduling/ResourcesManager.tsx';
+import WorkLogEditor from '../components/scheduling/WorkLogEditor.tsx';
+import InvoiceView from '../components/scheduling/InvoiceView.tsx';
 import '../index.css';
 
-// ── Date helpers (relative to "today" so the board always looks populated) ──
 const toISO = (d: Date) =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-const addDays = (n: number) => {
-  const d = new Date();
-  d.setDate(d.getDate() + n);
-  return toISO(d);
-};
+const addDays = (n: number) => { const d = new Date(); d.setDate(d.getDate() + n); return toISO(d); };
 
 const crews: Crew[] = [
   { id: 'c1', name: 'Alpha Crew',   size: 4, memberIds: [] },
@@ -20,7 +18,6 @@ const crews: Crew[] = [
   { id: 'c4', name: 'Delta Crew',   size: 2, memberIds: [] },
   { id: 'c5', name: 'Echo Crew',    size: 3, memberIds: [] },
 ];
-
 const jobs: JobOption[] = [
   { jobNumber: 'J-2041', location: '1180 Riverside Dr, Austin',     estimatedDays: 5 },
   { jobNumber: 'J-2042', location: '95 Industrial Pkwy, Round Rock', estimatedDays: 3 },
@@ -29,7 +26,6 @@ const jobs: JobOption[] = [
   { jobNumber: 'J-2045', location: '2300 Oltorf St, Austin',         estimatedDays: 6 },
   { jobNumber: 'J-2046', location: '8 Quarry Rd, Cedar Park',        estimatedDays: 2 },
 ];
-
 const blocks: ScheduleBlock[] = [
   { id: 'b1', crewId: 'c1', jobNumber: 'J-2041', startDate: addDays(-3), durationDays: 5, type: 'job', extended: false, equipmentIds: ['e1', 'e2'] },
   { id: 'b2', crewId: 'c1', jobNumber: 'J-2042', startDate: addDays(3),  durationDays: 3, type: 'job', extended: false },
@@ -43,33 +39,33 @@ const blocks: ScheduleBlock[] = [
   { id: 'b9', crewId: 'c5', jobNumber: 'J-2041', startDate: addDays(4),  durationDays: 5, type: 'job', extended: false },
 ];
 
-const TABS = [
-  { id: 'board',     label: 'Dispatch Board', icon: <CalendarRange size={16} />, active: true },
-  { id: 'resources', label: 'Resources',      icon: <Boxes size={16} />,         active: false },
-  { id: 'logs',      label: 'Work Logs',      icon: <ClipboardList size={16} />, active: false },
-  { id: 'invoices',  label: 'Invoices',       icon: <Receipt size={16} />,       active: false },
+type Tab = 'board' | 'resources' | 'logs' | 'invoices';
+const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
+  { id: 'board',     label: 'Dispatch Board', icon: <CalendarRange size={16} /> },
+  { id: 'resources', label: 'Resources',      icon: <Boxes size={16} /> },
+  { id: 'logs',      label: 'Work Logs',      icon: <ClipboardList size={16} /> },
+  { id: 'invoices',  label: 'Invoices',       icon: <Receipt size={16} /> },
 ];
 
 function Preview() {
+  const [tab, setTab] = useState<Tab>('board');
   return (
     <div style={{ minHeight: '100vh', background: '#f1f5f9', padding: '28px 24px' }}>
       <div style={{ maxWidth: 1180, margin: '0 auto' }}>
-        <div style={{ marginBottom: 8 }}>
-          <h1 className="font-display" style={{ fontSize: 22, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em' }}>
-            Scheduling &amp; Field Ops
-          </h1>
-          <p style={{ fontSize: 13, color: '#64748b', marginTop: 2 }}>
-            Redesign preview · mock data · fully interactive (try the Edit toggle)
-          </p>
-        </div>
+        <h1 className="font-display" style={{ fontSize: 22, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em' }}>
+          Scheduling &amp; Field Ops
+        </h1>
+        <p style={{ fontSize: 13, color: '#64748b', marginTop: 2 }}>
+          Redesign preview · mock data · fully interactive
+        </p>
 
-        {/* Module tab bar — same segmented control used in SchedulingView */}
         <div className="inline-flex items-center gap-1 p-1 rounded-xl border bg-slate-100/70 border-slate-200" style={{ margin: '14px 0' }}>
           {TABS.map(t => (
             <button
               key={t.id}
+              onClick={() => setTab(t.id)}
               className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
-                t.active ? 'bg-brand text-white shadow-sm' : 'text-slate-500 hover:text-slate-900 hover:bg-white'
+                tab === t.id ? 'bg-brand text-white shadow-sm' : 'text-slate-500 hover:text-slate-900 hover:bg-white'
               }`}
             >
               {t.icon}{t.label}
@@ -77,22 +73,17 @@ function Preview() {
           ))}
         </div>
 
-        {/* The redesigned board */}
-        <div style={{ height: 620 }}>
-          <Scheduler
-            crews={crews}
-            jobs={jobs}
-            initialBlocks={blocks}
-            userRole="admin"
-          />
-        </div>
+        {tab === 'board' && (
+          <div style={{ height: 620 }}>
+            <Scheduler crews={crews} jobs={jobs} initialBlocks={blocks} userRole="admin" />
+          </div>
+        )}
+        {tab === 'resources' && <ResourcesManager companyId="demo" isAdmin isDarkMode={false} />}
+        {tab === 'logs'      && <WorkLogEditor   companyId="demo" isAdmin isDarkMode={false} />}
+        {tab === 'invoices'  && <InvoiceView     companyId="demo" companyName="Demo Underground Co." isAdmin isDarkMode={false} />}
       </div>
     </div>
   );
 }
 
-createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <Preview />
-  </React.StrictMode>,
-);
+createRoot(document.getElementById('root')!).render(<React.StrictMode><Preview /></React.StrictMode>);

--- a/preview/mockScheduleService.ts
+++ b/preview/mockScheduleService.ts
@@ -1,0 +1,108 @@
+// In-memory stand-in for services/scheduleService.ts, used ONLY by the preview
+// build (wired via a Vite resolve alias). Lets the data-driven scheduling views
+// render with representative sample data without the Supabase backend.
+import {
+  Employee, Equipment, Material, ServiceJob, WorkLog, WorkLogEntry,
+  WorkLogTemplate, Invoice, InvoiceSettings,
+} from '../services/schedulingTypes.ts';
+
+const wait = <T>(v: T): Promise<T> => new Promise(r => setTimeout(() => r(v), 120));
+
+let employees: Employee[] = [
+  { id: 1, companyId: 'demo', name: 'Marcus Webb',    role: 'Foreman',         hourlyRate: 48, profileId: null },
+  { id: 2, companyId: 'demo', name: 'Diego Alvarez',  role: 'Operator',        hourlyRate: 41, profileId: null },
+  { id: 3, companyId: 'demo', name: 'Tyler Nguyen',   role: 'Laborer',         hourlyRate: 32, profileId: null },
+  { id: 4, companyId: 'demo', name: 'Priya Anand',    role: 'Pipe Layer',      hourlyRate: 38, profileId: null },
+  { id: 5, companyId: 'demo', name: 'Sam Carter',     role: 'Equipment Op.',   hourlyRate: 44, profileId: null },
+];
+let equipment: Equipment[] = [
+  { id: 'eq1', companyId: 'demo', name: '2020 Caterpillar 320 Excavator', hourlyRate: 145, unitNumber: '1001', equipmentType: 'Excavator', year: 2020, make: 'Caterpillar', model: '320' },
+  { id: 'eq2', companyId: 'demo', name: '2019 Kenworth T880 Dump Truck',  hourlyRate: 95,  unitNumber: '1002', equipmentType: 'Dump Truck', year: 2019, make: 'Kenworth', model: 'T880' },
+  { id: 'eq3', companyId: 'demo', name: '2021 Bobcat S76 Skid Steer',     hourlyRate: 72,  unitNumber: '1003', equipmentType: 'Skid Steer', year: 2021, make: 'Bobcat', model: 'S76' },
+  { id: 'eq4', companyId: 'demo', name: '2021 Bomag BW213D Compactor',    hourlyRate: 55,  unitNumber: '1004', equipmentType: 'Compactor', year: 2021, make: 'Bomag', model: 'BW213D' },
+  { id: 'eq5', companyId: 'demo', name: 'Multiquip Trash Pump',           hourlyRate: 28,  unitNumber: '1005', equipmentType: 'Pump', make: 'Multiquip' },
+];
+let materials: Material[] = [
+  { id: 1, companyId: 'demo', name: 'Concrete (cu yd)',  unitPrice: 142 },
+  { id: 2, companyId: 'demo', name: 'Rebar #5 (ton)',    unitPrice: 880 },
+  { id: 3, companyId: 'demo', name: '6" PVC Pipe (ft)',  unitPrice: 7.25 },
+  { id: 4, companyId: 'demo', name: 'Crushed Stone (ton)', unitPrice: 24 },
+  { id: 5, companyId: 'demo', name: 'Geotextile Fabric (roll)', unitPrice: null },
+];
+const log = (id: number, jobId: number, date: string, notes: string, e: WorkLogEntry): WorkLog => ({ id, jobId, date, notes, data: e });
+let serviceJobs: ServiceJob[] = [
+  {
+    id: 1, companyId: 'demo', customerName: 'City of Austin PW', jobName: 'Riverside Main Replacement', jobNumber: 'J-2041',
+    address: '1180 Riverside Dr, Austin', startDate: null, endDate: null, notes: '', status: 'active', foremanId: null,
+    logs: [
+      log(11, 1, '2026-06-15', 'Trench + lay pipe', { employees: [{ employeeId: 1, hours: 8, rate: 48 }, { employeeId: 4, hours: 8, rate: 38 }], equipment: [{ equipmentId: 'eq1', hours: 8, rate: 145 }], materials: [{ materialId: 3, name: '6" PVC Pipe (ft)', quantity: 120, unitPrice: 7.25 }] }),
+      log(12, 1, '2026-06-16', 'Backfill + compact', { employees: [{ employeeId: 1, hours: 8, rate: 48 }, { employeeId: 3, hours: 8, rate: 32 }], equipment: [{ equipmentId: 'eq4', hours: 6, rate: 55 }], materials: [{ materialId: 4, name: 'Crushed Stone (ton)', quantity: 18, unitPrice: 24 }] }),
+    ],
+  },
+  {
+    id: 2, companyId: 'demo', customerName: 'Round Rock ISD', jobName: 'Industrial Pkwy Storm Drain', jobNumber: 'J-2042',
+    address: '95 Industrial Pkwy, Round Rock', startDate: null, endDate: null, notes: '', status: 'active', foremanId: null,
+    logs: [
+      log(21, 2, '2026-06-17', 'Set inlets', { employees: [{ employeeId: 5, hours: 8, rate: 44 }, { employeeId: 2, hours: 8, rate: 41 }], equipment: [{ equipmentId: 'eq3', hours: 8, rate: 72 }], materials: [{ materialId: 1, name: 'Concrete (cu yd)', quantity: 6, unitPrice: 142 }] }),
+    ],
+  },
+  {
+    id: 3, companyId: 'demo', customerName: 'Lakeway HOA', jobName: 'Lakeway Blvd Curb & Gutter', jobNumber: 'J-2043',
+    address: '400 Lakeway Blvd, Lakeway', startDate: null, endDate: null, notes: '', status: 'active', foremanId: null,
+    logs: [],
+  },
+];
+let invoices: Invoice[] = [
+  { id: 101, companyId: 'demo', jobId: 1, invoiceNumber: 'INV-J-2041-8842', date: '2026-06-17', dueDate: '2026-07-17', status: 'sent',  laborTotal: 1408, equipmentTotal: 1490, materialTotal: 1302, grandTotal: 4200, data: {} },
+  { id: 102, companyId: 'demo', jobId: 2, invoiceNumber: 'INV-J-2042-1190', date: '2026-06-18', dueDate: '2026-07-18', status: 'draft', laborTotal: 680,  equipmentTotal: 576,  materialTotal: 852,  grandTotal: 2108, data: {} },
+];
+let templates: WorkLogTemplate[] = [
+  { id: 1, companyId: 'demo', name: 'Standard 2-man crew + excavator', data: { employees: [{ employeeId: 1, hours: 8, rate: 48 }, { employeeId: 3, hours: 8, rate: 32 }], equipment: [{ equipmentId: 'eq1', hours: 8, rate: 145 }], materials: [] } },
+];
+let settings: InvoiceSettings = {
+  id: 1, companyId: 'demo', companyName: 'Demo Underground Co.', companyAddress: '500 Industrial Blvd, Austin, TX',
+  companyPhone: '(512) 555-0142', companyEmail: 'billing@demoug.com', logoInitials: 'DU',
+  paymentTerms: 'Payment due within 30 days.', headerColor: '#0a142d', accentColor: '#c49614',
+};
+
+let eqSeq = 6, matSeq = 6, empSeq = 6, jobSeq = 4, logSeq = 900, invSeq = 200, tplSeq = 10;
+
+export const scheduleService = {
+  getEmployees: () => wait([...employees]),
+  createEmployee: (companyId: string, e: Omit<Employee, 'id' | 'companyId'>) => { const row = { ...e, id: empSeq++, companyId }; employees.push(row); return wait(row); },
+  updateEmployee: () => wait(undefined),
+  deleteEmployee: (id: number) => { employees = employees.filter(x => x.id !== id); return wait(undefined); },
+
+  getEquipment: () => wait([...equipment]),
+  createEquipment: (companyId: string, e: Omit<Equipment, 'id' | 'companyId'>) => { const row = { ...e, id: 'eq' + eqSeq++, companyId }; equipment.push(row); return wait(row); },
+  updateEquipment: () => wait(undefined),
+  deleteEquipment: (id: string) => { equipment = equipment.filter(x => x.id !== id); return wait(undefined); },
+  bulkCreateEquipment: (companyId: string, items: Omit<Equipment, 'id' | 'companyId'>[]) => { const rows = items.map(i => ({ ...i, id: 'eq' + eqSeq++, companyId })); equipment.push(...rows); return wait(rows); },
+
+  getMaterials: () => wait([...materials]),
+  createMaterial: (companyId: string, m: Omit<Material, 'id' | 'companyId'>) => { const row = { ...m, id: matSeq++, companyId }; materials.push(row); return wait(row); },
+  updateMaterial: () => wait(undefined),
+  deleteMaterial: (id: number) => { materials = materials.filter(x => x.id !== id); return wait(undefined); },
+  bulkCreateMaterial: (companyId: string, items: Omit<Material, 'id' | 'companyId'>[]) => { const rows = items.map(i => ({ ...i, id: matSeq++, companyId })); materials.push(...rows); return wait(rows); },
+
+  getServiceJobs: () => wait(JSON.parse(JSON.stringify(serviceJobs)) as ServiceJob[]),
+  createServiceJob: (companyId: string, j: Omit<ServiceJob, 'id' | 'companyId' | 'logs'>) => { const row: ServiceJob = { ...j, id: jobSeq++, companyId, logs: [] }; serviceJobs.push(row); return wait(row); },
+  updateServiceJob: () => wait(undefined),
+  deleteServiceJob: (id: number) => { serviceJobs = serviceJobs.filter(x => x.id !== id); return wait(undefined); },
+
+  createWorkLog: (jobId: number, date: string, notes: string, data: WorkLogEntry) => { const row = log(logSeq++, jobId, date, notes, data); const job = serviceJobs.find(j => j.id === jobId); if (job) job.logs = [...(job.logs ?? []), row]; return wait(row); },
+  updateWorkLog: () => wait(undefined),
+  deleteWorkLog: (id: number) => { serviceJobs.forEach(j => { if (j.logs) j.logs = j.logs.filter(l => l.id !== id); }); return wait(undefined); },
+
+  getTemplates: () => wait([...templates]),
+  createTemplate: (companyId: string, name: string, data: WorkLogEntry) => { const row = { id: tplSeq++, companyId, name, data }; templates.push(row); return wait(row); },
+  deleteTemplate: (id: number) => { templates = templates.filter(x => x.id !== id); return wait(undefined); },
+
+  getInvoices: () => wait([...invoices]),
+  createInvoice: (companyId: string, inv: Omit<Invoice, 'id' | 'companyId'>) => { const row = { ...inv, id: invSeq++, companyId }; invoices.push(row); return wait(row); },
+  updateInvoiceStatus: (id: number, status: 'draft' | 'sent' | 'paid') => { const i = invoices.find(x => x.id === id); if (i) i.status = status; return wait(undefined); },
+  deleteInvoice: (id: number) => { invoices = invoices.filter(x => x.id !== id); return wait(undefined); },
+
+  getInvoiceSettings: () => wait(settings),
+  upsertInvoiceSettings: (companyId: string, s: Omit<InvoiceSettings, 'id' | 'companyId'>) => { settings = { ...s, id: 1, companyId }; return wait(settings); },
+};

--- a/vite.preview.config.ts
+++ b/vite.preview.config.ts
@@ -8,6 +8,13 @@ import { resolve } from 'path';
 export default defineConfig({
   base: './',
   plugins: [react()],
+  resolve: {
+    alias: [
+      // Swap the Supabase-backed data service for an in-memory mock so the
+      // data-driven scheduling views render without the backend.
+      { find: /^.*services\/scheduleService\.ts$/, replacement: resolve(__dirname, 'preview/mockScheduleService.ts') },
+    ],
+  },
   define: {
     'process.env.SUPABASE_URL': '""',
     'process.env.SUPABASE_ANON_KEY': '""',

--- a/vite.preview.config.ts
+++ b/vite.preview.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+// Standalone build for the throwaway Scheduler preview (preview/index.html).
+// Produces a single inlinable JS + CSS bundle so it can be flattened into one
+// self-contained HTML file that opens from the local filesystem.
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  define: {
+    'process.env.SUPABASE_URL': '""',
+    'process.env.SUPABASE_ANON_KEY': '""',
+  },
+  build: {
+    outDir: 'preview-dist',
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: resolve(__dirname, 'preview/index.html'),
+      output: { inlineDynamicImports: true },
+    },
+  },
+});


### PR DESCRIPTION
Unify the previously mismatched dark-header / light-grid look into one
cohesive, modern dispatch board:

- Refined dark command bar with a branded title block, segmented view
  toggle, grouped navigation, a date-range pill, and clearer action grouping
- Light, airy column headers with a brand-filled "today" date badge and
  subtle today-column / weekend shading
- Light crew sidebar with colored per-crew avatar chips and a cleaner
  worker/member summary
- Job blocks redesigned with a subtle gradient sheen, left accent strip,
  softer layered shadows, rounded corners, a duration pill, and crisper
  label typography
- Polished, harmonious crew color palette and roomier spacing
- Board wrapped in a contained, rounded, bordered panel
- Refined equipment tray styling

No behavioral changes — drag/drop, resize, delays, equipment, and
persistence all preserved.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015YCNNHo2Nra4Z8zAWzYxym