### PR TITLE
Manually set shop location: coordinates, drag, and tap-to-place

### DIFF
--- a/components/EquipmentMapView.tsx
+++ b/components/EquipmentMapView.tsx
@@ -140,6 +140,9 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
   const mapDivRef  = useRef<HTMLDivElement>(null);
   const mapRef     = useRef<L.Map | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
+  // Set when a shop marker is dragged so the next marker re-render keeps the
+  // current viewport instead of snapping back via fitBounds.
+  const skipFitRef = useRef(false);
 
   const [items, setItems]         = useState<InventoryItem[]>([]);
   const [locations, setLocations] = useState<InventoryLocation[]>([]);
@@ -409,14 +412,35 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
           </div>
           <div style="font-size:13px;font-weight:800;color:#0f172a;margin-bottom:1px;">${escapeHtml(placement.label)}</div>
           ${placement.sublabel ? `<div style="font-size:10px;color:#64748b;margin-bottom:4px;">${escapeHtml(placement.sublabel)}</div>` : ''}
+          ${placement.kind === 'shop' ? `<div style="font-size:9px;font-weight:700;color:#10b981;margin-bottom:4px;">Drag this pin to set the shop's location manually.</div>` : ''}
           <div style="margin-top:4px;">${itemsHtml}</div>
         </div>`;
 
+      // Shops can be repositioned by hand — drag the pin and we persist the new
+      // coordinates. Job-site pins follow their dig tickets and stay fixed.
+      const isShop = placement.kind === 'shop' && placement.key.startsWith('shop:');
+
       const marker = L.marker([placement.lat!, placement.lng!], {
         icon: createMarkerIcon(placement.kind, placement.items.length),
+        draggable: isShop,
+        autoPan: true,
       })
         .bindPopup(popupHtml)
         .addTo(map);
+
+      if (isShop) {
+        const locId = placement.key.slice('shop:'.length);
+        marker.on('dragend', () => {
+          const { lat, lng } = marker.getLatLng();
+          // Keep the viewport put — the user just placed this pin deliberately.
+          skipFitRef.current = true;
+          setPlacements(prev => prev.map(p => p.key === placement.key ? { ...p, lat, lng } : p));
+          setLocations(prev => prev.map(l => l.id === locId ? { ...l, lat, lng } : l));
+          apiService.updateLocationCoords(locId, lat, lng).catch(err =>
+            console.error('Failed to persist shop coordinates for location', locId, err),
+          );
+        });
+      }
 
       // Wire each "Move" button to open the relocate panel.
       marker.on('popupopen', () => {
@@ -433,7 +457,10 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
       bounds.push([placement.lat!, placement.lng!]);
     });
 
-    if (bounds.length > 0) {
+    if (skipFitRef.current) {
+      // A drag just moved a pin — preserve the user's current view.
+      skipFitRef.current = false;
+    } else if (bounds.length > 0) {
       map.fitBounds(bounds as L.LatLngBoundsExpression, { padding: [40, 40], maxZoom: 14 });
     }
   }, [placements]);

--- a/components/EquipmentMapView.tsx
+++ b/components/EquipmentMapView.tsx
@@ -190,6 +190,12 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
   const setRelocatingRef = useRef(setRelocating);
   setRelocatingRef.current = setRelocating;
 
+  // Shop awaiting a tap-to-place repositioning. Mobile-friendly alternative to
+  // dragging the pin: pick a shop, then tap anywhere on the map to drop it.
+  const [repositioning, setRepositioning] = useState<{ key: string; locId: string; name: string } | null>(null);
+  const setRepositioningRef = useRef(setRepositioning);
+  setRepositioningRef.current = setRepositioning;
+
   // ── Load inventory + shop locations ────────────────────────────────────────
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -412,7 +418,13 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
           </div>
           <div style="font-size:13px;font-weight:800;color:#0f172a;margin-bottom:1px;">${escapeHtml(placement.label)}</div>
           ${placement.sublabel ? `<div style="font-size:10px;color:#64748b;margin-bottom:4px;">${escapeHtml(placement.sublabel)}</div>` : ''}
-          ${placement.kind === 'shop' ? `<div style="font-size:9px;font-weight:700;color:#10b981;margin-bottom:4px;">Drag this pin to set the shop's location manually.</div>` : ''}
+          ${placement.kind === 'shop' ? `
+            <button data-shop-place style="
+              margin:4px 0 2px;padding:6px 10px;width:100%;background:#10b981;color:white;border:none;border-radius:8px;
+              font-size:10px;font-weight:900;text-transform:uppercase;letter-spacing:0.06em;cursor:pointer;
+            ">Set location on map</button>
+            <div style="font-size:9px;color:#64748b;margin-bottom:4px;">Tap the button, then tap the map — or drag this pin.</div>
+          ` : ''}
           <div style="margin-top:4px;">${itemsHtml}</div>
         </div>`;
 
@@ -428,21 +440,16 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
         .bindPopup(popupHtml)
         .addTo(map);
 
+      const locId = isShop ? placement.key.slice('shop:'.length) : '';
       if (isShop) {
-        const locId = placement.key.slice('shop:'.length);
         marker.on('dragend', () => {
           const { lat, lng } = marker.getLatLng();
-          // Keep the viewport put — the user just placed this pin deliberately.
-          skipFitRef.current = true;
-          setPlacements(prev => prev.map(p => p.key === placement.key ? { ...p, lat, lng } : p));
-          setLocations(prev => prev.map(l => l.id === locId ? { ...l, lat, lng } : l));
-          apiService.updateLocationCoords(locId, lat, lng).catch(err =>
-            console.error('Failed to persist shop coordinates for location', locId, err),
-          );
+          commitShopCoords(placement.key, locId, lat, lng);
         });
       }
 
-      // Wire each "Move" button to open the relocate panel.
+      // Wire the popup buttons (raw HTML): "Move" opens the relocate panel,
+      // "Set location on map" starts tap-to-place repositioning for the shop.
       marker.on('popupopen', () => {
         const el = marker.getPopup()?.getElement();
         el?.querySelectorAll<HTMLButtonElement>('button[data-equip-move]').forEach(btn => {
@@ -451,6 +458,13 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
             if (item) { marker.closePopup(); setRelocatingRef.current(item); }
           };
         });
+        if (isShop) {
+          const placeBtn = el?.querySelector<HTMLButtonElement>('button[data-shop-place]');
+          if (placeBtn) placeBtn.onclick = () => {
+            marker.closePopup();
+            setRepositioningRef.current({ key: placement.key, locId, name: placement.label });
+          };
+        }
       });
 
       markersRef.current.push(marker);
@@ -464,6 +478,35 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
       map.fitBounds(bounds as L.LatLngBoundsExpression, { padding: [40, 40], maxZoom: 14 });
     }
   }, [placements]);
+
+  // Persist a manually chosen shop position (from a drag or a tap-to-place) and
+  // reflect it in local state immediately, keeping the current viewport.
+  const commitShopCoords = useCallback((key: string, locId: string, lat: number, lng: number) => {
+    skipFitRef.current = true;
+    setPlacements(prev => prev.map(p => p.key === key ? { ...p, lat, lng } : p));
+    setLocations(prev => prev.map(l => l.id === locId ? { ...l, lat, lng } : l));
+    apiService.updateLocationCoords(locId, lat, lng).catch(err =>
+      console.error('Failed to persist shop coordinates for location', locId, err),
+    );
+  }, []);
+
+  // While a shop is awaiting placement, the next tap on the map drops it there.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !repositioning) return;
+    const onClick = (e: L.LeafletMouseEvent) => {
+      commitShopCoords(repositioning.key, repositioning.locId, e.latlng.lat, e.latlng.lng);
+      setRepositioning(null);
+    };
+    map.on('click', onClick);
+    const container = map.getContainer();
+    const prevCursor = container.style.cursor;
+    container.style.cursor = 'crosshair';
+    return () => {
+      map.off('click', onClick);
+      container.style.cursor = prevCursor;
+    };
+  }, [repositioning, commitShopCoords]);
 
   // Apply a completed relocation to local state so the map updates instantly.
   const handleMoved = useCallback((updated: InventoryItem) => {
@@ -529,6 +572,17 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 pointer-events-none">
             <p className={`text-[11px] font-black uppercase tracking-widest ${subtitle}`}>Nothing to map</p>
             <p className={`text-[10px] font-bold ${subtitle}`}>Add inventory in the Inventory tab and assign it to a job or shop.</p>
+          </div>
+        )}
+        {repositioning && (
+          <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[20] flex items-center gap-3 px-4 py-2 rounded-xl shadow-lg bg-emerald-500 text-white">
+            <span className="text-[10px] font-black uppercase tracking-widest">Tap the map to place “{repositioning.name}”</span>
+            <button
+              onClick={() => setRepositioning(null)}
+              className="text-[10px] font-black uppercase tracking-widest px-2.5 py-1 rounded-lg bg-white/20 hover:bg-white/30"
+            >
+              Cancel
+            </button>
           </div>
         )}
         <div ref={mapDivRef} className="w-full h-full" />

--- a/components/InventoryView.tsx
+++ b/components/InventoryView.tsx
@@ -776,6 +776,8 @@ const LocationFormModal: React.FC<LocationFormProps> = ({ location, companyId, i
   const [city, setCity] = useState(location?.city || '');
   const [state, setState] = useState(location?.state || '');
   const [zip, setZip] = useState(location?.zip || '');
+  const [lat, setLat] = useState(location?.lat != null ? String(location.lat) : '');
+  const [lng, setLng] = useState(location?.lng != null ? String(location.lng) : '');
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState('');
 
@@ -787,10 +789,25 @@ const LocationFormModal: React.FC<LocationFormProps> = ({ location, companyId, i
 
   const handleSave = async () => {
     if (!name.trim()) { setError('Name is required'); return; }
+
+    // Manual map position is optional, but if one coordinate is filled in both
+    // must be — and both must be in range — otherwise the pin can't be placed.
+    const latStr = lat.trim();
+    const lngStr = lng.trim();
+    let latNum: number | null = null;
+    let lngNum: number | null = null;
+    if (latStr || lngStr) {
+      if (!latStr || !lngStr) { setError('Enter both latitude and longitude, or leave both blank.'); return; }
+      latNum = Number(latStr);
+      lngNum = Number(lngStr);
+      if (!Number.isFinite(latNum) || latNum < -90 || latNum > 90) { setError('Latitude must be a number between -90 and 90.'); return; }
+      if (!Number.isFinite(lngNum) || lngNum < -180 || lngNum > 180) { setError('Longitude must be a number between -180 and 180.'); return; }
+    }
+
     setIsSaving(true);
     setError('');
     try {
-      const saved = await apiService.saveInventoryLocation({ ...(location ? { id: location.id } : {}), companyId, name: name.trim(), address: address.trim(), city: city.trim(), state: state.trim(), zip: zip.trim() });
+      const saved = await apiService.saveInventoryLocation({ ...(location ? { id: location.id } : {}), companyId, name: name.trim(), address: address.trim(), city: city.trim(), state: state.trim(), zip: zip.trim(), lat: latNum, lng: lngNum });
       onSave(saved);
     } catch (e: any) {
       setError(e.message || 'Save failed');
@@ -830,7 +847,17 @@ const LocationFormModal: React.FC<LocationFormProps> = ({ location, companyId, i
             <input className={inputCls} value={zip} onChange={e => setZip(e.target.value)} placeholder="62704" />
           </div>
         </div>
-        <p className={d('text-[10px] text-slate-500', 'text-[10px] text-slate-400')}>Add a full address so equipment parked here pins accurately on the map.</p>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">Latitude</p>
+            <input className={inputCls} value={lat} onChange={e => setLat(e.target.value)} placeholder="39.7990" inputMode="decimal" />
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">Longitude</p>
+            <input className={inputCls} value={lng} onChange={e => setLng(e.target.value)} placeholder="-89.6540" inputMode="decimal" />
+          </div>
+        </div>
+        <p className={d('text-[10px] text-slate-500', 'text-[10px] text-slate-400')}>Add a full address so equipment parked here pins accurately on the map. Set latitude &amp; longitude to drop the pin manually instead — leave them blank to auto-locate from the address.</p>
         {error && <p className="text-[11px] font-bold text-rose-400">{error}</p>}
         <div className="flex gap-3 pt-2">
           <button onClick={onClose} className={`flex-1 py-3 rounded-2xl text-[10px] font-black uppercase tracking-widest border transition-all ${d('border-white/10 text-slate-500 hover:text-slate-200', 'border-slate-200 text-slate-500 hover:text-slate-700')}`}>Cancel</button>

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -881,7 +881,14 @@ export const apiService = {
     return (data || []).map((d: Record<string, unknown>) => mapInvLocation(d));
   },
 
-  async saveInventoryLocation(loc: { id?: string; companyId: string; name: string; address?: string; city?: string; state?: string; zip?: string }): Promise<InventoryLocation> {
+  async saveInventoryLocation(loc: { id?: string; companyId: string; name: string; address?: string; city?: string; state?: string; zip?: string; lat?: number | null; lng?: number | null }): Promise<InventoryLocation> {
+    // Manual coordinates win: when the caller supplies a finite lat/lng pair we
+    // persist it verbatim and the equipment map pins it without geocoding.
+    // Otherwise clear any saved coordinates so the map re-geocodes the (possibly
+    // changed) address once and re-saves the result.
+    const hasManualCoords =
+      typeof loc.lat === 'number' && Number.isFinite(loc.lat) &&
+      typeof loc.lng === 'number' && Number.isFinite(loc.lng);
     const payload = {
       company_id: loc.companyId,
       name: loc.name,
@@ -889,10 +896,8 @@ export const apiService = {
       city: loc.city || '',
       state: loc.state || '',
       zip: loc.zip || '',
-      // Address fields may have changed — clear any saved coordinates so the
-      // equipment map re-geocodes the new address once and re-saves the result.
-      lat: null,
-      lng: null,
+      lat: hasManualCoords ? loc.lat : null,
+      lng: hasManualCoords ? loc.lng : null,
     };
     if (loc.id) {
       const { data, error } = await supabase.from('inventory_locations').update(payload).eq('id', loc.id).select().single();


### PR DESCRIPTION
## Summary

Adds three ways to set an inventory location's ("shop") map position by hand, instead of relying solely on address geocoding. All three work on mobile.

### 1. Manual coordinate fields in the location form
- Optional **Latitude** / **Longitude** inputs in the Add/Edit Location modal (Inventory → Locations).
- Both required together and range-validated (lat −90…90, lng −180…180). Leaving both blank keeps the existing auto-locate-from-address behavior.
- Pre-fills with the location's saved coordinates when editing.

### 2. Tap-to-place on the map (mobile-friendly)
- Shop popup gains a **"Set location on map"** button. Tapping it starts placement mode; the next tap on the map drops the shop there and persists it.
- A banner with **Cancel** shows while active, and the cursor switches to a crosshair.

### 3. Drag-to-reposition (desktop)
- Shop pins are draggable; dropping one persists the new coordinates. Job-site pins stay fixed (they follow dig tickets).

Drag and tap-to-place share a single `commitShopCoords` helper that persists via `updateLocationCoords` and preserves the current viewport (no snap-back).

## Data layer
- `saveInventoryLocation` now persists a supplied finite lat/lng pair verbatim and skips geocoding; otherwise it clears the coords so the map re-geocodes the address. No DB migration needed — the nullable `lat`/`lng` columns on `inventory_locations` already exist.

## Testing
- `tsc --noEmit`: no new errors (two pre-existing errors in `InventoryView.tsx` are unrelated and present on `main`).
- `vite build`: passes.
- ⚠️ Not exercised at runtime — the dev environment blocks outbound network to Supabase/OSM tiles, so the UI flows were not run live. Manual verification on a real device is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RzhnKMe6i3h3qetH2ouhz