### PR TITLE
fix: parse combined Year/Make/Model column and capture VIN, license, notes from equipment spreadsheet

### DIFF
--- a/components/scheduling/CsvImportModal.tsx
+++ b/components/scheduling/CsvImportModal.tsx
@@ -235,7 +235,7 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
   return (
     <div className={overlay} onClick={onClose}>
       <div
-        className={`w-full max-w-2xl rounded-2xl border shadow-2xl ${card} p-6`}
+        className={`w-full max-w-2xl rounded-2xl border shadow-2xl ${card} p-6 max-h-[90vh] overflow-y-auto`}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
@@ -316,7 +316,14 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
               <button onClick={clearRows} className={`ml-auto text-xs underline ${subtext}`}>Change file</button>
             </div>
 
-            <div className={`overflow-auto max-h-56 rounded-lg border ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
+            {importError && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-rose-50 border border-rose-200 text-rose-700 text-sm">
+                <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                <span>{importError}</span>
+              </div>
+            )}
+
+            <div className={`overflow-auto max-h-48 rounded-lg border ${isDarkMode ? 'border-slate-700' : 'border-slate-200'}`}>
               <table className="w-full">
                 <thead className={isDarkMode ? 'bg-slate-900' : 'bg-slate-50'}>
                   <tr>
@@ -365,13 +372,6 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
                 </tbody>
               </table>
             </div>
-
-            {importError && (
-              <div className="flex items-start gap-2 p-3 rounded-lg bg-rose-50 border border-rose-200 text-rose-700 text-sm">
-                <AlertCircle size={16} className="mt-0.5 shrink-0" />
-                <span>{importError}</span>
-              </div>
-            )}
 
             <div className="flex gap-3">
               <button

--- a/components/scheduling/CsvImportModal.tsx
+++ b/components/scheduling/CsvImportModal.tsx
@@ -20,6 +20,10 @@ type EquipmentDraft = {
   make: string;
   model: string;
   hourlyRate: number;
+  vin: string;
+  serialNumber: string;
+  licensePlate: string;
+  notes: string;
 };
 type MaterialDraft  = { name: string; unitPrice: number | null };
 
@@ -45,26 +49,87 @@ async function parseSpreadsheet(file: File): Promise<Record<string, unknown>[]> 
   });
 }
 
+// Splits "2020 Chevrolet 2500 HD LT" → { year: 2020, make: "Chevrolet", model: "2500 HD LT" }
+function parseYearMakeModel(raw: string): { year: number | null; make: string; model: string } {
+  const s = (raw ?? '').trim();
+  if (!s || s === 'X') return { year: null, make: '', model: '' };
+  const m = s.match(/^(\d{4})\s+(.+)/);
+  if (m) {
+    const year = parseInt(m[1], 10);
+    const rest = m[2];
+    const sp   = rest.indexOf(' ');
+    return sp === -1
+      ? { year, make: rest, model: '' }
+      : { year, make: rest.slice(0, sp), model: rest.slice(sp + 1) };
+  }
+  const sp = s.indexOf(' ');
+  return sp === -1
+    ? { year: null, make: s, model: '' }
+    : { year: null, make: s.slice(0, sp), model: s.slice(sp + 1) };
+}
+
+// Splits "VIN#1GC4..." → vin field; "Ser#..." / "SN#..." → serialNumber field
+function parseVinSerial(raw: string): { vin: string; serialNumber: string } {
+  const s = (raw ?? '').trim();
+  if (!s) return { vin: '', serialNumber: '' };
+  if (/^VIN#?\s*/i.test(s)) {
+    return { vin: s.replace(/^VIN#?\s*/i, '').split('/')[0].trim(), serialNumber: '' };
+  }
+  const serial = s.replace(/^(S\/N#?|SN#?|Ser#?|Serial#?)\s*/i, '').split('/')[0].trim();
+  return { vin: '', serialNumber: serial };
+}
+
+// Strips "Lic# " prefix and trailing asterisks from license plate values
+function parseLicense(raw: string): string {
+  return (raw ?? '').trim().replace(/^Lic\s*#?\s*/i, '').replace(/\*$/, '').trim();
+}
+
 function toEquipmentRows(raw: Record<string, unknown>[]): EquipmentDraft[] {
   return raw.map(row => {
     const keys = Object.keys(row);
-    const unitKey  = findKey(keys, ['unitnumber', 'unit', 'unitno', 'unit#', 'equipno', 'equipnumber', 'equipmentnumber', 'truckno', 'assetno', 'assetnumber']);
-    const typeKey  = findKey(keys, ['equipmenttype', 'type', 'category', 'class', 'kind']);
-    const yearKey  = findKey(keys, ['year', 'yr', 'modelyear']);
-    const makeKey  = findKey(keys, ['make', 'manufacturer', 'brand', 'mfg']);
-    const modelKey = findKey(keys, ['model', 'modelnumber', 'modelno', 'series']);
-    const rateKey  = findKey(keys, ['hourlyrate', 'rate', 'hr', 'hourlycost', 'costperhr', 'costperhour', 'hourlyrental']);
+    const unitKey     = findKey(keys, ['unitnumber', 'unit', 'unitno', 'unit#', 'equipno', 'equipnumber', 'equipmentnumber', 'truckno', 'assetno', 'assetnumber']);
+    const typeKey     = findKey(keys, ['equipmenttype', 'type', 'category', 'class', 'kind']);
+    const yearKey     = findKey(keys, ['year', 'yr', 'modelyear']);
+    const makeKey     = findKey(keys, ['make', 'manufacturer', 'brand', 'mfg']);
+    const modelKey    = findKey(keys, ['model', 'modelnumber', 'modelno', 'series']);
+    const rateKey     = findKey(keys, ['hourlyrate', 'rate', 'hr', 'hourlycost', 'costperhr', 'costperhour', 'hourlyrental']);
+    const ymmKey      = findKey(keys, ['yearmakemodel', 'yearmodel', 'makemodel', 'ymm']);
+    const vinKey      = findKey(keys, ['vinserial', 'vinserialnumber', 'vin', 'serial', 'serialnumber', 'sn']);
+    const licenseKey  = findKey(keys, ['license', 'licensenumber', 'licenseplate', 'licno', 'lic', 'plate']);
+    const notesKey    = findKey(keys, ['notes', 'note', 'comments', 'comment', 'remarks']);
 
     const rawRate = String(row[rateKey ?? ''] ?? '').replace(/[^0-9.]/g, '');
-    const rawYear = yearKey ? String(row[yearKey] ?? '').replace(/[^0-9]/g, '') : '';
+
+    // Year/Make/Model: prefer separate columns, fall back to combined column
+    let year: number | null = null;
+    let make = '';
+    let model = '';
+    if (yearKey || makeKey || modelKey) {
+      const rawYear = yearKey ? String(row[yearKey] ?? '').replace(/[^0-9]/g, '') : '';
+      year  = rawYear ? parseInt(rawYear, 10) : null;
+      make  = makeKey  ? String(row[makeKey]  ?? '').trim() : '';
+      model = modelKey ? String(row[modelKey] ?? '').trim() : '';
+    } else if (ymmKey) {
+      ({ year, make, model } = parseYearMakeModel(String(row[ymmKey] ?? '')));
+    }
+
+    const { vin, serialNumber } = vinKey
+      ? parseVinSerial(String(row[vinKey] ?? ''))
+      : { vin: '', serialNumber: '' };
+
+    const rawType = typeKey ? String(row[typeKey] ?? '').trim() : '';
 
     return {
       unitNumber:    unitKey  ? String(row[unitKey]  ?? '').trim() : '',
-      equipmentType: typeKey  ? String(row[typeKey]  ?? '').trim() : '',
-      year:          rawYear  ? parseInt(rawYear, 10) : null,
-      make:          makeKey  ? String(row[makeKey]  ?? '').trim() : '',
-      model:         modelKey ? String(row[modelKey] ?? '').trim() : '',
+      equipmentType: rawType === 'X' ? '' : rawType,
+      year,
+      make,
+      model,
       hourlyRate:    rawRate  ? parseFloat(rawRate)  : 0,
+      vin,
+      serialNumber,
+      licensePlate:  licenseKey ? parseLicense(String(row[licenseKey] ?? '')) : '',
+      notes:         notesKey   ? String(row[notesKey] ?? '').trim() : '',
     };
   }).filter(r => r.unitNumber || r.make || r.model || r.equipmentType);
 }
@@ -149,6 +214,10 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
           equipRows!.map(e => ({
             ...e,
             name: [e.year, e.make, e.model].filter(Boolean).join(' ') || e.unitNumber || e.equipmentType || 'Equipment',
+            vin:          e.vin,
+            serialNumber: e.serialNumber,
+            licensePlate: e.licensePlate,
+            notes:        e.notes,
           }))
         );
       } else {

--- a/services/scheduleService.ts
+++ b/services/scheduleService.ts
@@ -33,11 +33,15 @@ const mapEquipment = (row: Record<string, unknown>): Equipment => ({
   companyId:     String(row.company_id ?? ''),
   name:          String(row.name ?? ''),
   hourlyRate:    Number(row.hourly_rate ?? 0),
-  unitNumber:    row.unit_number != null ? String(row.unit_number) : undefined,
+  unitNumber:    row.unit_number    != null ? String(row.unit_number)    : undefined,
   equipmentType: row.equipment_type != null ? String(row.equipment_type) : undefined,
-  year:          row.year != null ? Number(row.year) : null,
-  make:          row.make != null ? String(row.make) : undefined,
-  model:         row.model != null ? String(row.model) : undefined,
+  year:          row.year           != null ? Number(row.year)           : null,
+  make:          row.make           != null ? String(row.make)           : undefined,
+  model:         row.model          != null ? String(row.model)          : undefined,
+  vin:           row.vin            != null ? String(row.vin)            : undefined,
+  serialNumber:  row.serial_number  != null ? String(row.serial_number)  : undefined,
+  licensePlate:  row.license_plate  != null ? String(row.license_plate)  : undefined,
+  notes:         row.notes          != null ? String(row.notes)          : undefined,
 });
 
 const mapMaterial = (row: Record<string, unknown>): Material => ({
@@ -213,11 +217,15 @@ export const scheduleService = {
       name:           e.name,
       item_type:      'EQUIPMENT',
       hourly_rate:    e.hourlyRate,
-      unit_number:    e.unitNumber ?? null,
+      unit_number:    e.unitNumber    ?? null,
       equipment_type: e.equipmentType ?? null,
-      year:           e.year ?? null,
-      make:           e.make ?? null,
-      model:          e.model ?? null,
+      year:           e.year          ?? null,
+      make:           e.make          ?? null,
+      model:          e.model         ?? null,
+      vin:            e.vin           ?? null,
+      serial_number:  e.serialNumber  ?? null,
+      license_plate:  e.licensePlate  ?? null,
+      notes:          e.notes         ?? null,
     }));
     const { data, error } = await supabase.from('inventory_items').insert(rows).select();
     if (error) throw error;

--- a/services/schedulingTypes.ts
+++ b/services/schedulingTypes.ts
@@ -32,6 +32,10 @@ export interface Equipment {
   year?: number | null;
   make?: string;
   model?: string;
+  vin?: string;
+  serialNumber?: string;
+  licensePlate?: string;
+  notes?: string;
 }
 
 export interface Material {


### PR DESCRIPTION
The existing parser looked for separate year/make/model columns, which don't
exist in the customer's spreadsheet. That spreadsheet uses a single combined
"Year/Make/Model" column (e.g. "2020 Chevrolet 2500 HD LT") alongside
"VIN / Serial #", "License #", and "Notes" columns that map to DB fields
already present in inventory_items but were never read.

Changes:
- Add parseYearMakeModel(): splits "YYYY Make Model..." into year/make/model
- Add parseVinSerial(): routes "VIN#..." to vin field, "Ser#/SN#..." to serial_number
- Add parseLicense(): strips "Lic# " prefix/trailing asterisks from license values
- toEquipmentRows() now detects the combined "yearmakemodel" header (after norm())
  and falls back to it when separate year/make/model columns are absent
- EquipmentDraft gains vin, serialNumber, licensePlate, notes fields
- Equipment interface, mapEquipment(), and bulkCreateEquipment() updated to
  carry and persist those four additional fields to the DB

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B3YTEybbpyKU7j3WkcQYHb