### PR TITLE
Show unit number in inventory history tab and item modals

### DIFF
--- a/components/InventoryView.tsx
+++ b/components/InventoryView.tsx
@@ -405,7 +405,14 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
                         <p className={d('text-[9px]', 'text-slate-600', 'text-slate-400')}>{mvDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</p>
                       </td>
                       <td className="px-5 py-3">
-                        <p className={d('text-[11px] font-bold', 'text-slate-300', 'text-slate-700')}>{item?.name || mv.itemId}</p>
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          {item?.unitNumber && (
+                            <span className={d('inline-flex px-1.5 py-0.5 rounded text-[9px] font-black uppercase tracking-widest', 'bg-amber-500/15 text-amber-400', 'bg-amber-50 text-amber-700 border border-amber-200')}>
+                              #{item.unitNumber}
+                            </span>
+                          )}
+                          <p className={d('text-[11px] font-bold', 'text-slate-300', 'text-slate-700')}>{item?.name || mv.itemId}</p>
+                        </div>
                       </td>
                       <td className="px-5 py-3">
                         <span className={`inline-flex px-2 py-0.5 rounded-md text-[8px] font-black uppercase tracking-widest border ${colorClass}`}>
@@ -955,7 +962,14 @@ const MovementModal: React.FC<MovementModalProps> = ({ item, locations, users, j
         <div className="flex items-center justify-between">
           <div>
             <p className="text-[9px] font-black uppercase tracking-widest text-brand">Log Movement</p>
-            <h3 className={`text-[15px] font-black ${d('text-white', 'text-slate-900')}`}>{item.name}</h3>
+            <div className="flex items-center gap-1.5 flex-wrap">
+              {item.unitNumber && (
+                <span className={d('inline-flex px-1.5 py-0.5 rounded text-[9px] font-black uppercase tracking-widest bg-amber-500/15 text-amber-400', 'inline-flex px-1.5 py-0.5 rounded text-[9px] font-black uppercase tracking-widest bg-amber-50 text-amber-700 border border-amber-200')}>
+                  #{item.unitNumber}
+                </span>
+              )}
+              <h3 className={`text-[15px] font-black ${d('text-white', 'text-slate-900')}`}>{item.name}</h3>
+            </div>
           </div>
           <button onClick={onClose} className={`p-2 rounded-xl ${d('text-slate-500 hover:text-white hover:bg-white/10', 'text-slate-400 hover:text-slate-700 hover:bg-slate-100')}`}>
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
@@ -1081,7 +1095,14 @@ const ItemHistoryModal: React.FC<ItemHistoryModalProps> = ({ item, movements, lo
         <div className={`flex items-center justify-between p-6 border-b ${d('border-white/10', 'border-slate-100')}`}>
           <div>
             <p className="text-[9px] font-black uppercase tracking-widest text-brand">Movement History</p>
-            <h3 className={`text-[15px] font-black ${d('text-white', 'text-slate-900')}`}>{item.name}</h3>
+            <div className="flex items-center gap-1.5 flex-wrap">
+              {item.unitNumber && (
+                <span className={d('inline-flex px-1.5 py-0.5 rounded text-[9px] font-black uppercase tracking-widest bg-amber-500/15 text-amber-400', 'inline-flex px-1.5 py-0.5 rounded text-[9px] font-black uppercase tracking-widest bg-amber-50 text-amber-700 border border-amber-200')}>
+                  #{item.unitNumber}
+                </span>
+              )}
+              <h3 className={`text-[15px] font-black ${d('text-white', 'text-slate-900')}`}>{item.name}</h3>
+            </div>
           </div>
           <button onClick={onClose} className={`p-2 rounded-xl ${d('text-slate-500 hover:text-white hover:bg-white/10', 'text-slate-400 hover:text-slate-700 hover:bg-slate-100')}`}>
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M6 18L18 6M6 6l12 12" /></svg>


### PR DESCRIPTION
The unit number badge already appeared in the Items table but was missing
everywhere else an item is referenced. Add it to the History tab's Item
column, the Log Movement modal header, and the Movement History modal
header so the unit number displays consistently across the Inventory tab.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HHGLWUAkcTLF4e7jsLqkT1