### PR TITLE
Remove permission allowlist that reduced permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npm run lint *)"
-    ]
-  }
-}


### PR DESCRIPTION
Deletes .claude/settings.json, which allowlisted `npm run lint` to cut
down on permission prompts. Reverts the change so commands prompt again.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ZmuzjHYtFPGNdDsNZRisu