### PR TITLE
Add employee CSV/spreadsheet import with inline rate editor

### DIFF
--- a/components/scheduling/CsvImportModal.tsx
+++ b/components/scheduling/CsvImportModal.tsx
@@ -3,7 +3,7 @@ import * as XLSX from 'xlsx';
 import { X, FileSpreadsheet, CheckCircle, AlertCircle } from 'lucide-react';
 import { scheduleService } from '../../services/scheduleService.ts';
 
-type ImportType = 'equipment' | 'materials';
+type ImportType = 'equipment' | 'materials' | 'employees';
 
 interface CsvImportModalProps {
   type: ImportType;
@@ -26,6 +26,7 @@ type EquipmentDraft = {
   notes: string;
 };
 type MaterialDraft  = { name: string; unitPrice: number | null };
+type EmployeeDraft  = { name: string; role: string; hourlyRate: number | null };
 
 function norm(s: string) { return s.toLowerCase().replace(/[\s_\-\/\.#()]/g, ''); }
 
@@ -147,13 +148,32 @@ function toMaterialRows(raw: Record<string, unknown>[]): MaterialDraft[] {
   }).filter(r => r.name);
 }
 
+function toEmployeeRows(raw: Record<string, unknown>[]): EmployeeDraft[] {
+  return raw.map(row => {
+    const keys = Object.keys(row);
+    const nameKey = findKey(keys, ['name', 'fullname', 'employeename', 'employee', 'worker', 'person']) ?? keys[0];
+    const roleKey = findKey(keys, ['role', 'title', 'jobtitle', 'position', 'trade', 'classification', 'class']);
+    const rateKey = findKey(keys, ['hourlyrate', 'rate', 'hr', 'hourlypay', 'wage', 'pay', 'hourly', 'costperhr', 'payrate']);
+    const rawRate = rateKey ? String(row[rateKey] ?? '').replace(/[^0-9.]/g, '') : '';
+    return {
+      name:       String(row[nameKey ?? ''] ?? '').trim(),
+      role:       roleKey ? String(row[roleKey] ?? '').trim() : '',
+      hourlyRate: rawRate ? parseFloat(rawRate) : null,
+    };
+  }).filter(r => r.name);
+}
+
 function downloadTemplate(type: ImportType) {
   const header  = type === 'equipment'
     ? 'unitNumber,equipmentType,year,make,model,hourlyRate'
-    : 'name,unitPrice';
+    : type === 'employees'
+      ? 'name,role,hourlyRate'
+      : 'name,unitPrice';
   const example = type === 'equipment'
     ? '1001,Excavator,2020,Caterpillar,320,75\n1002,Dump Truck,2019,Kenworth,T880,50\n1003,Compactor,2021,Bomag,BW213D,40'
-    : 'Concrete (cu yd),120\nRebar (ton),850\nConduit (ft),3.50';
+    : type === 'employees'
+      ? 'Jane Smith,Operator,32.50\nBob Johnson,Laborer,28.00\nMaria Garcia,Foreman,'
+      : 'Concrete (cu yd),120\nRebar (ton),850\nConduit (ft),3.50';
   const blob = new Blob([`${header}\n${example}`], { type: 'text/csv' });
   const url  = URL.createObjectURL(blob);
   const a    = document.createElement('a');
@@ -167,13 +187,14 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
   const [isDragging,   setIsDragging]   = useState(false);
   const [equipRows,    setEquipRows]    = useState<EquipmentDraft[] | null>(null);
   const [matRows,      setMatRows]      = useState<MaterialDraft[]  | null>(null);
+  const [empRows,      setEmpRows]      = useState<EmployeeDraft[]  | null>(null);
   const [parseError,   setParseError]   = useState<string | null>(null);
   const [importing,    setImporting]    = useState(false);
   const [importError,  setImportError]  = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
-  const label = type === 'equipment' ? 'Equipment' : 'Materials';
-  const rows  = (type === 'equipment' ? equipRows : matRows) as (EquipmentDraft | MaterialDraft)[] | null;
+  const label = type === 'equipment' ? 'Equipment' : type === 'employees' ? 'Employee' : 'Materials';
+  const rows  = (type === 'equipment' ? equipRows : type === 'employees' ? empRows : matRows) as (EquipmentDraft | EmployeeDraft | MaterialDraft)[] | null;
   const count = rows?.length ?? 0;
 
   const overlay  = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4';
@@ -188,13 +209,14 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
   const thCls = `px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide border-b ${isDarkMode ? 'text-slate-400 border-slate-700' : 'text-slate-500 border-slate-200'}`;
   const tdCls = `px-3 py-1.5 border-b text-sm ${isDarkMode ? 'border-slate-700 text-slate-200' : 'border-slate-100 text-slate-700'}`;
 
-  const clearRows = () => { setEquipRows(null); setMatRows(null); setParseError(null); };
+  const clearRows = () => { setEquipRows(null); setMatRows(null); setEmpRows(null); setParseError(null); };
 
   const processFile = async (file: File) => {
     clearRows();
     try {
       const raw = await parseSpreadsheet(file);
       if (type === 'equipment') setEquipRows(toEquipmentRows(raw));
+      else if (type === 'employees') setEmpRows(toEmployeeRows(raw));
       else setMatRows(toMaterialRows(raw));
     } catch {
       setParseError('Could not parse this file. Make sure it is a valid CSV or Excel spreadsheet.');
@@ -219,6 +241,11 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
             licensePlate: e.licensePlate,
             notes:        e.notes,
           }))
+        );
+      } else if (type === 'employees') {
+        await scheduleService.bulkCreateEmployee(
+          companyId,
+          empRows!.map(e => ({ name: e.name, role: e.role, hourlyRate: e.hourlyRate ?? 0 }))
         );
       } else {
         await scheduleService.bulkCreateMaterial(companyId, matRows!);
@@ -282,6 +309,14 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
                   <code className="font-mono">model</code>,{' '}
                   <code className="font-mono">hourlyRate</code>
                 </>
+              ) : type === 'employees' ? (
+                <>
+                  Required:{' '}
+                  <code className="font-mono">name</code>
+                  {' · '}Optional:{' '}
+                  <code className="font-mono">role</code>,{' '}
+                  <code className="font-mono">hourlyRate</code>{' '}(can be set later)
+                </>
               ) : (
                 <>
                   Expected columns:{' '}
@@ -335,6 +370,12 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
                         <th className={thCls}>Make / Model</th>
                         <th className={`${thCls} text-right`}>Rate / hr</th>
                       </>
+                    ) : type === 'employees' ? (
+                      <>
+                        <th className={thCls}>Name</th>
+                        <th className={thCls}>Role</th>
+                        <th className={`${thCls} text-right`}>Rate / hr</th>
+                      </>
                     ) : (
                       <>
                         <th className={thCls}>Name</th>
@@ -355,6 +396,19 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
                             <td className={tdCls}>{e.year ?? <span className={subtext}>—</span>}</td>
                             <td className={tdCls}>{[e.make, e.model].filter(Boolean).join(' ') || <span className={subtext}>—</span>}</td>
                             <td className={`${tdCls} text-right`}>${e.hourlyRate.toFixed(2)}/hr</td>
+                          </>
+                        );
+                      })() : type === 'employees' ? (() => {
+                        const e = r as EmployeeDraft;
+                        return (
+                          <>
+                            <td className={tdCls}>{e.name}</td>
+                            <td className={tdCls}>{e.role || <span className={subtext}>—</span>}</td>
+                            <td className={`${tdCls} text-right`}>
+                              {e.hourlyRate != null
+                                ? `$${e.hourlyRate.toFixed(2)}/hr`
+                                : <span className={subtext}>set later</span>}
+                            </td>
                           </>
                         );
                       })() : (
@@ -403,6 +457,12 @@ export default function CsvImportModal({ type, companyId, isDarkMode, onClose, o
                 <code className="font-mono text-xs">make</code>{', '}
                 <code className="font-mono text-xs">model</code>{', '}
                 <code className="font-mono text-xs">hourlyRate</code>
+              </p>
+            ) : type === 'employees' ? (
+              <p>
+                <code className="font-mono text-xs">name</code>{' (required), '}
+                <code className="font-mono text-xs">role</code>{' and '}
+                <code className="font-mono text-xs">hourlyRate</code>{' (optional)'}
               </p>
             ) : (
               <p>

--- a/components/scheduling/ResourcesManager.tsx
+++ b/components/scheduling/ResourcesManager.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Plus, Trash2, Users, Wrench, Package, Upload, Pencil, X, Check } from 'lucide-react';
+import { Plus, Trash2, Users, Wrench, Package, Upload, Pencil, X, Check, DollarSign } from 'lucide-react';
 import { scheduleService } from '../../services/scheduleService.ts';
 import { Employee, Equipment, Material } from '../../services/schedulingTypes.ts';
 import CsvImportModal from './CsvImportModal.tsx';
@@ -29,7 +29,7 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
   const [equipment, setEquipment] = useState<Equipment[]>([]);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [loading, setLoading] = useState(true);
-  const [csvModal, setCsvModal] = useState<'equipment' | 'materials' | null>(null);
+  const [csvModal, setCsvModal] = useState<'equipment' | 'materials' | 'employees' | null>(null);
 
   // New-row drafts
   const [empDraft, setEmpDraft] = useState({ name: '', role: '', hourlyRate: '' });
@@ -40,6 +40,11 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
   const [editingEq, setEditingEq]   = useState<Equipment | null>(null);
   const [editDraft, setEditDraft]   = useState<Partial<Equipment>>(BLANK_EDIT);
   const [saving, setSaving]         = useState(false);
+
+  // Employee edit modal
+  const [editingEmp, setEditingEmp]     = useState<Employee | null>(null);
+  const [editEmpDraft, setEditEmpDraft] = useState({ name: '', role: '', hourlyRate: '' });
+  const [savingEmp, setSavingEmp]       = useState(false);
 
   const reload = async () => {
     setLoading(true);
@@ -135,6 +140,29 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
     }
   };
 
+  const openEditEmp = (emp: Employee) => {
+    setEditingEmp(emp);
+    setEditEmpDraft({ name: emp.name, role: emp.role, hourlyRate: emp.hourlyRate > 0 ? String(emp.hourlyRate) : '' });
+  };
+  const closeEditEmp = () => { setEditingEmp(null); setEditEmpDraft({ name: '', role: '', hourlyRate: '' }); };
+  const saveEditEmp = async () => {
+    if (!editingEmp || !editEmpDraft.name.trim()) return;
+    setSavingEmp(true);
+    try {
+      await scheduleService.updateEmployee(editingEmp.id, {
+        name:       editEmpDraft.name.trim(),
+        role:       editEmpDraft.role.trim(),
+        hourlyRate: editEmpDraft.hourlyRate !== '' ? Number(editEmpDraft.hourlyRate) : 0,
+      });
+      closeEditEmp();
+      reload();
+    } catch (err) {
+      console.error('[ResourcesManager] save employee failed', err);
+    } finally {
+      setSavingEmp(false);
+    }
+  };
+
   const TABS: { id: ResourceTab; label: string; icon: React.ReactNode }[] = [
     { id: 'employees', label: 'Employees', icon: <Users size={16} /> },
     { id: 'equipment', label: 'Equipment', icon: <Wrench size={16} /> },
@@ -189,17 +217,32 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
                 <span className={`flex-1 ${label}`}>Name</span>
                 <span className={`flex-1 ${label}`}>Role</span>
                 <span className={`w-24 text-right ${label}`}>Rate / hr</span>
-                {isAdmin && <span className="w-6 shrink-0" />}
+                {isAdmin && <span className="w-12 shrink-0" />}
               </div>
               {employees.map(e => (
                 <div key={e.id} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border-b last:border-b-0 transition-colors ${rowCls}`}>
                   <span className={`flex-1 font-medium ${text}`}>{e.name}</span>
                   <span className={`flex-1 ${subtext}`}>{e.role || '—'}</span>
-                  <span className={`w-24 text-right font-mono tabular-nums text-sm ${text}`}>${e.hourlyRate.toFixed(2)}</span>
+                  <span className={`w-24 text-right font-mono tabular-nums text-sm ${e.hourlyRate > 0 ? text : subtext}`}>
+                    {e.hourlyRate > 0 ? `$${e.hourlyRate.toFixed(2)}` : '—'}
+                  </span>
                   {isAdmin && (
-                    <button onClick={() => scheduleService.deleteEmployee(e.id).then(reload)} className="w-6 shrink-0 flex justify-center text-slate-400 hover:text-rose-600 transition-colors" aria-label={`Delete ${e.name}`}>
-                      <Trash2 size={16} />
-                    </button>
+                    <div className="w-12 shrink-0 flex justify-end gap-1">
+                      <button
+                        onClick={() => openEditEmp(e)}
+                        className="w-6 flex justify-center text-slate-400 hover:text-brand transition-colors"
+                        aria-label={`Edit ${e.name}`}
+                      >
+                        <Pencil size={15} />
+                      </button>
+                      <button
+                        onClick={() => scheduleService.deleteEmployee(e.id).then(reload)}
+                        className="w-6 flex justify-center text-slate-400 hover:text-rose-600 transition-colors"
+                        aria-label={`Delete ${e.name}`}
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
                   )}
                 </div>
               ))}
@@ -213,13 +256,19 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
                 <div className={`mt-3 pt-3 border-t ${isDarkMode ? 'border-slate-700' : 'border-slate-100'} space-y-2`}>
                   <p className={label}>Add employee</p>
                   <div className="flex flex-col sm:flex-row gap-2">
-                    <input className={input} placeholder="Name" value={empDraft.name} onChange={e => setEmpDraft({ ...empDraft, name: e.target.value })} />
-                    <input className={input} placeholder="Role" value={empDraft.role} onChange={e => setEmpDraft({ ...empDraft, role: e.target.value })} />
-                    <input className={input} placeholder="Rate/hr" type="number" value={empDraft.hourlyRate} onChange={e => setEmpDraft({ ...empDraft, hourlyRate: e.target.value })} />
+                    <input className={input} placeholder="Name *" value={empDraft.name} onChange={e => setEmpDraft({ ...empDraft, name: e.target.value })} />
+                    <input className={input} placeholder="Role (optional)" value={empDraft.role} onChange={e => setEmpDraft({ ...empDraft, role: e.target.value })} />
+                    <input className={input} placeholder="Rate/hr (optional)" type="number" value={empDraft.hourlyRate} onChange={e => setEmpDraft({ ...empDraft, hourlyRate: e.target.value })} />
                     <button onClick={addEmployee} className={addBtn}>
                       <Plus size={16} />Add
                     </button>
                   </div>
+                  <button
+                    onClick={() => setCsvModal('employees')}
+                    className={`flex items-center gap-2 text-sm font-medium px-3 py-1.5 rounded-lg border transition ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+                  >
+                    <Upload size={14} />Import CSV / Spreadsheet
+                  </button>
                 </div>
               )}
             </div>
@@ -342,6 +391,64 @@ export default function ResourcesManager({ companyId, isAdmin, isDarkMode }: Res
           onClose={() => setCsvModal(null)}
           onImported={reload}
         />
+      )}
+
+      {/* Employee Edit Modal */}
+      {editingEmp && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={e => { if (e.target === e.currentTarget) closeEditEmp(); }}>
+          <div className={`w-full max-w-sm rounded-2xl border shadow-2xl ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-slate-200'}`}>
+            <div className={`flex items-center justify-between px-5 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-slate-100'}`}>
+              <div className="flex items-center gap-2">
+                <Users size={17} className="text-brand" />
+                <h2 className={`text-base font-semibold ${text}`}>Edit Employee</h2>
+              </div>
+              <button onClick={closeEditEmp} className={`rounded-lg p-1.5 transition hover:bg-slate-100 ${isDarkMode ? 'hover:bg-slate-700 text-slate-400' : 'text-slate-400'}`}>
+                <X size={18} />
+              </button>
+            </div>
+            <div className="p-5 space-y-4">
+              <div>
+                <p className={`mb-1 ${label}`}>Name *</p>
+                <input className={input} value={editEmpDraft.name} onChange={e => setEditEmpDraft(d => ({ ...d, name: e.target.value }))} />
+              </div>
+              <div>
+                <p className={`mb-1 ${label}`}>Role</p>
+                <input className={input} placeholder="e.g. Operator, Foreman, Laborer" value={editEmpDraft.role} onChange={e => setEditEmpDraft(d => ({ ...d, role: e.target.value }))} />
+              </div>
+              <div>
+                <p className={`mb-1 ${label}`}>Rate / hr ($)</p>
+                <div className="relative">
+                  <DollarSign size={14} className={`absolute left-3 top-1/2 -translate-y-1/2 ${subtext}`} />
+                  <input
+                    className={`${input} pl-7`}
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="0.00"
+                    value={editEmpDraft.hourlyRate}
+                    onChange={e => setEditEmpDraft(d => ({ ...d, hourlyRate: e.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className={`flex items-center justify-end gap-2 px-5 py-4 border-t ${isDarkMode ? 'border-slate-700' : 'border-slate-100'}`}>
+              <button
+                onClick={closeEditEmp}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition ${isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-slate-600 hover:bg-slate-100'}`}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={saveEditEmp}
+                disabled={savingEmp || !editEmpDraft.name.trim()}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand text-white text-sm font-semibold transition hover:opacity-90 disabled:opacity-50"
+              >
+                {savingEmp ? <span className="w-4 h-4 rounded-full border-2 border-white/30 border-t-white animate-spin" /> : <Check size={15} />}
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Equipment Edit Modal */}

--- a/services/scheduleService.ts
+++ b/services/scheduleService.ts
@@ -215,6 +215,19 @@ export const scheduleService = {
     if (error) throw error;
   },
 
+  async bulkCreateEmployee(companyId: string, items: Pick<Employee, 'name' | 'role' | 'hourlyRate'>[]): Promise<Employee[]> {
+    const rows = items.map(e => ({
+      company_id:  companyId,
+      name:        e.name,
+      role:        e.role,
+      hourly_rate: e.hourlyRate,
+      profile_id:  null,
+    }));
+    const { data, error } = await supabase.from('employees').insert(rows).select();
+    if (error) throw error;
+    return (data ?? []).map(r => mapEmployee(r as Record<string, unknown>));
+  },
+
   async bulkCreateEquipment(companyId: string, items: Omit<Equipment, 'id' | 'companyId'>[]): Promise<Equipment[]> {
     const rows = items.map(e => ({
       company_id:     companyId,


### PR DESCRIPTION
- CsvImportModal: add 'employees' type — parses name (required), role
  and hourlyRate (both optional); preview table shows 'set later' for
  employees without a rate; download template included
- ResourcesManager: wire Import CSV / Spreadsheet button to employees
  tab; add pencil-icon edit modal per row so admins can adjust name,
  role, and rate at any time
- scheduleService: add bulkCreateEmployee for batch inserts

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HxTpwUeJ2kFEAVLNZPUFvL