### PR TITLE
Default equipment to the shop and pin it on the equipment map

### DIFF
--- a/components/EquipmentMapView.tsx
+++ b/components/EquipmentMapView.tsx
@@ -116,6 +116,14 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
   const locMap  = useMemo(() => new Map(locations.map(l => [l.id, l])), [locations]);
   const userMap = useMemo(() => new Map(users.map(u => [u.id, u])), [users]);
 
+  // The "default shop" is where otherwise-idle equipment is parked on the map.
+  // Prefer the first location that has an address (so it can be geocoded);
+  // fall back to the first location if none have an address yet.
+  const defaultShop = useMemo(
+    () => locations.find(l => l.address) ?? locations[0] ?? null,
+    [locations],
+  );
+
   // Look up a job's coordinates from any of its dig tickets that already carry
   // GPS/geocoded coords — saves a network round-trip whenever possible.
   const jobTicketCoords = useMemo(() => {
@@ -164,19 +172,25 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
   // nowhere with a known address) — surfaced in a list beneath the map.
   const unplaced = useMemo(() => {
     return visibleItems.filter(e => {
-      if (e.currentJobId && jobMap.has(e.currentJobId)) return false;
-      if (e.currentLocationId && locMap.get(e.currentLocationId)?.address) return false;
-      return true;
+      if (e.currentJobId && jobMap.has(e.currentJobId)) return false;          // out on a job
+      if (e.currentAssigneeId && !e.currentLocationId && userMap.has(e.currentAssigneeId)) {
+        return true;                                                            // checked out to a crew member — can't be mapped
+      }
+      // Everything else defaults to a shop: its own addressed location, or the
+      // default shop. It's only unmappable if no shop has an address at all.
+      const ownLoc = e.currentLocationId ? locMap.get(e.currentLocationId) : undefined;
+      const shop = ownLoc?.address ? ownLoc : defaultShop;
+      return !shop?.address;
     });
-  }, [visibleItems, jobMap, locMap]);
+  }, [visibleItems, jobMap, locMap, userMap, defaultShop]);
 
   // ── Build placement groups and resolve coordinates ─────────────────────────
   const placementKey = useMemo(() => {
     return visibleItems
-      .map(e => `${e.id}:${e.currentJobId ?? ''}:${e.currentLocationId ?? ''}:${e.updatedAt}`)
+      .map(e => `${e.id}:${e.currentJobId ?? ''}:${e.currentLocationId ?? ''}:${e.currentAssigneeId ?? ''}:${e.updatedAt}`)
       .sort()
-      .join('|') + `#${jobMap.size}#${locMap.size}#${jobTicketCoords.size}`;
-  }, [visibleItems, jobMap, locMap, jobTicketCoords]);
+      .join('|') + `#${jobMap.size}#${locMap.size}#${jobTicketCoords.size}#${userMap.size}#${defaultShop?.id ?? ''}#${defaultShop?.address ?? ''}`;
+  }, [visibleItems, jobMap, locMap, userMap, jobTicketCoords, defaultShop]);
 
   useEffect(() => {
     // Group inventory by destination (job site or shop).
@@ -203,15 +217,24 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
           const coords = jobTicketCoords.get(job.jobNumber) ?? (geoQuery ? cache.get(geoQuery) : undefined);
           if (coords) { placement.lat = coords.lat; placement.lng = coords.lng; }
         }
-      } else if (item.currentLocationId && locMap.get(item.currentLocationId)?.address) {
-        const loc = locMap.get(item.currentLocationId)!;
-        key = `shop:${loc.id}`;
+      } else if (item.currentAssigneeId && !item.currentLocationId && userMap.has(item.currentAssigneeId)) {
+        // Checked out to a crew member with no shop — can't be mapped; shown in
+        // the "Not on map" list instead.
+        continue;
+      } else {
+        // Default to a shop: the item's own addressed location when it has one,
+        // otherwise the company's default shop. This parks all otherwise-idle
+        // equipment at the shop address and keeps the shop pinned on the map.
+        const ownLoc = item.currentLocationId ? locMap.get(item.currentLocationId) : undefined;
+        const shop = ownLoc?.address ? ownLoc : defaultShop;
+        if (!shop?.address) continue; // no shop with an address defined yet
+        key = `shop:${shop.id}`;
         if (!groups.has(key)) {
-          const geoQuery = loc.address || loc.name;
+          const geoQuery = shop.address;
           placement = {
             key, kind: 'shop',
-            label: loc.name,
-            sublabel: loc.address || '',
+            label: shop.name,
+            sublabel: shop.address,
             items: [], geoQuery,
           };
           const coords = cache.get(geoQuery);

--- a/components/EquipmentMapView.tsx
+++ b/components/EquipmentMapView.tsx
@@ -31,6 +31,24 @@ interface EquipmentMapViewProps {
 // A grouping of inventory that shares a single map location — either a job
 // site or a shop (inventory location). Multiple items parked at the same place
 // collapse into one marker so pins never stack on top of each other.
+// Structured address used for geocoding. Nominatim resolves these far more
+// reliably than a single free-text line.
+interface GeoInput {
+  street?: string;
+  city?:   string;
+  state?:  string;
+  zip?:    string;
+}
+
+const geoToText = (g: GeoInput): string =>
+  [g.street, g.city, g.state, g.zip].map(s => s?.trim()).filter(Boolean).join(', ');
+
+const locGeo = (l: InventoryLocation): GeoInput =>
+  ({ street: l.address, city: l.city, state: l.state, zip: l.zip });
+
+const locHasAddress = (l?: InventoryLocation | null): boolean =>
+  !!l && geoToText(locGeo(l)).length > 0;
+
 interface Placement {
   key:      string;
   kind:     'job' | 'shop';
@@ -39,7 +57,7 @@ interface Placement {
   items:    InventoryItem[];
   lat?:     number;
   lng?:     number;
-  geoQuery?: string;       // address to geocode when coords aren't known yet
+  geo?:     GeoInput;      // address to geocode when coords aren't known yet
 }
 
 const JOB_COLOR  = '#3b82f6'; // blue — out on a job
@@ -64,17 +82,43 @@ const createMarkerIcon = (kind: 'job' | 'shop', count: number) => {
   });
 };
 
-const geocodeAddress = async (query: string): Promise<{ lat: number; lng: number } | null> => {
-  if (!query) return null;
+const parseHit = (data: any): { lat: number; lng: number } | null =>
+  data?.length > 0 ? { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) } : null;
+
+// Geocode an address, preferring Nominatim's structured search (street / city /
+// state / postalcode) — the same high-accuracy path the dig-ticket map uses —
+// and falling back to a free-text query when structured search comes up empty.
+const geocodeAddress = async (geo: GeoInput): Promise<{ lat: number; lng: number } | null> => {
+  const text = geoToText(geo);
+  if (!text) return null;
+
+  // Strategy 1: structured search (most accurate).
+  if (geo.street || geo.city || geo.zip) {
+    const params = new URLSearchParams({ format: 'json', limit: '1', countrycodes: 'us' });
+    if (geo.street) params.set('street', geo.street.trim());
+    if (geo.city)   params.set('city', geo.city.trim());
+    if (geo.state)  params.set('state', geo.state.trim());
+    if (geo.zip)    params.set('postalcode', geo.zip.trim());
+    try {
+      const res = await fetch(`https://nominatim.openstreetmap.org/search?${params.toString()}`,
+        { headers: { 'Accept-Language': 'en' } });
+      const hit = parseHit(await res.json());
+      if (hit) return hit;
+    } catch {
+      // fall through to free-text
+    }
+    // Honor the rate limit between the two requests.
+    await new Promise(r => setTimeout(r, NOMINATIM_RATE_LIMIT_MS));
+  }
+
+  // Strategy 2: free-text fallback.
   try {
     const res = await fetch(
-      `https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=us&q=${encodeURIComponent(query)}`,
+      `https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=us&q=${encodeURIComponent(text)}`,
       { headers: { 'Accept-Language': 'en' } },
     );
-    const data = await res.json();
-    if (data?.length > 0) {
-      return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) };
-    }
+    const hit = parseHit(await res.json());
+    if (hit) return hit;
   } catch {
     // Geocoding failed — return null
   }
@@ -117,10 +161,10 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
   const userMap = useMemo(() => new Map(users.map(u => [u.id, u])), [users]);
 
   // The "default shop" is where otherwise-idle equipment is parked on the map.
-  // Prefer the first location that has an address (so it can be geocoded);
+  // Prefer the first location that has a usable address (so it can be geocoded);
   // fall back to the first location if none have an address yet.
   const defaultShop = useMemo(
-    () => locations.find(l => l.address) ?? locations[0] ?? null,
+    () => locations.find(l => geoToText(locGeo(l))) ?? locations[0] ?? null,
     [locations],
   );
 
@@ -179,18 +223,19 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
       // Everything else defaults to a shop: its own addressed location, or the
       // default shop. It's only unmappable if no shop has an address at all.
       const ownLoc = e.currentLocationId ? locMap.get(e.currentLocationId) : undefined;
-      const shop = ownLoc?.address ? ownLoc : defaultShop;
-      return !shop?.address;
+      const shop = locHasAddress(ownLoc) ? ownLoc : defaultShop;
+      return !locHasAddress(shop);
     });
   }, [visibleItems, jobMap, locMap, userMap, defaultShop]);
 
   // ── Build placement groups and resolve coordinates ─────────────────────────
   const placementKey = useMemo(() => {
+    const locFingerprint = locations.map(l => `${l.id}:${geoToText(locGeo(l))}`).join(',');
     return visibleItems
       .map(e => `${e.id}:${e.currentJobId ?? ''}:${e.currentLocationId ?? ''}:${e.currentAssigneeId ?? ''}:${e.updatedAt}`)
       .sort()
-      .join('|') + `#${jobMap.size}#${locMap.size}#${jobTicketCoords.size}#${userMap.size}#${defaultShop?.id ?? ''}#${defaultShop?.address ?? ''}`;
-  }, [visibleItems, jobMap, locMap, userMap, jobTicketCoords, defaultShop]);
+      .join('|') + `#${jobMap.size}#${locMap.size}#${jobTicketCoords.size}#${userMap.size}#${defaultShop?.id ?? ''}#${locFingerprint}`;
+  }, [visibleItems, jobMap, locMap, userMap, jobTicketCoords, defaultShop, locations]);
 
   useEffect(() => {
     // Group inventory by destination (job site or shop).
@@ -205,13 +250,13 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
         const job = jobMap.get(item.currentJobId)!;
         key = `job:${job.id}`;
         if (!groups.has(key)) {
-          const addressParts = [job.address, job.city, job.state].filter(Boolean);
-          const geoQuery = addressParts.join(', ');
+          const geo: GeoInput = { street: job.address, city: job.city, state: job.state };
+          const geoQuery = geoToText(geo);
           placement = {
             key, kind: 'job',
             label: `Job #${job.jobNumber}`,
             sublabel: geoQuery || job.customer || '',
-            items: [], geoQuery,
+            items: [], geo,
           };
           // Prefer coords already resolved on one of the job's dig tickets.
           const coords = jobTicketCoords.get(job.jobNumber) ?? (geoQuery ? cache.get(geoQuery) : undefined);
@@ -226,16 +271,17 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
         // otherwise the company's default shop. This parks all otherwise-idle
         // equipment at the shop address and keeps the shop pinned on the map.
         const ownLoc = item.currentLocationId ? locMap.get(item.currentLocationId) : undefined;
-        const shop = ownLoc?.address ? ownLoc : defaultShop;
-        if (!shop?.address) continue; // no shop with an address defined yet
-        key = `shop:${shop.id}`;
+        const shop = locHasAddress(ownLoc) ? ownLoc! : defaultShop;
+        if (!locHasAddress(shop)) continue; // no shop with an address defined yet
+        key = `shop:${shop!.id}`;
         if (!groups.has(key)) {
-          const geoQuery = shop.address;
+          const geo = locGeo(shop!);
+          const geoQuery = geoToText(geo);
           placement = {
             key, kind: 'shop',
-            label: shop.name,
-            sublabel: shop.address,
-            items: [], geoQuery,
+            label: shop!.name,
+            sublabel: geoQuery,
+            items: [], geo,
           };
           const coords = cache.get(geoQuery);
           if (coords) { placement.lat = coords.lat; placement.lng = coords.lng; }
@@ -251,7 +297,7 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
     setPlacements(list);
 
     // Geocode any placements without known coordinates, honoring the rate limit.
-    const needGeocode = list.filter(p => (p.lat == null || p.lng == null) && p.geoQuery);
+    const needGeocode = list.filter(p => (p.lat == null || p.lng == null) && p.geo && geoToText(p.geo));
     setTotalToGeocode(needGeocode.length);
     setGeocodedCount(0);
 
@@ -266,10 +312,10 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
     (async () => {
       for (const placement of needGeocode) {
         if (cancelled) break;
-        const coords = await geocodeAddress(placement.geoQuery!);
+        const coords = await geocodeAddress(placement.geo!);
         if (!cancelled) {
           if (coords) {
-            cache.set(placement.geoQuery!, coords);
+            cache.set(geoToText(placement.geo!), coords);
             setPlacements(prev => prev.map(p =>
               p.key === placement.key ? { ...p, lat: coords.lat, lng: coords.lng } : p,
             ));

--- a/components/InventoryView.tsx
+++ b/components/InventoryView.tsx
@@ -326,7 +326,7 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
                       <p className={d('text-[13px] font-bold', 'text-slate-100', 'text-slate-900')}>{loc.name}</p>
                     </td>
                     <td className="px-5 py-4">
-                      <p className={d('text-[11px]', 'text-slate-500', 'text-slate-500')}>{loc.address || '—'}</p>
+                      <p className={d('text-[11px]', 'text-slate-500', 'text-slate-500')}>{[loc.address, loc.city, loc.state, loc.zip].filter(Boolean).join(', ') || '—'}</p>
                     </td>
                     <td className="px-5 py-4">
                       <span className={d('text-[10px] font-black uppercase px-2 py-1 rounded-lg', 'bg-white/[0.04] text-slate-500', 'bg-slate-100 text-slate-500')}>{hereCount}</span>
@@ -536,7 +536,7 @@ const ItemFormModal: React.FC<ItemFormProps> = ({ item, locations, users, jobs, 
   // New equipment defaults to the shop (first location with an address, else the
   // first location) so it lands on the equipment map right away. Existing items
   // keep whatever location they already have.
-  const defaultLocationId = (locations.find(l => l.address) ?? locations[0])?.id ?? '';
+  const defaultLocationId = (locations.find(l => l.address || l.city || l.zip) ?? locations[0])?.id ?? '';
   const [currentLocationId, setCurrentLocationId] = useState(item?.currentLocationId ?? (item ? '' : defaultLocationId));
   const [notes, setNotes] = useState(item?.notes || '');
   const [isSaving, setIsSaving] = useState(false);
@@ -705,6 +705,9 @@ interface LocationFormProps {
 const LocationFormModal: React.FC<LocationFormProps> = ({ location, companyId, isDarkMode, onSave, onClose }) => {
   const [name, setName] = useState(location?.name || '');
   const [address, setAddress] = useState(location?.address || '');
+  const [city, setCity] = useState(location?.city || '');
+  const [state, setState] = useState(location?.state || '');
+  const [zip, setZip] = useState(location?.zip || '');
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState('');
 
@@ -719,7 +722,7 @@ const LocationFormModal: React.FC<LocationFormProps> = ({ location, companyId, i
     setIsSaving(true);
     setError('');
     try {
-      const saved = await apiService.saveInventoryLocation({ ...(location ? { id: location.id } : {}), companyId, name: name.trim(), address: address.trim() });
+      const saved = await apiService.saveInventoryLocation({ ...(location ? { id: location.id } : {}), companyId, name: name.trim(), address: address.trim(), city: city.trim(), state: state.trim(), zip: zip.trim() });
       onSave(saved);
     } catch (e: any) {
       setError(e.message || 'Save failed');
@@ -742,9 +745,24 @@ const LocationFormModal: React.FC<LocationFormProps> = ({ location, companyId, i
           <input className={inputCls} value={name} onChange={e => setName(e.target.value)} placeholder="Main Yard, Warehouse B…" />
         </div>
         <div className="space-y-1.5">
-          <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">Address (optional)</p>
-          <input className={inputCls} value={address} onChange={e => setAddress(e.target.value)} placeholder="123 Storage Rd, City, ST" />
+          <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">Street Address</p>
+          <input className={inputCls} value={address} onChange={e => setAddress(e.target.value)} placeholder="123 Storage Rd" />
         </div>
+        <div className="space-y-1.5">
+          <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">City</p>
+          <input className={inputCls} value={city} onChange={e => setCity(e.target.value)} placeholder="Springfield" />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">State</p>
+            <input className={inputCls} value={state} onChange={e => setState(e.target.value)} placeholder="IL" />
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">ZIP Code</p>
+            <input className={inputCls} value={zip} onChange={e => setZip(e.target.value)} placeholder="62704" />
+          </div>
+        </div>
+        <p className={d('text-[10px] text-slate-500', 'text-[10px] text-slate-400')}>Add a full address so equipment parked here pins accurately on the map.</p>
         {error && <p className="text-[11px] font-bold text-rose-400">{error}</p>}
         <div className="flex gap-3 pt-2">
           <button onClick={onClose} className={`flex-1 py-3 rounded-2xl text-[10px] font-black uppercase tracking-widest border transition-all ${d('border-white/10 text-slate-500 hover:text-slate-200', 'border-slate-200 text-slate-500 hover:text-slate-700')}`}>Cancel</button>

--- a/components/InventoryView.tsx
+++ b/components/InventoryView.tsx
@@ -533,7 +533,11 @@ const ItemFormModal: React.FC<ItemFormProps> = ({ item, locations, users, jobs, 
   const [hourlyRate, setHourlyRate] = useState(item?.hourlyRate?.toString() || '');
   const [quantity, setQuantity] = useState(item?.quantity?.toString() || '0');
   const [unit, setUnit] = useState(item?.unit || 'each');
-  const [currentLocationId, setCurrentLocationId] = useState(item?.currentLocationId || '');
+  // New equipment defaults to the shop (first location with an address, else the
+  // first location) so it lands on the equipment map right away. Existing items
+  // keep whatever location they already have.
+  const defaultLocationId = (locations.find(l => l.address) ?? locations[0])?.id ?? '';
+  const [currentLocationId, setCurrentLocationId] = useState(item?.currentLocationId ?? (item ? '' : defaultLocationId));
   const [notes, setNotes] = useState(item?.notes || '');
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState('');

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -25,6 +25,17 @@ const mapInvItem = (d: Record<string, unknown>): InventoryItem => ({
   updatedAt: new Date(d.updated_at as string).getTime(),
 });
 
+const mapInvLocation = (d: Record<string, unknown>): InventoryLocation => ({
+  id: d.id as string,
+  companyId: d.company_id as string,
+  name: d.name as string,
+  address: (d.address as string) || '',
+  city: (d.city as string) || '',
+  state: (d.state as string) || '',
+  zip: (d.zip as string) || '',
+  createdAt: new Date(d.created_at as string).getTime(),
+});
+
 const mapRole = (role: string | undefined): UserRole => {
   const r = role?.toUpperCase();
   if (r === 'SUPER_ADMIN') return UserRole.SUPER_ADMIN;
@@ -860,25 +871,26 @@ export const apiService = {
   async getInventoryLocations(): Promise<InventoryLocation[]> {
     const { data, error } = await supabase.from('inventory_locations').select('*').order('name');
     if (error) throw error;
-    return (data || []).map((d: Record<string, unknown>) => ({
-      id: d.id as string,
-      companyId: d.company_id as string,
-      name: d.name as string,
-      address: (d.address as string) || '',
-      createdAt: new Date(d.created_at as string).getTime(),
-    }));
+    return (data || []).map((d: Record<string, unknown>) => mapInvLocation(d));
   },
 
-  async saveInventoryLocation(loc: { id?: string; companyId: string; name: string; address?: string }): Promise<InventoryLocation> {
-    const payload = { company_id: loc.companyId, name: loc.name, address: loc.address || '' };
+  async saveInventoryLocation(loc: { id?: string; companyId: string; name: string; address?: string; city?: string; state?: string; zip?: string }): Promise<InventoryLocation> {
+    const payload = {
+      company_id: loc.companyId,
+      name: loc.name,
+      address: loc.address || '',
+      city: loc.city || '',
+      state: loc.state || '',
+      zip: loc.zip || '',
+    };
     if (loc.id) {
       const { data, error } = await supabase.from('inventory_locations').update(payload).eq('id', loc.id).select().single();
       if (error) throw error;
-      return { id: data.id, companyId: data.company_id, name: data.name, address: data.address || '', createdAt: new Date(data.created_at).getTime() };
+      return mapInvLocation(data);
     }
     const { data, error } = await supabase.from('inventory_locations').insert([payload]).select().single();
     if (error) throw error;
-    return { id: data.id, companyId: data.company_id, name: data.name, address: data.address || '', createdAt: new Date(data.created_at).getTime() };
+    return mapInvLocation(data);
   },
 
   async deleteInventoryLocation(id: string): Promise<void> {

--- a/supabase/migrations/20260619000000_add_location_address_fields.sql
+++ b/supabase/migrations/20260619000000_add_location_address_fields.sql
@@ -1,0 +1,14 @@
+-- =============================================================================
+-- Migration: Structured address fields for inventory locations
+--
+-- PURELY ADDITIVE — adds city / state / zip columns to inventory_locations so
+-- shop addresses can be geocoded with Nominatim's structured search (more
+-- accurate than a single free-text line). The existing `address` column keeps
+-- the street line. Existing rows default to empty strings and continue to work
+-- via the free-text geocoding fallback.
+-- =============================================================================
+
+ALTER TABLE public.inventory_locations
+  ADD COLUMN IF NOT EXISTS city  TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS state TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS zip   TEXT NOT NULL DEFAULT '';

--- a/types.ts
+++ b/types.ts
@@ -55,7 +55,10 @@ export interface InventoryLocation {
   id: string;
   companyId: string;
   name: string;
-  address?: string;
+  address?: string;  // street line
+  city?: string;
+  state?: string;
+  zip?: string;
   createdAt: number;
 }
 


### PR DESCRIPTION
Previously the equipment map only created a shop placement when an item
had a currentLocationId pointing to a shop that already had an address.
New/unassigned equipment carries no location, so no shop placement was
ever built — the shop's address was never geocoded and nothing showed
on the map.

- Park any equipment that isn't out on a job and isn't checked out to a
  crew member at the shop: its own addressed location, or the company's
  default shop (first location with an address). This keeps the shop
  geocoded and pinned, and collapses idle equipment onto it.
- Update the "Not on map" list to match: items are only unmappable when
  checked out to a person or when no shop has an address yet.
- Default new inventory items' storage location to the shop so they land
  on the map right away.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H4bGAiTqLjgKa5k8YJyThY