### PR TITLE
fix(scheduler): improve mobile layout for the Dispatch Board module

### DIFF
--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -2205,7 +2205,7 @@ export default function Scheduler({
   // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
-    <div className="flex flex-col h-full bg-white select-none rounded-2xl border border-slate-200 overflow-hidden shadow-sm" style={{ minHeight: 0 }}>
+    <div className="flex flex-col bg-white select-none rounded-2xl border border-slate-200 overflow-hidden shadow-sm" style={{ height: 'calc(100svh - 220px)', minHeight: '420px' }}>
       {/* ─── Toolbar ─── */}
       <div
         className="flex items-center gap-x-3 gap-y-2.5 px-5 py-3.5 shrink-0 flex-wrap"

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -2291,7 +2291,7 @@ export default function Scheduler({
                 : 'bg-white/10 hover:bg-white/20 text-slate-200 border-white/10'
             }`}
           >
-            <Pencil className="w-3.5 h-3.5" /> {editMode ? 'Editing' : 'Edit'}
+            <Pencil className="w-3.5 h-3.5" /><span className="hidden sm:inline">{editMode ? 'Editing' : 'Edit'}</span>
           </button>
           {/* Undo button — visible only in edit mode */}
           {editMode && (
@@ -2306,7 +2306,7 @@ export default function Scheduler({
                   : 'bg-white/5 text-slate-600 border-white/5 cursor-not-allowed'
               }`}
             >
-              <RotateCcw className="w-3.5 h-3.5" /> Undo
+              <RotateCcw className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Undo</span>
             </button>
           )}
 
@@ -2317,15 +2317,17 @@ export default function Scheduler({
             <>
               <button
                 onClick={() => setShowManageCrews(true)}
+                title="Manage crews"
                 className="flex items-center gap-1.5 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-slate-200 text-xs font-semibold rounded-lg transition-colors border border-white/10"
               >
-                <Users className="w-3.5 h-3.5" /> Crews
+                <Users className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Crews</span>
               </button>
               <button
                 onClick={() => setShowManageJobs(true)}
+                title="Manage jobs"
                 className="flex items-center gap-1.5 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-slate-200 text-xs font-semibold rounded-lg transition-colors border border-white/10"
               >
-                <Briefcase className="w-3.5 h-3.5" /> Jobs
+                <Briefcase className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Jobs</span>
               </button>
             </>
           )}
@@ -2333,19 +2335,22 @@ export default function Scheduler({
             onClick={() => setShowEquipTray(t => !t)}
             aria-pressed={showEquipTray}
             aria-label="Toggle equipment tray"
+            title="Toggle equipment tray"
             className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors border ${
               showEquipTray
                 ? 'bg-amber-500 text-white border-amber-400 shadow-sm'
                 : 'bg-white/10 hover:bg-white/20 text-slate-200 border-white/10'
             }`}
           >
-            <Wrench className="w-3.5 h-3.5" /> Equipment
+            <Wrench className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Equipment</span>
           </button>
           <button
             onClick={() => setShowAddModal(true)}
+            aria-label="Add job"
+            title="Add job"
             className="flex items-center gap-1.5 px-3.5 py-1.5 bg-brand hover:opacity-90 text-white text-xs font-semibold rounded-lg transition-all shadow-brand/20 hover:-translate-y-px"
           >
-            <Plus className="w-3.5 h-3.5" /> Add Job
+            <Plus className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Add Job</span>
           </button>
         </div>
       </div>

--- a/components/scheduling/SchedulingView.tsx
+++ b/components/scheduling/SchedulingView.tsx
@@ -49,27 +49,30 @@ export default function SchedulingView({ sessionUser, jobs, companyName, isDarkM
   ];
 
   return (
-    <div className="space-y-4">
-      <div
-        className={`inline-flex items-center gap-1 p-1 rounded-xl border ${
-          isDarkMode ? 'bg-slate-800/60 border-slate-700' : 'bg-slate-100/70 border-slate-200'
-        }`}
-      >
-        {TABS.map(t => (
-          <button
-            key={t.id}
-            onClick={() => setTab(t.id)}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
-              tab === t.id
-                ? 'bg-brand text-white shadow-sm'
-                : isDarkMode
-                  ? 'text-slate-300 hover:text-white hover:bg-white/5'
-                  : 'text-slate-500 hover:text-slate-900 hover:bg-white'
-            }`}
-          >
-            {t.icon}{t.label}
-          </button>
-        ))}
+    <div className="flex flex-col gap-4">
+      <div className="overflow-x-auto no-scrollbar shrink-0">
+        <div
+          className={`inline-flex items-center gap-1 p-1 rounded-xl border ${
+            isDarkMode ? 'bg-slate-800/60 border-slate-700' : 'bg-slate-100/70 border-slate-200'
+          }`}
+        >
+          {TABS.map(t => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-all shrink-0 ${
+                tab === t.id
+                  ? 'bg-brand text-white shadow-sm'
+                  : isDarkMode
+                    ? 'text-slate-300 hover:text-white hover:bg-white/5'
+                    : 'text-slate-500 hover:text-slate-900 hover:bg-white'
+              }`}
+            >
+              {t.icon}
+              <span className="hidden sm:inline">{t.label}</span>
+            </button>
+          ))}
+        </div>
       </div>
 
       {tab === 'board' && (


### PR DESCRIPTION
- SchedulingView: wrap tab bar in overflow-x-auto so it scrolls
  horizontally on narrow screens rather than overflowing the viewport;
  hide tab labels on xs and show them on sm+ so 4 tabs fit without scrolling
- Scheduler: replace h-full (which collapsed to nothing without a parent
  height) with calc(100svh - 220px) / minHeight 420px so the Gantt chart
  fills the visible screen on both mobile and desktop

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GNw9wJQnwWFv2ni8qZVxqd