### PR TITLE
As-built markup: continuous scroll through all PDF pages

### DIFF
--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -695,6 +695,393 @@ const nudgeAnnotationData = (data: AnyAnnotationData, toolType: ToolType, dx: nu
 };
 
 // ─────────────────────────────────────────────────────────────
+// Page layer (memoized)
+// ─────────────────────────────────────────────────────────────
+
+type PenPoint = { x: number; y: number; pressure?: number };
+type TextInputState = { px: number; py: number; rx: number; ry: number; calloutData?: AnyAnnotationData };
+type ScaleInputState = { lineStart: { x: number; y: number }; lineEnd: { x: number; y: number } };
+
+// Shared stable references so memoized pages with no annotations / no active drawing
+// receive referentially-equal props and skip re-rendering.
+const EMPTY_ANNS: PdfAnnotation[] = [];
+const EMPTY_POINTS: PenPoint[] = [];
+
+interface PageLayerProps {
+  pageNum: number;
+  w: number;
+  h: number;
+  toolCursor: string;
+  pageAnns: PdfAnnotation[];
+  selectedAnnId: string | null;
+  liveEditData: AnyAnnotationData | null;
+  sel: PdfAnnotation | null;
+  scaleInfo: ScaleInfo | null;
+  currentTool: ToolType;
+  currentColor: string;
+  strokeWidth: number;
+  opacity: number;
+  isActive: boolean;
+  previewData: AnyAnnotationData | null;
+  penPoints: PenPoint[];
+  drawStart: { x: number; y: number } | null;
+  isDrawing: boolean;
+  textInput: TextInputState | null;
+  textValue: string;
+  fontSize: number;
+  scaleInput: ScaleInputState | null;
+  scaleValue: string;
+  scaleUnit: string;
+  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerCancel: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onDoubleClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  registerContainer: (p: number, el: HTMLDivElement | null) => void;
+  registerCanvas: (p: number, el: HTMLCanvasElement | null) => void;
+  textFieldRef: React.RefObject<HTMLInputElement | null>;
+  scaleInputRef: React.RefObject<HTMLInputElement | null>;
+  setTextValue: (v: string) => void;
+  setTextInput: (v: TextInputState | null) => void;
+  handleTextSubmit: () => void;
+  setScaleValue: (v: string) => void;
+  setScaleUnit: (v: string) => void;
+  setScaleInput: (v: ScaleInputState | null) => void;
+  handleScaleConfirm: () => void;
+}
+
+// A single stacked page: canvas + SVG annotation overlay. Wrapped in React.memo so
+// that high-frequency updates (drawing previews, scroll) only re-render the one page
+// being interacted with, keeping large documents responsive.
+const PageLayer = React.memo(function PageLayer(props: PageLayerProps) {
+  const {
+    pageNum, w, h, toolCursor, pageAnns, selectedAnnId, liveEditData, sel, scaleInfo,
+    currentTool, currentColor, strokeWidth, opacity, isActive,
+    previewData, penPoints, drawStart, isDrawing, textInput, textValue, fontSize,
+    scaleInput, scaleValue, scaleUnit,
+    onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onDoubleClick,
+    registerContainer, registerCanvas, textFieldRef, scaleInputRef,
+    setTextValue, setTextInput, handleTextSubmit, setScaleValue, setScaleUnit, setScaleInput, handleScaleConfirm,
+  } = props;
+
+  const containerCb = useCallback((el: HTMLDivElement | null) => registerContainer(pageNum, el), [registerContainer, pageNum]);
+  const canvasCb = useCallback((el: HTMLCanvasElement | null) => registerCanvas(pageNum, el), [registerCanvas, pageNum]);
+
+  const penPreviewPath = isActive && (currentTool === 'pen' || currentTool === 'highlighter') && penPoints.length > 1 && isDrawing
+    ? penPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x * w} ${p.y * h}`).join(' ')
+    : null;
+
+  return (
+    <div
+      data-page={pageNum}
+      ref={containerCb}
+      className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 bg-slate-800/40 ${toolCursor}`}
+      style={{ width: w || '100%', height: h || undefined, touchAction: 'none' }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onDoubleClick={onDoubleClick}
+    >
+      {/* Canvas is absolutely positioned and stretched to the container so the
+          reserved page height is independent of whether the bitmap is painted. */}
+      <canvas
+        ref={canvasCb}
+        className="absolute inset-0 w-full h-full block"
+      />
+
+      <svg className="absolute inset-0 pointer-events-none"
+        width={w} height={h}
+        viewBox={`0 0 ${w} ${h}`}>
+
+        {pageAnns.map(ann => {
+          const data = (ann.id === selectedAnnId && liveEditData !== null)
+            ? liveEditData
+            : ann.data as AnyAnnotationData;
+          return renderAnnotationSvg({ ...ann, data }, w, h, ann.id, scaleInfo);
+        })}
+
+        {sel && currentTool === 'select' && (() => {
+          const displayData = liveEditData ?? sel.data as AnyAnnotationData;
+          const rotation    = (displayData.rotation as number | undefined) ?? 0;
+          const handles     = getHandlesNorm({ ...sel, data: displayData });
+          const bbox        = getAnnotationBBox(sel, displayData);
+          const SELECTION_BOX_PADDING = 8;
+          // Pixel coordinates of the bbox centre (used for the rotation transform)
+          const bboxCxPx = bbox ? (bbox.x + bbox.w / 2) * w : 0;
+          const bboxCyPx = bbox ? (bbox.y + bbox.h / 2) * h : 0;
+          const rotateHandle = handles.find(hh => hh.isRotateHandle);
+          return (
+            <g>
+              {/* Dashed bounding box — rotated with the annotation */}
+              {bbox && bbox.w > 0.005 && (
+                <g transform={rotation ? `rotate(${rotation}, ${bboxCxPx}, ${bboxCyPx})` : undefined}>
+                  <rect
+                    x={bbox.x * w - SELECTION_BOX_PADDING}
+                    y={bbox.y * h - SELECTION_BOX_PADDING}
+                    width={bbox.w * w + SELECTION_BOX_PADDING * 2}
+                    height={bbox.h * h + SELECTION_BOX_PADDING * 2}
+                    fill="none" stroke="white" strokeWidth="1.5"
+                    strokeDasharray="5 3" opacity="0.5" rx="3" />
+                </g>
+              )}
+              {/* Stem line from bbox top-centre to the rotate handle */}
+              {bbox && bbox.w > 0.005 && rotateHandle && (() => {
+                // Compute the rotated top-centre of the bounding box
+                const stemBaseX = bbox.x * w + (bbox.w * w) / 2;
+                const stemBaseY = bbox.y * h - SELECTION_BOX_PADDING;
+                if (rotation) {
+                  const rad = (rotation * Math.PI) / 180;
+                  const cos = Math.cos(rad), sin = Math.sin(rad);
+                  const dx = stemBaseX - bboxCxPx, dy = stemBaseY - bboxCyPx;
+                  const rx = bboxCxPx + dx * cos - dy * sin;
+                  const ry = bboxCyPx + dx * sin + dy * cos;
+                  return <line x1={rx} y1={ry} x2={rotateHandle.nx * w} y2={rotateHandle.ny * h}
+                    stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
+                }
+                return <line x1={stemBaseX} y1={stemBaseY} x2={rotateHandle.nx * w} y2={rotateHandle.ny * h}
+                  stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
+              })()}
+              {handles.map(hh => {
+                const cx = hh.nx * w;
+                const cy = hh.ny * h;
+                const isCalloutArrowTip = sel.toolType === 'callout' && !hh.isMoveHandle && !hh.isRotateHandle && hh.index === 1;
+                const handleFill = hh.isRotateHandle ? '#22c55e'
+                  : hh.isMoveHandle ? '#6366f1'
+                  : hh.isEdgeHandle ? '#0ea5e9'
+                  : isCalloutArrowTip ? '#f59e0b'
+                  : '#3b82f6';
+                const edgeLabel = hh.index === EDGE_HANDLE_TOP ? 'top' : hh.index === EDGE_HANDLE_RIGHT ? 'right' : hh.index === EDGE_HANDLE_BOTTOM ? 'bottom' : 'left';
+                const handleTitle = hh.isRotateHandle
+                  ? `Rotate — drag to rotate (${Math.round(rotation)}°), hold Shift for 15° snapping`
+                  : hh.isMoveHandle
+                    ? 'Move annotation'
+                    : hh.isEdgeHandle
+                      ? `Resize ${edgeLabel} edge — drag to resize on one axis`
+                      : sel.toolType === 'callout'
+                        ? hh.index === 0 ? 'Text box — drag to reposition' : 'Arrow tip — drag to repoint'
+                        : sel.toolType === 'arrow' || sel.toolType === 'double_arrow'
+                          ? hh.index === 0 ? 'Line start — drag to adjust' : 'Arrow head — drag to adjust'
+                          : `Endpoint ${hh.index + 1} — drag to reshape`;
+                const r = hh.isRotateHandle || hh.isMoveHandle ? 9 : 8;
+                return (
+                  <g key={`handle-${hh.index}`}>
+                    {/* Hit-area circle (invisible, larger) */}
+                    <circle cx={cx} cy={cy} r="18" fill="transparent">
+                      <title>{handleTitle}</title>
+                    </circle>
+                    {/* Edge handles: diamond (rotated square) shape */}
+                    {hh.isEdgeHandle ? (
+                      <rect
+                        x={cx - 6} y={cy - 6} width={12} height={12}
+                        fill={handleFill} stroke="white" strokeWidth="2"
+                        transform={`rotate(45, ${cx}, ${cy})`}
+                      />
+                    ) : (
+                      /* Visible handle circle */
+                      <circle cx={cx} cy={cy} r={r} fill={handleFill} stroke="white" strokeWidth="2.5" />
+                    )}
+                    {/* Rotate handle: circular-arrow icon */}
+                    {hh.isRotateHandle && (
+                      <g transform={`translate(${cx}, ${cy})`} stroke="white" strokeWidth="1.5" strokeLinecap="round" fill="none">
+                        <path d="M -4 -3 A 5 5 0 1 1 3.5 -3.5" />
+                        <polyline points="3.5,-3.5 5.5,-1.5 5.5,-5" />
+                      </g>
+                    )}
+                    {/* Move handle: cross icon */}
+                    {hh.isMoveHandle && (
+                      <g stroke="white" strokeWidth="1.5" strokeLinecap="round">
+                        <line x1={cx - 4} y1={cy} x2={cx + 4} y2={cy} />
+                        <line x1={cx} y1={cy - 4} x2={cx} y2={cy + 4} />
+                      </g>
+                    )}
+                  </g>
+                );
+              })}
+            </g>
+          );
+        })()}
+
+        {pageAnns.map(ann => {
+          const anchor = getAnnotationAnchor(ann);
+          if (!anchor) return null;
+          const initials  = getInitials(ann.authorName);
+          const bw        = initials.length * 7 + 10;
+          const bx        = anchor.x * w;
+          const by        = anchor.y * h;
+          const isPending = ann.id.startsWith('tmp-');
+          return (
+            <g key={`badge-${ann.id}`}>
+              <rect x={bx} y={by - 17} width={bw} height={17} rx="3"
+                fill={ann.color} opacity={isPending ? 0.5 : 0.88}
+                stroke={isPending ? 'white' : 'none'} strokeWidth={isPending ? 1 : 0}
+                strokeDasharray={isPending ? '3 2' : undefined} />
+              <text x={bx + 5} y={by - 3} fontSize="11" fontFamily="monospace" fontWeight="bold" fill="white">
+                {initials}
+              </text>
+            </g>
+          );
+        })}
+
+        {penPreviewPath && (
+          <path d={penPreviewPath} stroke={currentColor}
+            strokeWidth={currentTool === 'highlighter' ? strokeWidth * 5 : strokeWidth}
+            fill="none" strokeLinecap="round" strokeLinejoin="round"
+            opacity={currentTool === 'highlighter' ? opacity * 0.35 : opacity * 0.75} />
+        )}
+
+        {isActive && previewData && currentTool !== 'pen' && currentTool !== 'highlighter' && currentTool !== 'scale' &&
+          renderAnnotationSvg({ toolType: currentTool, color: currentColor, strokeWidth, data: previewData },
+            w, h, 'preview', scaleInfo)
+        }
+
+        {isActive && isDrawing && currentTool === 'scale' && previewData && (
+          <line
+            x1={(previewData.x1 ?? 0) * w} y1={(previewData.y1 ?? 0) * h}
+            x2={(previewData.x2 ?? 0) * w} y2={(previewData.y2 ?? 0) * h}
+            stroke="#fbbf24" strokeWidth="2" strokeDasharray="6 3" strokeLinecap="round" opacity="0.9"
+          />
+        )}
+
+        {isActive && scaleInput && (
+          <line
+            x1={scaleInput.lineStart.x * w} y1={scaleInput.lineStart.y * h}
+            x2={scaleInput.lineEnd.x * w} y2={scaleInput.lineEnd.y * h}
+            stroke="#fbbf24" strokeWidth="2.5" strokeDasharray="6 3" strokeLinecap="round"
+          />
+        )}
+
+        {/* Start-point crosshair while drawing lines / callout / shapes */}
+        {isActive && isDrawing && drawStart && !['pen', 'highlighter', 'text', 'stamp', 'select', 'pan'].includes(currentTool) && (
+          <g>
+            <circle cx={drawStart.x * w} cy={drawStart.y * h}
+              r="5" fill={currentColor} stroke="white" strokeWidth="2" opacity="0.9" />
+            <line x1={drawStart.x * w - 10} y1={drawStart.y * h}
+              x2={drawStart.x * w + 10} y2={drawStart.y * h}
+              stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
+            <line x1={drawStart.x * w} y1={drawStart.y * h - 10}
+              x2={drawStart.x * w} y2={drawStart.y * h + 10}
+              stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
+          </g>
+        )}
+
+        {/* Angle badge for line-type tools while drawing */}
+        {isActive && isDrawing && previewData && (
+          currentTool === 'line' || currentTool === 'dashed_line' ||
+          currentTool === 'arrow' || currentTool === 'double_arrow' ||
+          currentTool === 'dimension' || currentTool === 'callout'
+        ) && (() => {
+          const x2px = (previewData.x2 ?? 0) * w;
+          const y2px = (previewData.y2 ?? 0) * h;
+          const dx = ((previewData.x2 ?? 0) - (previewData.x1 ?? 0)) * w;
+          const dy = ((previewData.y2 ?? 0) - (previewData.y1 ?? 0)) * h;
+          const angleDeg = ((Math.round(Math.atan2(dy, dx) * 180 / Math.PI) % 360) + 360) % 360;
+          const bx = Math.min(x2px + 12, w - 52);
+          const by = y2px > 20 ? y2px - 8 : y2px + 26;
+          return (
+            <g opacity="0.92">
+              <rect x={bx} y={by - 13} width={44} height={16} rx="4" fill="rgba(0,0,0,0.72)" />
+              <text x={bx + 5} y={by - 1} fontSize="11" fill="white" fontFamily="monospace" fontWeight="bold">
+                {angleDeg}°
+              </text>
+            </g>
+          );
+        })()}
+
+        {/* Ghost callout preview while the text input is open */}
+        {isActive && textInput && textInput.calloutData && (
+          renderAnnotationSvg({
+            toolType: 'callout', color: currentColor, strokeWidth,
+            data: { ...textInput.calloutData, text: textValue.trim() || ' ', fontSize },
+          }, w, h, 'callout-ghost')
+        )}
+
+        {/* Scale bar */}
+        {scaleInfo && w > 0 && (() => {
+          const targetPx = w * 0.15;
+          const rawUnits = (targetPx / h) * scaleInfo.unitsPerNormDist;
+          const nices = [0.25,0.5,1,2,5,10,20,25,50,100,200,500,1000];
+          const nice = nices.reduce((a, b) => Math.abs(b - rawUnits) < Math.abs(a - rawUnits) ? b : a);
+          const barPx = (nice / scaleInfo.unitsPerNormDist) * h;
+          const barX = 16, barY = h - 16;
+          const label = `${nice} ${scaleInfo.unit}`;
+          const lblW = label.length * 6 + 12;
+          return (
+            <g opacity="0.9">
+              <rect x={barX - 4} y={barY - 24} width={Math.max(barPx + 8, lblW + 8)} height={28} rx="4" fill="rgba(0,0,0,0.72)" />
+              <line x1={barX} y1={barY - 10} x2={barX + barPx} y2={barY - 10} stroke="white" strokeWidth="2" />
+              <line x1={barX} y1={barY - 16} x2={barX} y2={barY - 4} stroke="white" strokeWidth="2" />
+              <line x1={barX + barPx} y1={barY - 16} x2={barX + barPx} y2={barY - 4} stroke="white" strokeWidth="2" />
+              <text x={barX + barPx / 2} y={barY} textAnchor="middle" fill="white" fontSize="9" fontFamily="monospace" fontWeight="bold">{label}</text>
+            </g>
+          );
+        })()}
+      </svg>
+
+      {isActive && scaleInput && (
+        <div className="absolute bg-slate-900 border border-white/20 rounded-xl p-4 shadow-2xl z-20 w-60"
+          style={{ left: Math.min(w - 248, Math.max(0, scaleInput.lineEnd.x * w - 120)),
+                   top: Math.min(h - 120, Math.max(0, scaleInput.lineEnd.y * h + 16)) }}>
+          <p className="text-[10px] text-brand font-black uppercase tracking-widest mb-3">Set Scale Reference</p>
+          <p className="text-[9px] text-slate-400 mb-2">What length does this line represent?</p>
+          <div className="flex gap-2 mb-3">
+            <input ref={scaleInputRef} type="number" min="0.001" step="any" value={scaleValue}
+              onChange={e => setScaleValue(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') handleScaleConfirm(); if (e.key === 'Escape') setScaleInput(null); }}
+              placeholder="Distance"
+              className="flex-1 bg-slate-800 text-white rounded-lg px-2 py-1.5 text-sm border border-white/10 outline-none focus:border-brand min-w-0" />
+            <select value={scaleUnit} onChange={e => setScaleUnit(e.target.value)}
+              className="bg-slate-800 text-white rounded-lg px-2 text-sm border border-white/10 outline-none focus:border-brand shrink-0">
+              <option value="ft">ft</option>
+              <option value="in">in</option>
+              <option value="yd">yd</option>
+              <option value="m">m</option>
+              <option value="cm">cm</option>
+              <option value="mm">mm</option>
+            </select>
+          </div>
+          <div className="flex gap-2">
+            <button onClick={handleScaleConfirm}
+              className="flex-1 bg-brand text-slate-900 rounded-lg py-1.5 text-[11px] font-black hover:brightness-110 transition-all">
+              Set Scale
+            </button>
+            <button onClick={() => { setScaleInput(null); setScaleValue(''); }}
+              className="px-3 bg-slate-800 text-slate-300 hover:bg-slate-700 rounded-lg py-1.5 text-[11px] font-black transition-all">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isActive && textInput && (
+        <input
+          ref={textFieldRef}
+          type="text"
+          value={textValue}
+          onChange={e => setTextValue(e.target.value)}
+          onBlur={handleTextSubmit}
+          onKeyDown={e => {
+            if (e.key === 'Enter') handleTextSubmit();
+            if (e.key === 'Escape') { setTextInput(null); setTextValue(''); }
+          }}
+          className="absolute bg-black/50 backdrop-blur rounded px-2 py-1 border border-dashed outline-none z-10 font-bold"
+          style={{
+            left: textInput.calloutData
+              ? Math.min(w - 172, Math.max(4, textInput.rx * w - 80))
+              : textInput.px,
+            top: textInput.calloutData
+              ? Math.min(h - 40, Math.max(4, textInput.ry * h - fontSize - 14))
+              : textInput.py - 16,
+            color: currentColor, borderColor: currentColor, fontSize: fontSize + 'px', minWidth: '160px',
+          }}
+          placeholder={textInput.calloutData ? 'Callout text, then Enter…' : 'Type, then Enter…'}
+        />
+      )}
+    </div>
+  );
+});
+
+// ─────────────────────────────────────────────────────────────
 // Component
 // ─────────────────────────────────────────────────────────────
 
@@ -708,6 +1095,9 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const [fontSize, setFontSize]         = useState(DEFAULT_FONT_SIZE);
   const [stampType, setStampType]       = useState<StampType>('APPROVED');
   const [pageNumber, setPageNumber]     = useState(1);
+  // Page the current gesture is acting on (drives which page renders drawing previews
+  // and inputs). Separate from pageNumber so scrolling doesn't re-render page layers.
+  const [activePage, setActivePage]     = useState(1);
   const [numPages, setNumPages]         = useState(0);
   const [zoomLevel, setZoomLevel]       = useState(1.0);
   // Intrinsic (scale-1) dimensions of each page, indexed by (page number − 1).
@@ -763,6 +1153,8 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const visiblePagesRef = useRef<Set<number>>(new Set());
   // Scroll position as a fraction of scrollable height, kept current so zoom can restore it.
   const scrollRatioRef = useRef(0);
+  // Pending requestAnimationFrame id for throttling scroll-driven work.
+  const scrollRafRef = useRef(0);
   const drawingPtrRef = useRef<number | null>(null);
   const touchPtsRef   = useRef<Map<number, { x: number; y: number }>>(new Map());
   const isPinchRef    = useRef(false);
@@ -972,20 +1364,34 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   }, [zoomLevel, availWidth]);
 
   // Track the page most centered in the viewport so the header indicator stays accurate
-  // as the user scrolls through the document.
+  // as the user scrolls through the document. Throttled to once per frame and computed
+  // analytically from page sizes (no per-page DOM reads) so scrolling stays smooth even
+  // for documents with hundreds of pages.
   const handleScroll = useCallback(() => {
-    const main = mainRef.current;
-    if (!main) return;
-    const sh = main.scrollHeight - main.clientHeight;
-    scrollRatioRef.current = sh > 0 ? main.scrollTop / sh : 0;
-    const viewportCenter = main.scrollTop + main.clientHeight / 2;
-    let best = 1, bestDist = Infinity;
-    pageContainerRefs.current.forEach((el, p) => {
-      const center = el.offsetTop + el.offsetHeight / 2;
-      const dist = Math.abs(center - viewportCenter);
-      if (dist < bestDist) { bestDist = dist; best = p; }
+    if (scrollRafRef.current) return;
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = 0;
+      const main = mainRef.current;
+      if (!main) return;
+      const sh = main.scrollHeight - main.clientHeight;
+      scrollRatioRef.current = sh > 0 ? main.scrollTop / sh : 0;
+
+      // Walk cumulative page heights (container p-4 = 16px padding, gap-4 = 16px gap)
+      // to find the page under the viewport centre without forcing layout per page.
+      const PAD = 16, GAP = 16;
+      const colW = Math.min(availWidthRef.current || 0, 1400) * zoomRef.current;
+      const dims = pageDimsRef.current;
+      const center = main.scrollTop + main.clientHeight / 2;
+      let top = PAD, best = 1;
+      for (let i = 0; i < dims.length; i++) {
+        const dim = dims[i];
+        const hgt = dim && colW > 0 ? colW * (dim.height / dim.width) : 0;
+        best = i + 1;
+        if (center <= top + hgt) break;
+        top += hgt + GAP;
+      }
+      setPageNumber(prev => (prev === best ? prev : best));
     });
-    setPageNumber(prev => (prev === best ? prev : best));
   }, []);
 
   // Undo
@@ -1023,6 +1429,15 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     const canvas = pageCanvasRefs.current.get(pageNum ?? activePageRef.current);
     if (!canvas) return { x: 0, y: 0 };
     return getRelativeCoords(clientX, clientY, canvas);
+  }, []);
+
+  // Stable ref-registration callbacks so memoized PageLayers never re-render from
+  // receiving a fresh ref function each render.
+  const registerContainer = useCallback((p: number, el: HTMLDivElement | null) => {
+    if (el) pageContainerRefs.current.set(p, el); else pageContainerRefs.current.delete(p);
+  }, []);
+  const registerCanvas = useCallback((p: number, el: HTMLCanvasElement | null) => {
+    if (el) pageCanvasRefs.current.set(p, el); else pageCanvasRefs.current.delete(p);
   }, []);
 
   // Stage annotation locally; persisted to DB only when the user clicks Save.
@@ -1326,7 +1741,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     // previews, and new annotations all bind to the correct page.
     const pageNum = Number(e.currentTarget.dataset.page) || 1;
     activePageRef.current = pageNum;
-    setPageNumber(pageNum);
+    setActivePage(pageNum);
 
     // Palm rejection: if pen is active, ignore new touch contacts
     if (drawingPtrRef.current !== null && e.pointerType === 'touch') return;
@@ -1750,6 +2165,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     if (currentTool !== 'select') return;
     const pageNum = Number(e.currentTarget.dataset.page) || activePageRef.current;
     activePageRef.current = pageNum;
+    setActivePage(pageNum);
     const coords = getCoords(e.clientX, e.clientY, pageNum);
     const pageAnns = [...annotations, ...pendingAnnotations].filter(a => a.pageNumber === pageNum);
     let nearest: PdfAnnotation | null = null;
@@ -1833,328 +2249,6 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     return { width: columnWidth, height: columnWidth * (dim.height / dim.width) };
   };
 
-  // Renders a single stacked page: its canvas + the SVG annotation overlay.
-  // Live drawing previews and the text/scale inputs render only on the page the
-  // current gesture is acting on (activePageRef); annotations render on every page.
-  const renderPageLayer = (pageNum: number) => {
-    const { width: w, height: h } = getDisplaySize(pageNum);
-    const isActive = activePageRef.current === pageNum;
-    const pageAnns = annotationsByPage.get(pageNum) ?? [];
-    const sel = selectedAnn && selectedAnn.pageNumber === pageNum ? selectedAnn : null;
-    const penPreviewPath = isActive && (currentTool === 'pen' || currentTool === 'highlighter') && penPoints.length > 1 && isDrawing
-      ? penPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x * w} ${p.y * h}`).join(' ')
-      : null;
-
-    return (
-      <div
-        key={pageNum}
-        data-page={pageNum}
-        ref={el => { if (el) pageContainerRefs.current.set(pageNum, el); else pageContainerRefs.current.delete(pageNum); }}
-        className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 bg-slate-800/40 ${toolCursor}`}
-        style={{ width: w || '100%', height: h || undefined, touchAction: 'none' }}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerCancel}
-        onDoubleClick={handleDoubleClick}
-      >
-        {/* Canvas is absolutely positioned and stretched to the container so the
-            reserved page height is independent of whether the bitmap is painted. */}
-        <canvas
-          ref={el => { if (el) pageCanvasRefs.current.set(pageNum, el); else pageCanvasRefs.current.delete(pageNum); }}
-          className="absolute inset-0 w-full h-full block"
-        />
-
-        <svg className="absolute inset-0 pointer-events-none"
-          width={w} height={h}
-          viewBox={`0 0 ${w} ${h}`}>
-
-          {pageAnns.map(ann => {
-            const data = (ann.id === selectedAnnId && liveEditData !== null)
-              ? liveEditData
-              : ann.data as AnyAnnotationData;
-            return renderAnnotationSvg({ ...ann, data }, w, h, ann.id, scaleInfo);
-          })}
-
-          {sel && currentTool === 'select' && (() => {
-            const displayData = liveEditData ?? sel.data as AnyAnnotationData;
-            const rotation    = (displayData.rotation as number | undefined) ?? 0;
-            const handles     = getHandlesNorm({ ...sel, data: displayData });
-            const bbox        = getAnnotationBBox(sel, displayData);
-            const SELECTION_BOX_PADDING = 8;
-            // Pixel coordinates of the bbox centre (used for the rotation transform)
-            const bboxCxPx = bbox ? (bbox.x + bbox.w / 2) * w : 0;
-            const bboxCyPx = bbox ? (bbox.y + bbox.h / 2) * h : 0;
-            const rotateHandle = handles.find(hh => hh.isRotateHandle);
-            return (
-              <g>
-                {/* Dashed bounding box — rotated with the annotation */}
-                {bbox && bbox.w > 0.005 && (
-                  <g transform={rotation ? `rotate(${rotation}, ${bboxCxPx}, ${bboxCyPx})` : undefined}>
-                    <rect
-                      x={bbox.x * w - SELECTION_BOX_PADDING}
-                      y={bbox.y * h - SELECTION_BOX_PADDING}
-                      width={bbox.w * w + SELECTION_BOX_PADDING * 2}
-                      height={bbox.h * h + SELECTION_BOX_PADDING * 2}
-                      fill="none" stroke="white" strokeWidth="1.5"
-                      strokeDasharray="5 3" opacity="0.5" rx="3" />
-                  </g>
-                )}
-                {/* Stem line from bbox top-centre to the rotate handle */}
-                {bbox && bbox.w > 0.005 && rotateHandle && (() => {
-                  // Compute the rotated top-centre of the bounding box
-                  const stemBaseX = bbox.x * w + (bbox.w * w) / 2;
-                  const stemBaseY = bbox.y * h - SELECTION_BOX_PADDING;
-                  if (rotation) {
-                    const rad = (rotation * Math.PI) / 180;
-                    const cos = Math.cos(rad), sin = Math.sin(rad);
-                    const dx = stemBaseX - bboxCxPx, dy = stemBaseY - bboxCyPx;
-                    const rx = bboxCxPx + dx * cos - dy * sin;
-                    const ry = bboxCyPx + dx * sin + dy * cos;
-                    return <line x1={rx} y1={ry} x2={rotateHandle.nx * w} y2={rotateHandle.ny * h}
-                      stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
-                  }
-                  return <line x1={stemBaseX} y1={stemBaseY} x2={rotateHandle.nx * w} y2={rotateHandle.ny * h}
-                    stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
-                })()}
-                {handles.map(hh => {
-                  const cx = hh.nx * w;
-                  const cy = hh.ny * h;
-                  const isCalloutArrowTip = sel.toolType === 'callout' && !hh.isMoveHandle && !hh.isRotateHandle && hh.index === 1;
-                  const handleFill = hh.isRotateHandle ? '#22c55e'
-                    : hh.isMoveHandle ? '#6366f1'
-                    : hh.isEdgeHandle ? '#0ea5e9'
-                    : isCalloutArrowTip ? '#f59e0b'
-                    : '#3b82f6';
-                  const edgeLabel = hh.index === EDGE_HANDLE_TOP ? 'top' : hh.index === EDGE_HANDLE_RIGHT ? 'right' : hh.index === EDGE_HANDLE_BOTTOM ? 'bottom' : 'left';
-                  const handleTitle = hh.isRotateHandle
-                    ? `Rotate — drag to rotate (${Math.round(rotation)}°), hold Shift for 15° snapping`
-                    : hh.isMoveHandle
-                      ? 'Move annotation'
-                      : hh.isEdgeHandle
-                        ? `Resize ${edgeLabel} edge — drag to resize on one axis`
-                        : sel.toolType === 'callout'
-                          ? hh.index === 0 ? 'Text box — drag to reposition' : 'Arrow tip — drag to repoint'
-                          : sel.toolType === 'arrow' || sel.toolType === 'double_arrow'
-                            ? hh.index === 0 ? 'Line start — drag to adjust' : 'Arrow head — drag to adjust'
-                            : `Endpoint ${hh.index + 1} — drag to reshape`;
-                  const r = hh.isRotateHandle || hh.isMoveHandle ? 9 : 8;
-                  return (
-                    <g key={`handle-${hh.index}`}>
-                      {/* Hit-area circle (invisible, larger) */}
-                      <circle cx={cx} cy={cy} r="18" fill="transparent">
-                        <title>{handleTitle}</title>
-                      </circle>
-                      {/* Edge handles: diamond (rotated square) shape */}
-                      {hh.isEdgeHandle ? (
-                        <rect
-                          x={cx - 6} y={cy - 6} width={12} height={12}
-                          fill={handleFill} stroke="white" strokeWidth="2"
-                          transform={`rotate(45, ${cx}, ${cy})`}
-                        />
-                      ) : (
-                        /* Visible handle circle */
-                        <circle cx={cx} cy={cy} r={r} fill={handleFill} stroke="white" strokeWidth="2.5" />
-                      )}
-                      {/* Rotate handle: circular-arrow icon */}
-                      {hh.isRotateHandle && (
-                        <g transform={`translate(${cx}, ${cy})`} stroke="white" strokeWidth="1.5" strokeLinecap="round" fill="none">
-                          <path d="M -4 -3 A 5 5 0 1 1 3.5 -3.5" />
-                          <polyline points="3.5,-3.5 5.5,-1.5 5.5,-5" />
-                        </g>
-                      )}
-                      {/* Move handle: cross icon */}
-                      {hh.isMoveHandle && (
-                        <g stroke="white" strokeWidth="1.5" strokeLinecap="round">
-                          <line x1={cx - 4} y1={cy} x2={cx + 4} y2={cy} />
-                          <line x1={cx} y1={cy - 4} x2={cx} y2={cy + 4} />
-                        </g>
-                      )}
-                    </g>
-                  );
-                })}
-              </g>
-            );
-          })()}
-
-          {pageAnns.map(ann => {
-            const anchor = getAnnotationAnchor(ann);
-            if (!anchor) return null;
-            const initials  = getInitials(ann.authorName);
-            const bw        = initials.length * 7 + 10;
-            const bx        = anchor.x * w;
-            const by        = anchor.y * h;
-            const isPending = ann.id.startsWith('tmp-');
-            return (
-              <g key={`badge-${ann.id}`}>
-                <rect x={bx} y={by - 17} width={bw} height={17} rx="3"
-                  fill={ann.color} opacity={isPending ? 0.5 : 0.88}
-                  stroke={isPending ? 'white' : 'none'} strokeWidth={isPending ? 1 : 0}
-                  strokeDasharray={isPending ? '3 2' : undefined} />
-                <text x={bx + 5} y={by - 3} fontSize="11" fontFamily="monospace" fontWeight="bold" fill="white">
-                  {initials}
-                </text>
-              </g>
-            );
-          })}
-
-          {penPreviewPath && (
-            <path d={penPreviewPath} stroke={currentColor}
-              strokeWidth={currentTool === 'highlighter' ? strokeWidth * 5 : strokeWidth}
-              fill="none" strokeLinecap="round" strokeLinejoin="round"
-              opacity={currentTool === 'highlighter' ? opacity * 0.35 : opacity * 0.75} />
-          )}
-
-          {isActive && previewData && currentTool !== 'pen' && currentTool !== 'highlighter' && currentTool !== 'scale' &&
-            renderAnnotationSvg({ toolType: currentTool, color: currentColor, strokeWidth, data: previewData },
-              w, h, 'preview', scaleInfo)
-          }
-
-          {isActive && isDrawing && currentTool === 'scale' && previewData && (
-            <line
-              x1={(previewData.x1 ?? 0) * w} y1={(previewData.y1 ?? 0) * h}
-              x2={(previewData.x2 ?? 0) * w} y2={(previewData.y2 ?? 0) * h}
-              stroke="#fbbf24" strokeWidth="2" strokeDasharray="6 3" strokeLinecap="round" opacity="0.9"
-            />
-          )}
-
-          {isActive && scaleInput && (
-            <line
-              x1={scaleInput.lineStart.x * w} y1={scaleInput.lineStart.y * h}
-              x2={scaleInput.lineEnd.x * w} y2={scaleInput.lineEnd.y * h}
-              stroke="#fbbf24" strokeWidth="2.5" strokeDasharray="6 3" strokeLinecap="round"
-            />
-          )}
-
-          {/* Start-point crosshair while drawing lines / callout / shapes */}
-          {isActive && isDrawing && drawStart && !['pen', 'highlighter', 'text', 'stamp', 'select', 'pan'].includes(currentTool) && (
-            <g>
-              <circle cx={drawStart.x * w} cy={drawStart.y * h}
-                r="5" fill={currentColor} stroke="white" strokeWidth="2" opacity="0.9" />
-              <line x1={drawStart.x * w - 10} y1={drawStart.y * h}
-                x2={drawStart.x * w + 10} y2={drawStart.y * h}
-                stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
-              <line x1={drawStart.x * w} y1={drawStart.y * h - 10}
-                x2={drawStart.x * w} y2={drawStart.y * h + 10}
-                stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
-            </g>
-          )}
-
-          {/* Angle badge for line-type tools while drawing */}
-          {isActive && isDrawing && previewData && (
-            currentTool === 'line' || currentTool === 'dashed_line' ||
-            currentTool === 'arrow' || currentTool === 'double_arrow' ||
-            currentTool === 'dimension' || currentTool === 'callout'
-          ) && (() => {
-            const x2px = (previewData.x2 ?? 0) * w;
-            const y2px = (previewData.y2 ?? 0) * h;
-            const dx = ((previewData.x2 ?? 0) - (previewData.x1 ?? 0)) * w;
-            const dy = ((previewData.y2 ?? 0) - (previewData.y1 ?? 0)) * h;
-            const angleDeg = ((Math.round(Math.atan2(dy, dx) * 180 / Math.PI) % 360) + 360) % 360;
-            const bx = Math.min(x2px + 12, w - 52);
-            const by = y2px > 20 ? y2px - 8 : y2px + 26;
-            return (
-              <g opacity="0.92">
-                <rect x={bx} y={by - 13} width={44} height={16} rx="4" fill="rgba(0,0,0,0.72)" />
-                <text x={bx + 5} y={by - 1} fontSize="11" fill="white" fontFamily="monospace" fontWeight="bold">
-                  {angleDeg}°
-                </text>
-              </g>
-            );
-          })()}
-
-          {/* Ghost callout preview while the text input is open */}
-          {isActive && textInput && textInput.calloutData && (
-            renderAnnotationSvg({
-              toolType: 'callout', color: currentColor, strokeWidth,
-              data: { ...textInput.calloutData, text: textValue.trim() || ' ', fontSize },
-            }, w, h, 'callout-ghost')
-          )}
-
-          {/* Scale bar */}
-          {scaleInfo && w > 0 && (() => {
-            const targetPx = w * 0.15;
-            const rawUnits = (targetPx / h) * scaleInfo.unitsPerNormDist;
-            const nices = [0.25,0.5,1,2,5,10,20,25,50,100,200,500,1000];
-            const nice = nices.reduce((a, b) => Math.abs(b - rawUnits) < Math.abs(a - rawUnits) ? b : a);
-            const barPx = (nice / scaleInfo.unitsPerNormDist) * h;
-            const barX = 16, barY = h - 16;
-            const label = `${nice} ${scaleInfo.unit}`;
-            const lblW = label.length * 6 + 12;
-            return (
-              <g opacity="0.9">
-                <rect x={barX - 4} y={barY - 24} width={Math.max(barPx + 8, lblW + 8)} height={28} rx="4" fill="rgba(0,0,0,0.72)" />
-                <line x1={barX} y1={barY - 10} x2={barX + barPx} y2={barY - 10} stroke="white" strokeWidth="2" />
-                <line x1={barX} y1={barY - 16} x2={barX} y2={barY - 4} stroke="white" strokeWidth="2" />
-                <line x1={barX + barPx} y1={barY - 16} x2={barX + barPx} y2={barY - 4} stroke="white" strokeWidth="2" />
-                <text x={barX + barPx / 2} y={barY} textAnchor="middle" fill="white" fontSize="9" fontFamily="monospace" fontWeight="bold">{label}</text>
-              </g>
-            );
-          })()}
-        </svg>
-
-        {isActive && scaleInput && (
-          <div className="absolute bg-slate-900 border border-white/20 rounded-xl p-4 shadow-2xl z-20 w-60"
-            style={{ left: Math.min(w - 248, Math.max(0, scaleInput.lineEnd.x * w - 120)),
-                     top: Math.min(h - 120, Math.max(0, scaleInput.lineEnd.y * h + 16)) }}>
-            <p className="text-[10px] text-brand font-black uppercase tracking-widest mb-3">Set Scale Reference</p>
-            <p className="text-[9px] text-slate-400 mb-2">What length does this line represent?</p>
-            <div className="flex gap-2 mb-3">
-              <input ref={scaleInputRef} type="number" min="0.001" step="any" value={scaleValue}
-                onChange={e => setScaleValue(e.target.value)}
-                onKeyDown={e => { if (e.key === 'Enter') handleScaleConfirm(); if (e.key === 'Escape') setScaleInput(null); }}
-                placeholder="Distance"
-                className="flex-1 bg-slate-800 text-white rounded-lg px-2 py-1.5 text-sm border border-white/10 outline-none focus:border-brand min-w-0" />
-              <select value={scaleUnit} onChange={e => setScaleUnit(e.target.value)}
-                className="bg-slate-800 text-white rounded-lg px-2 text-sm border border-white/10 outline-none focus:border-brand shrink-0">
-                <option value="ft">ft</option>
-                <option value="in">in</option>
-                <option value="yd">yd</option>
-                <option value="m">m</option>
-                <option value="cm">cm</option>
-                <option value="mm">mm</option>
-              </select>
-            </div>
-            <div className="flex gap-2">
-              <button onClick={handleScaleConfirm}
-                className="flex-1 bg-brand text-slate-900 rounded-lg py-1.5 text-[11px] font-black hover:brightness-110 transition-all">
-                Set Scale
-              </button>
-              <button onClick={() => { setScaleInput(null); setScaleValue(''); }}
-                className="px-3 bg-slate-800 text-slate-300 hover:bg-slate-700 rounded-lg py-1.5 text-[11px] font-black transition-all">
-                Cancel
-              </button>
-            </div>
-          </div>
-        )}
-
-        {isActive && textInput && (
-          <input
-            ref={textFieldRef}
-            type="text"
-            value={textValue}
-            onChange={e => setTextValue(e.target.value)}
-            onBlur={handleTextSubmit}
-            onKeyDown={e => {
-              if (e.key === 'Enter') handleTextSubmit();
-              if (e.key === 'Escape') { setTextInput(null); setTextValue(''); }
-            }}
-            className="absolute bg-black/50 backdrop-blur rounded px-2 py-1 border border-dashed outline-none z-10 font-bold"
-            style={{
-              left: textInput.calloutData
-                ? Math.min(w - 172, Math.max(4, textInput.rx * w - 80))
-                : textInput.px,
-              top: textInput.calloutData
-                ? Math.min(h - 40, Math.max(4, textInput.ry * h - fontSize - 14))
-                : textInput.py - 16,
-              color: currentColor, borderColor: currentColor, fontSize: fontSize + 'px', minWidth: '160px',
-            }}
-            placeholder={textInput.calloutData ? 'Callout text, then Enter…' : 'Type, then Enter…'}
-          />
-        )}
-      </div>
-    );
-  };
 
   return (
     <div className="fixed inset-0 z-[300] bg-slate-950 flex flex-col select-none" onWheel={handleWheel}>
@@ -2654,7 +2748,43 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         )}
 
         {!isLoadingPdf && !pdfError &&
-          Array.from({ length: numPages }, (_, i) => renderPageLayer(i + 1))}
+          Array.from({ length: numPages }, (_, i) => {
+            const p = i + 1;
+            const { width: w, height: h } = getDisplaySize(p);
+            const active = activePage === p;
+            // Only the page holding the selection needs the live-edit data; gating it
+            // keeps every other page from re-rendering during a handle drag.
+            const isSelectedPage = selectedAnn !== null && selectedAnn.pageNumber === p;
+            return (
+              <PageLayer
+                key={p}
+                pageNum={p} w={w} h={h} toolCursor={toolCursor}
+                pageAnns={annotationsByPage.get(p) ?? EMPTY_ANNS}
+                selectedAnnId={isSelectedPage ? selectedAnnId : null} liveEditData={isSelectedPage ? liveEditData : null}
+                sel={isSelectedPage ? selectedAnn : null}
+                scaleInfo={scaleInfo}
+                currentTool={currentTool} currentColor={currentColor} strokeWidth={strokeWidth} opacity={opacity}
+                isActive={active}
+                previewData={active ? previewData : null}
+                penPoints={active ? penPoints : EMPTY_POINTS}
+                drawStart={active ? drawStart : null}
+                isDrawing={active ? isDrawing : false}
+                textInput={active ? textInput : null}
+                textValue={active ? textValue : ''}
+                fontSize={fontSize}
+                scaleInput={active ? scaleInput : null}
+                scaleValue={scaleValue} scaleUnit={scaleUnit}
+                onPointerDown={handlePointerDown} onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp} onPointerCancel={handlePointerCancel}
+                onDoubleClick={handleDoubleClick}
+                registerContainer={registerContainer} registerCanvas={registerCanvas}
+                textFieldRef={textFieldRef} scaleInputRef={scaleInputRef}
+                setTextValue={setTextValue} setTextInput={setTextInput} handleTextSubmit={handleTextSubmit}
+                setScaleValue={setScaleValue} setScaleUnit={setScaleUnit} setScaleInput={setScaleInput}
+                handleScaleConfirm={handleScaleConfirm}
+              />
+            );
+          })}
 
         {showLog && (
           <div className="w-full max-w-3xl bg-slate-900/80 border border-white/10 rounded-2xl p-4 shrink-0">

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
 import * as pdfjsLib from 'pdfjs-dist';
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 import { PdfAnnotation, JobPrint, User, UserRole } from '../types.ts';
@@ -708,9 +708,12 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const [pageNumber, setPageNumber]     = useState(1);
   const [numPages, setNumPages]         = useState(0);
   const [zoomLevel, setZoomLevel]       = useState(1.0);
-  // Rendered pixel dimensions of each page's canvas, keyed by 1-based page number.
-  // Used to size the per-page SVG overlay and denormalize annotation coordinates.
-  const [pageSizes, setPageSizes]       = useState<Map<number, { width: number; height: number }>>(new Map());
+  // Intrinsic (scale-1) dimensions of each page, indexed by (page number − 1).
+  // The on-screen size is derived from these + the column width + zoom, so every
+  // page reserves correct scroll height even before its canvas is lazily rendered.
+  const [pageDims, setPageDims]         = useState<Array<{ width: number; height: number }>>([]);
+  // Width available for the page column (container width minus padding/scrollbar).
+  const [availWidth, setAvailWidth]     = useState(0);
   const [isDrawing, setIsDrawing]       = useState(false);
   const [drawStart, setDrawStart]       = useState<{ x: number; y: number } | null>(null);
   const [penPoints, setPenPoints]       = useState<Array<{ x: number; y: number; pressure?: number }>>([]);
@@ -752,8 +755,12 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const pdfDocRef     = useRef<pdfjsLib.PDFDocumentProxy | null>(null);
   // Active pdf.js render tasks keyed by page number, so re-renders can cancel cleanly.
   const renderTasksRef = useRef<Map<number, pdfjsLib.RenderTask>>(new Map());
-  // Monotonic token to discard results from superseded render passes (e.g. fast zooming).
-  const renderTokenRef = useRef(0);
+  // Zoom level at which each page's canvas was last painted (to skip redundant renders).
+  const renderedZoomRef = useRef<Map<number, number>>(new Map());
+  // Pages currently intersecting the viewport (plus the observer's prerender buffer).
+  const visiblePagesRef = useRef<Set<number>>(new Set());
+  // Scroll position as a fraction of scrollable height, kept current so zoom can restore it.
+  const scrollRatioRef = useRef(0);
   const drawingPtrRef = useRef<number | null>(null);
   const touchPtsRef   = useRef<Map<number, { x: number; y: number }>>(new Map());
   const isPinchRef    = useRef(false);
@@ -778,6 +785,13 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   // Stable ref to currentTool for use in non-reactive callbacks (e.g., touch listeners)
   const currentToolRef = useRef<ToolType>(currentTool);
   currentToolRef.current = currentTool;
+  // Stable refs to zoom / column width / page dims for use in non-reactive render callbacks.
+  const zoomRef = useRef(zoomLevel);
+  zoomRef.current = zoomLevel;
+  const availWidthRef = useRef(availWidth);
+  availWidthRef.current = availWidth;
+  const pageDimsRef = useRef(pageDims);
+  pageDimsRef.current = pageDims;
 
   // Load annotations
   useEffect(() => {
@@ -828,7 +842,18 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       }
       try {
         const pdf = await pdfjsLib.getDocument({ data: new Uint8Array(buffer) }).promise;
-        if (!cancelled) { pdfDocRef.current = pdf; setNumPages(pdf.numPages); setPageNumber(1); }
+        if (!cancelled) {
+          pdfDocRef.current = pdf;
+          setNumPages(pdf.numPages);
+          setPageNumber(1);
+          // Seed every page's size from page 1 so placeholders reserve height
+          // immediately; each page's real size is refined when it first renders.
+          try {
+            const first = await pdf.getPage(1);
+            const vp = first.getViewport({ scale: 1 });
+            if (!cancelled) setPageDims(Array.from({ length: pdf.numPages }, () => ({ width: vp.width, height: vp.height })));
+          } catch { /* dims refined lazily */ }
+        }
       } catch (e: unknown) {
         if (!cancelled) setPdfError(e instanceof Error ? e.message : 'Failed to parse PDF');
       } finally {
@@ -840,70 +865,102 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     return () => { cancelled = true; };
   }, [print.storagePath, print.url]);
 
-  // Render every page at the current zoom into its own stacked canvas.
-  // Pages share a single column width so the document scrolls continuously.
-  const renderAllPages = useCallback(async (zoom: number) => {
+  // Paint a single page's canvas at the current zoom. Only on-screen pages (plus a
+  // prerender buffer) are ever rendered, so very large documents stay light: off-screen
+  // pages keep their reserved height but hold no canvas bitmap.
+  const renderPage = useCallback(async (pageNum: number, force = false) => {
     const pdf = pdfDocRef.current;
-    if (!pdf) return;
-    const token = ++renderTokenRef.current;
-    const main  = mainRef.current;
-
-    // Preserve the scroll anchor across a zoom-driven re-render so the page the
-    // user is looking at stays roughly in view after every canvas resizes.
-    let ratioX = 0, ratioY = 0;
-    if (main) {
-      const scrollW = main.scrollWidth  - main.clientWidth;
-      const scrollH = main.scrollHeight - main.clientHeight;
-      ratioX = scrollW > 0 ? main.scrollLeft / scrollW : 0;
-      ratioY = scrollH > 0 ? main.scrollTop  / scrollH : 0;
-    }
-
-    const avail = (main?.clientWidth ?? window.innerWidth) - 48;
-    const sizes = new Map(pageSizes);
-    for (let p = 1; p <= pdf.numPages; p++) {
-      const canvas = pageCanvasRefs.current.get(p);
-      if (!canvas) continue;
-      const prev = renderTasksRef.current.get(p);
-      if (prev) { prev.cancel(); renderTasksRef.current.delete(p); }
-      try {
-        const page  = await pdf.getPage(p);
-        if (token !== renderTokenRef.current) return;
-        const base  = page.getViewport({ scale: 1 });
-        const scale = (Math.min(avail, 1400) / base.width) * zoom;
-        const vp    = page.getViewport({ scale });
-        canvas.width = vp.width; canvas.height = vp.height;
-        sizes.set(p, { width: vp.width, height: vp.height });
-        const ctx = canvas.getContext('2d');
-        if (!ctx) continue;
-        const task = page.render({ canvasContext: ctx, viewport: vp });
-        renderTasksRef.current.set(p, task);
-        await task.promise;
-        renderTasksRef.current.delete(p);
-      } catch { /* cancelled */ }
-    }
-    if (token !== renderTokenRef.current) return;
-    setPageSizes(sizes);
-
-    if (main) {
-      requestAnimationFrame(() => {
-        main.scrollLeft = ratioX * Math.max(0, main.scrollWidth  - main.clientWidth);
-        main.scrollTop  = ratioY * Math.max(0, main.scrollHeight - main.clientHeight);
+    const canvas = pageCanvasRefs.current.get(pageNum);
+    if (!pdf || !canvas) return;
+    const zoom = zoomRef.current;
+    if (!force && renderedZoomRef.current.get(pageNum) === zoom) return;
+    const prev = renderTasksRef.current.get(pageNum);
+    if (prev) { prev.cancel(); renderTasksRef.current.delete(pageNum); }
+    try {
+      const page = await pdf.getPage(pageNum);
+      const base = page.getViewport({ scale: 1 });
+      // Refine the seeded dimensions if this page differs in size from page 1.
+      setPageDims(prevDims => {
+        const cur = prevDims[pageNum - 1];
+        if (cur && Math.abs(cur.width - base.width) < 0.5 && Math.abs(cur.height - base.height) < 0.5) return prevDims;
+        const next = [...prevDims];
+        next[pageNum - 1] = { width: base.width, height: base.height };
+        return next;
       });
-    }
-  // pageSizes intentionally omitted: it is seeded fresh each pass and including it
-  // would re-create the callback on every render it performs.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+      const avail = (availWidthRef.current || (mainRef.current?.clientWidth ?? window.innerWidth) - 48);
+      const scale = (Math.min(avail, 1400) / base.width) * zoom;
+      const vp = page.getViewport({ scale });
+      canvas.width = vp.width; canvas.height = vp.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      const task = page.render({ canvasContext: ctx, viewport: vp });
+      renderTasksRef.current.set(pageNum, task);
+      await task.promise;
+      renderTasksRef.current.delete(pageNum);
+      renderedZoomRef.current.set(pageNum, zoom);
+    } catch { /* cancelled */ }
   }, []);
 
+  // Release a page's canvas bitmap when it scrolls far out of view (frees memory).
+  const clearPage = useCallback((pageNum: number) => {
+    const prev = renderTasksRef.current.get(pageNum);
+    if (prev) { prev.cancel(); renderTasksRef.current.delete(pageNum); }
+    const canvas = pageCanvasRefs.current.get(pageNum);
+    if (canvas) { canvas.width = 0; canvas.height = 0; }
+    renderedZoomRef.current.delete(pageNum);
+  }, []);
+
+  // Track the column width available for pages and react to container resizes.
   useEffect(() => {
-    if (!isLoadingPdf && pdfDocRef.current) renderAllPages(zoomLevel);
-  }, [zoomLevel, isLoadingPdf, numPages, renderAllPages]);
+    const main = mainRef.current;
+    if (!main) return;
+    const update = () => setAvailWidth(Math.max(0, main.clientWidth - 48));
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(main);
+    return () => ro.disconnect();
+  }, []);
+
+  // Lazily render pages as they enter the viewport (with a generous prerender buffer)
+  // and clear them as they leave, so memory use is bounded regardless of page count.
+  useEffect(() => {
+    if (isLoadingPdf || !numPages) return;
+    const main = mainRef.current;
+    if (!main) return;
+    const io = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        const p = Number((entry.target as HTMLElement).dataset.page);
+        if (!p) continue;
+        if (entry.isIntersecting) { visiblePagesRef.current.add(p); renderPage(p); }
+        else { visiblePagesRef.current.delete(p); clearPage(p); }
+      }
+    }, { root: main, rootMargin: '1200px 0px 1200px 0px', threshold: 0 });
+    pageContainerRefs.current.forEach(el => io.observe(el));
+    return () => io.disconnect();
+  }, [isLoadingPdf, numPages, renderPage, clearPage]);
+
+  // Re-render the currently visible pages when zoom or column width changes.
+  useEffect(() => {
+    if (isLoadingPdf) return;
+    visiblePagesRef.current.forEach(p => renderPage(p, true));
+  }, [zoomLevel, availWidth, isLoadingPdf, renderPage]);
+
+  // Keep the same scroll anchor when page sizes change (zoom / resize) so the user
+  // stays on the page they were viewing rather than jumping to the top.
+  useLayoutEffect(() => {
+    const main = mainRef.current;
+    if (!main) return;
+    const sh = main.scrollHeight - main.clientHeight;
+    if (sh > 0) main.scrollTop = scrollRatioRef.current * sh;
+  }, [zoomLevel, availWidth]);
 
   // Track the page most centered in the viewport so the header indicator stays accurate
   // as the user scrolls through the document.
   const handleScroll = useCallback(() => {
     const main = mainRef.current;
     if (!main) return;
+    const sh = main.scrollHeight - main.clientHeight;
+    scrollRatioRef.current = sh > 0 ? main.scrollTop / sh : 0;
     const viewportCenter = main.scrollTop + main.clientHeight / 2;
     let best = 1, bestDist = Infinity;
     pageContainerRefs.current.forEach((el, p) => {
@@ -1601,15 +1658,15 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     if (!scaleInput || !scaleValue) { setScaleInput(null); return; }
     const inputVal = parseFloat(scaleValue);
     if (isNaN(inputVal) || inputVal <= 0) { setScaleInput(null); return; }
-    const activeSize = pageSizes.get(activePageRef.current) ?? { width: 0, height: 0 };
-    const ar = activeSize.width / (activeSize.height || 1);
+    const dim = pageDimsRef.current[activePageRef.current - 1];
+    const ar = dim ? dim.width / (dim.height || 1) : 1;
     const dx = scaleInput.lineEnd.x - scaleInput.lineStart.x;
     const dy = scaleInput.lineEnd.y - scaleInput.lineStart.y;
     const normDist = Math.sqrt((dx * ar) ** 2 + dy ** 2);
     if (normDist < 0.001) { setScaleInput(null); return; }
     setScaleInfo({ unitsPerNormDist: inputVal / normDist, aspectRatio: ar, unit: scaleUnit });
     setScaleInput(null); setScaleValue(''); setCurrentTool('select');
-  }, [scaleInput, scaleValue, scaleUnit, pageSizes]);
+  }, [scaleInput, scaleValue, scaleUnit]);
 
   const flipAnnotationH = useCallback(() => {
     const selId = selectedAnnIdRef.current;
@@ -1696,6 +1753,17 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
     return map;
   }, [allDisplayAnnotations]);
+  // Group annotations by page once per render so each stacked page is an O(1) lookup
+  // instead of scanning every annotation — keeps re-renders cheap on large documents.
+  const annotationsByPage = useMemo(() => {
+    const map = new Map<number, PdfAnnotation[]>();
+    for (const ann of allDisplayAnnotations) {
+      if (filterAuthorId !== null && ann.authorId !== filterAuthorId) continue;
+      const list = map.get(ann.pageNumber);
+      if (list) list.push(ann); else map.set(ann.pageNumber, [ann]);
+    }
+    return map;
+  }, [allDisplayAnnotations, filterAuthorId]);
   // Selected annotation may live on any page; resolve it globally for the toolbar.
   const selectedAnn     = allDisplayAnnotations.find(a => a.id === selectedAnnId) ?? null;
   const canDeleteAnn = (ann: PdfAnnotation) =>
@@ -1716,17 +1784,23 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
   };
 
+  // On-screen size of a page: a shared column width (fit-to-width × zoom) and a
+  // height from the page's own aspect ratio. Derived, so it is known for every page
+  // up front and stays correct without the page having been rendered yet.
+  const columnWidth = Math.min(availWidth || 0, 1400) * zoomLevel;
+  const getDisplaySize = (pageNum: number) => {
+    const dim = pageDims[pageNum - 1];
+    if (!dim || columnWidth <= 0) return { width: 0, height: 0 };
+    return { width: columnWidth, height: columnWidth * (dim.height / dim.width) };
+  };
+
   // Renders a single stacked page: its canvas + the SVG annotation overlay.
   // Live drawing previews and the text/scale inputs render only on the page the
   // current gesture is acting on (activePageRef); annotations render on every page.
   const renderPageLayer = (pageNum: number) => {
-    const size = pageSizes.get(pageNum);
-    const w = size?.width ?? 0;
-    const h = size?.height ?? 0;
+    const { width: w, height: h } = getDisplaySize(pageNum);
     const isActive = activePageRef.current === pageNum;
-    const pageAnns = allDisplayAnnotations.filter(
-      a => a.pageNumber === pageNum && (filterAuthorId === null || a.authorId === filterAuthorId)
-    );
+    const pageAnns = annotationsByPage.get(pageNum) ?? [];
     const sel = selectedAnn && selectedAnn.pageNumber === pageNum ? selectedAnn : null;
     const penPreviewPath = isActive && (currentTool === 'pen' || currentTool === 'highlighter') && penPoints.length > 1 && isDrawing
       ? penPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x * w} ${p.y * h}`).join(' ')
@@ -1737,17 +1811,19 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         key={pageNum}
         data-page={pageNum}
         ref={el => { if (el) pageContainerRefs.current.set(pageNum, el); else pageContainerRefs.current.delete(pageNum); }}
-        className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 ${toolCursor}`}
-        style={{ width: w || '100%', touchAction: 'none' }}
+        className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 bg-slate-800/40 ${toolCursor}`}
+        style={{ width: w || '100%', height: h || undefined, touchAction: 'none' }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
         onDoubleClick={handleDoubleClick}
       >
+        {/* Canvas is absolutely positioned and stretched to the container so the
+            reserved page height is independent of whether the bitmap is painted. */}
         <canvas
           ref={el => { if (el) pageCanvasRefs.current.set(pageNum, el); else pageCanvasRefs.current.delete(pageNum); }}
-          className="block"
+          className="absolute inset-0 w-full h-full block"
         />
 
         <svg className="absolute inset-0 pointer-events-none"

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -776,7 +776,7 @@ const PageLayer = React.memo(function PageLayer(props: PageLayerProps) {
     <div
       data-page={pageNum}
       ref={containerCb}
-      className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 bg-slate-800/40 ${toolCursor}`}
+      className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 ${toolCursor}`}
       style={{ width: w || '100%', height: h || undefined, touchAction: 'none' }}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
@@ -784,6 +784,22 @@ const PageLayer = React.memo(function PageLayer(props: PageLayerProps) {
       onPointerCancel={onPointerCancel}
       onDoubleClick={onDoubleClick}
     >
+      {/* Loading placeholder. Sits BEHIND the canvas: when the PDF bitmap is painted
+          it is opaque white and fully covers this layer; while the page is not yet
+          rendered the canvas is empty/transparent and this shows through. Needs no
+          render state — the canvas paint hides it for free. Kept static (no per-page
+          animation) so a document with hundreds of pages has no idle GPU/battery cost. */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-gradient-to-b from-slate-800/40 to-slate-800/25 pointer-events-none select-none">
+        <svg className="w-8 h-8 text-slate-600/70" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        {w > 0 && h > 0 && (
+          <span className="text-[11px] font-black uppercase tracking-widest text-slate-500">
+            Page {pageNum}
+          </span>
+        )}
+      </div>
+
       {/* Canvas is absolutely positioned and stretched to the container so the
           reserved page height is independent of whether the bitmap is painted. */}
       <canvas

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1458,10 +1458,12 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       const sh = main.scrollHeight - main.clientHeight;
       scrollRatioRef.current = sh > 0 ? main.scrollTop / sh : 0;
 
-      // Walk cumulative page heights (gap-4 = 16px between pages) to find the page under
-      // the viewport centre without forcing layout per page. Seed the starting offset
-      // from the page column's actual position so error banners above it don't skew it.
-      const GAP = 16;
+      // Walk cumulative page heights to find the page under the viewport centre without
+      // forcing layout per page. Seed the starting offset from the page column's actual
+      // position so error banners above it don't skew it. The inter-page gap scales with
+      // zoom (see the page column's rowGap) so the pinch transform and the committed
+      // layout stay geometrically identical.
+      const GAP = 16 * zoomRef.current;
       const colW = Math.min(availWidthRef.current || 0, 1400) * zoomRef.current;
       const dims = pageDimsRef.current;
       const center = main.scrollTop + main.clientHeight / 2;
@@ -3116,7 +3118,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         )}
 
         {!isLoadingPdf && !pdfError && (
-          <div ref={zoomLayerRef} className="flex flex-col items-center gap-4 origin-top">
+          <div ref={zoomLayerRef} className="flex flex-col items-center origin-top" style={{ rowGap: `${16 * zoomLevel}px` }}>
           {Array.from({ length: numPages }, (_, i) => {
             const p = i + 1;
             const { width: w, height: h } = getDisplaySize(p);

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1157,6 +1157,10 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const scrollRafRef = useRef(0);
   const drawingPtrRef = useRef<number | null>(null);
   const touchPtsRef   = useRef<Map<number, { x: number; y: number }>>(new Map());
+  // Authoritative count of fingers on screen, maintained from native touch events
+  // (e.touches). Pinch is driven from this, never inferred from pointer-event tracking,
+  // so a single-finger scroll can never be mistaken for a two-finger pinch.
+  const activeTouchCountRef = useRef(0);
   const isPinchRef    = useRef(false);
   const pinchDistRef  = useRef(0);
   // Wrapper around the page column that receives a transient CSS transform during a
@@ -1714,12 +1718,89 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     return () => window.removeEventListener('wheel', onWheel);
   }, []);
 
-  // Touch-based pan for mobile: attach direct touch listeners on the canvas container.
-  // iOS Safari can fire pointercancel instead of pointermove when setPointerCapture is
-  // combined with touchAction:'none', making the pointer-event pan unreliable.
-  // Single-finger touch ALWAYS scrolls regardless of the active tool — drawing only
-  // happens via pen/stylus (pointerType==='pen') or mouse events.  Scroll is suppressed
-  // only while a pen/mouse draw gesture is actively in progress (drawingPtrRef !== null).
+  // ── Pinch-to-zoom (driven by native touch events for accurate finger tracking) ──
+  // During the gesture only a cheap CSS transform is applied to the page column; the
+  // real zoom + re-rasterization happens once, on release, anchored at the focus.
+  const beginPinch = useCallback((p1: { x: number; y: number }, p2: { x: number; y: number }) => {
+    const fx = (p1.x + p2.x) / 2, fy = (p1.y + p2.y) / 2;
+    isPinchRef.current = true;
+    pinchDistRef.current = Math.hypot(p1.x - p2.x, p1.y - p2.y) || 1;
+    pinchScaleRef.current = 1;
+    pinchStartFocalRef.current = { x: fx, y: fy };
+    pinchCurrentFocalRef.current = { x: fx, y: fy };
+    // Cancel any single-finger draw that was in progress when the pinch began.
+    if (drawingPtrRef.current !== null) {
+      drawingPtrRef.current = null;
+      setIsDrawing(false); setPenPoints([]); setPreviewData(null); setDrawStart(null);
+    }
+    // Resolve the page + normalized point under the focus for post-zoom re-anchoring.
+    let anchorEl = (document.elementFromPoint(fx, fy) as HTMLElement | null)?.closest('[data-page]') as HTMLElement | null;
+    if (!anchorEl) {
+      pageContainerRefs.current.forEach(c => {
+        const cr = c.getBoundingClientRect();
+        if (fx >= cr.left && fx <= cr.right && fy >= cr.top && fy <= cr.bottom) anchorEl = c;
+      });
+    }
+    if (anchorEl) {
+      const r = anchorEl.getBoundingClientRect();
+      pinchAnchorRef.current = {
+        pageNum: Number(anchorEl.dataset.page) || 1,
+        nx: r.width ? Math.max(0, Math.min(1, (fx - r.left) / r.width)) : 0.5,
+        ny: r.height ? Math.max(0, Math.min(1, (fy - r.top) / r.height)) : 0.5,
+      };
+    } else {
+      pinchAnchorRef.current = null;
+    }
+    const layer = zoomLayerRef.current;
+    if (layer) {
+      const zr = layer.getBoundingClientRect();
+      pinchOriginRef.current = { x: fx - zr.left, y: fy - zr.top };
+      layer.style.transformOrigin = `${pinchOriginRef.current.x}px ${pinchOriginRef.current.y}px`;
+      layer.style.willChange = 'transform';
+    }
+  }, []);
+
+  const updatePinch = useCallback((p1: { x: number; y: number }, p2: { x: number; y: number }) => {
+    if (!isPinchRef.current) return;
+    const fx = (p1.x + p2.x) / 2, fy = (p1.y + p2.y) / 2;
+    const dist = Math.hypot(p1.x - p2.x, p1.y - p2.y);
+    pinchCurrentFocalRef.current = { x: fx, y: fy };
+    const rawS = dist / (pinchDistRef.current || 1);
+    const targetZoom = Math.max(0.25, Math.min(4.0, (zoomRef.current || 1) * rawS));
+    const s = targetZoom / (zoomRef.current || 1);
+    pinchScaleRef.current = s;
+    const layer = zoomLayerRef.current;
+    if (layer) {
+      const dx = fx - pinchStartFocalRef.current.x;
+      const dy = fy - pinchStartFocalRef.current.y;
+      layer.style.transform = `translate(${dx}px, ${dy}px) scale(${s})`;
+    }
+  }, []);
+
+  // Commit a pinch: turn the transient transform into a real zoom level and queue a
+  // focal re-anchor so the point under the fingers stays put after re-layout.
+  const finalizePinch = useCallback(() => {
+    if (!isPinchRef.current) return;
+    isPinchRef.current = false;
+    const layer = zoomLayerRef.current;
+    if (layer) { layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = ''; }
+    const s = pinchScaleRef.current;
+    pinchScaleRef.current = 1;
+    const anchor = pinchAnchorRef.current;
+    pinchAnchorRef.current = null;
+    if (Math.abs(s - 1) < 0.002) return; // negligible change
+    const newZoom = Math.max(0.25, Math.min(4.0, (zoomRef.current || 1) * s));
+    if (Math.abs(newZoom - zoomRef.current) < 0.0005) return;
+    if (anchor) {
+      const f = pinchCurrentFocalRef.current;
+      pendingZoomAnchorRef.current = { pageNum: anchor.pageNum, nx: anchor.nx, ny: anchor.ny, fx: f.x, fy: f.y };
+    }
+    setZoomLevel(newZoom);
+  }, []);
+
+  // Touch-based pan + pinch for mobile (native touch events: e.touches is authoritative).
+  // Single finger over a nav tool scrolls; two fingers pinch-zoom. Pen/mouse drawing is
+  // handled separately via pointer events.
   useEffect(() => {
     if (isLoadingPdf) return;
     const main = mainRef.current;
@@ -1728,6 +1809,16 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     let startX = 0, startY = 0, startSL = 0, startST = 0, panning = false;
 
     const onTouchStart = (e: TouchEvent) => {
+      activeTouchCountRef.current = e.touches.length;
+      if (e.touches.length >= 2) {
+        panning = false;
+        beginPinch(
+          { x: e.touches[0].clientX, y: e.touches[0].clientY },
+          { x: e.touches[1].clientX, y: e.touches[1].clientY },
+        );
+        e.preventDefault();
+        return;
+      }
       // Only scroll for nav tools (pan/select). When a drawing tool is active, let
       // pointer events handle the gesture so the user can draw with their finger.
       const isNavTool = currentToolRef.current === 'pan' || currentToolRef.current === 'select';
@@ -1740,14 +1831,28 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     };
 
     const onTouchMove = (e: TouchEvent) => {
-      // If a handle drag has claimed the pointer, stop scrolling and let pointer events handle it.
+      activeTouchCountRef.current = e.touches.length;
+      // Two fingers → pinch-zoom.
+      if (e.touches.length >= 2) {
+        const p1 = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        const p2 = { x: e.touches[1].clientX, y: e.touches[1].clientY };
+        if (!isPinchRef.current) beginPinch(p1, p2); else updatePinch(p1, p2);
+        e.preventDefault();
+        return;
+      }
+      // One finger → scroll (only while a pan/select gesture is active).
       if (!panning || e.touches.length !== 1 || drawingPtrRef.current !== null) { panning = false; return; }
       e.preventDefault();
       main.scrollLeft = startSL - (e.touches[0].clientX - startX);
       main.scrollTop  = startST - (e.touches[0].clientY - startY);
     };
 
-    const onTouchEnd = () => { panning = false; };
+    const onTouchEnd = (e: TouchEvent) => {
+      activeTouchCountRef.current = e.touches.length;
+      // A finger lifting out of a two-finger gesture commits the zoom.
+      if (isPinchRef.current && e.touches.length < 2) finalizePinch();
+      if (e.touches.length === 0) panning = false;
+    };
 
     main.addEventListener('touchstart',  onTouchStart, { passive: false });
     main.addEventListener('touchmove',   onTouchMove,  { passive: false });
@@ -1760,7 +1865,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       main.removeEventListener('touchend',    onTouchEnd);
       main.removeEventListener('touchcancel', onTouchEnd);
     };
-  }, [isLoadingPdf]);
+  }, [isLoadingPdf, beginPinch, updatePinch, finalizePinch]);
 
   // ── Pointer Events (Apple Pencil + palm rejection + pinch-to-zoom) ──
   const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
@@ -1773,17 +1878,12 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     activePageRef.current = pageNum;
     setActivePage(pageNum);
 
+    // Two or more fingers down → the native touch listener owns the gesture (pinch).
+    // Ignore the pointer event so it never starts a draw/select.
+    if (e.pointerType === 'touch' && activeTouchCountRef.current >= 2) return;
+
     // Palm rejection: if pen is active, ignore new touch contacts
     if (drawingPtrRef.current !== null && e.pointerType === 'touch') return;
-
-    // Two touch fingers → start pinch, cancel draw
-    if (e.pointerType === 'touch' && touchPtsRef.current.size === 2) {
-      if (drawingPtrRef.current !== null) {
-        setIsDrawing(false); setPenPoints([]); setPreviewData(null); setDrawStart(null);
-        drawingPtrRef.current = null;
-      }
-      return;
-    }
 
     // Touch + pan always yields to the touch-scroll listener.
     if (e.pointerType === 'touch' && currentTool === 'pan') return;
@@ -1906,66 +2006,11 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   }, [currentTool, annotations, pendingAnnotations, getCoords]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // While two or more fingers are down, the native touch listener owns the gesture
+    // (pinch-zoom) — ignore pointer moves so nothing else reacts to it.
+    if (e.pointerType === 'touch' && activeTouchCountRef.current >= 2) return;
     touchPtsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     shiftPressedRef.current = e.shiftKey;
-
-    // Pinch-to-zoom: two touch points. Apply a transient GPU transform to the page
-    // column during the gesture (smooth, no re-render); the real zoom + re-rasterize
-    // happens once, on release, anchored at the pinch focus.
-    if (touchPtsRef.current.size >= 2) {
-      const [a, b] = [...touchPtsRef.current.values()];
-      const dist = Math.hypot(a.x - b.x, a.y - b.y);
-      const fx = (a.x + b.x) / 2, fy = (a.y + b.y) / 2;
-      const layer = zoomLayerRef.current;
-      if (!isPinchRef.current) {
-        // Cancel any single-finger draw that was in progress when the pinch began.
-        if (drawingPtrRef.current !== null) {
-          drawingPtrRef.current = null;
-          setIsDrawing(false); setPenPoints([]); setPreviewData(null); setDrawStart(null);
-        }
-        isPinchRef.current = true;
-        pinchDistRef.current = dist;
-        pinchScaleRef.current = 1;
-        pinchStartFocalRef.current = { x: fx, y: fy };
-        pinchCurrentFocalRef.current = { x: fx, y: fy };
-        // Resolve the page + normalized point under the focus for post-zoom re-anchoring.
-        let anchorEl = (document.elementFromPoint(fx, fy) as HTMLElement | null)?.closest('[data-page]') as HTMLElement | null;
-        if (!anchorEl) {
-          pageContainerRefs.current.forEach(c => {
-            const cr = c.getBoundingClientRect();
-            if (fx >= cr.left && fx <= cr.right && fy >= cr.top && fy <= cr.bottom) anchorEl = c;
-          });
-        }
-        if (anchorEl) {
-          const r = anchorEl.getBoundingClientRect();
-          pinchAnchorRef.current = {
-            pageNum: Number(anchorEl.dataset.page) || 1,
-            nx: r.width ? Math.max(0, Math.min(1, (fx - r.left) / r.width)) : 0.5,
-            ny: r.height ? Math.max(0, Math.min(1, (fy - r.top) / r.height)) : 0.5,
-          };
-        } else {
-          pinchAnchorRef.current = null;
-        }
-        if (layer) {
-          const zr = layer.getBoundingClientRect();
-          pinchOriginRef.current = { x: fx - zr.left, y: fy - zr.top };
-          layer.style.transformOrigin = `${pinchOriginRef.current.x}px ${pinchOriginRef.current.y}px`;
-          layer.style.willChange = 'transform';
-        }
-      } else {
-        pinchCurrentFocalRef.current = { x: fx, y: fy };
-        const rawS = dist / (pinchDistRef.current || 1);
-        const targetZoom = Math.max(0.25, Math.min(4.0, zoomRef.current * rawS));
-        const s = targetZoom / (zoomRef.current || 1);
-        pinchScaleRef.current = s;
-        if (layer) {
-          const dx = fx - pinchStartFocalRef.current.x;
-          const dy = fy - pinchStartFocalRef.current.y;
-          layer.style.transform = `translate(${dx}px, ${dy}px) scale(${s})`;
-        }
-      }
-      return;
-    }
 
     // Handle drag: update annotation geometry live while dragging a control point
     if (dragHandleRef.current && drawingPtrRef.current === e.pointerId) {
@@ -2029,35 +2074,11 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
   }, [currentTool, isDrawing, drawStart, getCoords, zoomLevel, annotations, pendingAnnotations]);
 
-  // Commit a pinch gesture: turn the transient transform into a real zoom level and
-  // queue a focal re-anchor so the point under the fingers stays put after re-layout.
-  const finalizePinch = useCallback(() => {
-    if (!isPinchRef.current) return;
-    isPinchRef.current = false;
-    const layer = zoomLayerRef.current;
-    if (layer) { layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = ''; }
-    const s = pinchScaleRef.current;
-    pinchScaleRef.current = 1;
-    const anchor = pinchAnchorRef.current;
-    pinchAnchorRef.current = null;
-    if (Math.abs(s - 1) < 0.002) return; // negligible change
-    const newZoom = Math.max(0.25, Math.min(4.0, (zoomRef.current || 1) * s));
-    if (Math.abs(newZoom - zoomRef.current) < 0.0005) return;
-    if (anchor) {
-      const f = pinchCurrentFocalRef.current;
-      pendingZoomAnchorRef.current = { pageNum: anchor.pageNum, nx: anchor.nx, ny: anchor.ny, fx: f.x, fy: f.y };
-    }
-    setZoomLevel(newZoom);
-  }, []);
-
   const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    // A finger lifting ends a pinch — commit the zoom now.
-    if (isPinchRef.current) {
-      touchPtsRef.current.delete(e.pointerId);
-      finalizePinch();
-      return;
-    }
     touchPtsRef.current.delete(e.pointerId);
+    // Pinch is owned by the native touch listener; a touch pointer-up during a pinch
+    // just cleans up here (it never started a draw, so there is nothing else to do).
+    if (isPinchRef.current) return;
     if (drawingPtrRef.current !== e.pointerId) return;
     drawingPtrRef.current = null; panStartRef.current = null;
 
@@ -2140,19 +2161,19 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     // Keep the current drawing tool active so the user can draw another annotation.
     // Only select the just-placed item so its bounding box is visible.
     setSelectedAnnId(placed.id);
-  }, [isDrawing, drawStart, currentTool, penPoints, getCoords, commitAnnotation, stampType, liveEditData, updateAnnotation, finalizePinch]);
+  }, [isDrawing, drawStart, currentTool, penPoints, getCoords, commitAnnotation, stampType, liveEditData, updateAnnotation]);
 
   const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     touchPtsRef.current.delete(e.pointerId);
-    // Pinch interrupted — commit whatever zoom was reached so the view doesn't snap back.
-    if (isPinchRef.current) { finalizePinch(); return; }
+    // Pinch lifecycle is owned by the native touch listener; nothing to do here for it.
+    if (isPinchRef.current) return;
     if (drawingPtrRef.current === e.pointerId) {
       drawingPtrRef.current = null;
       setIsDrawing(false); setPenPoints([]); setPreviewData(null); setDrawStart(null);
-      isPinchRef.current = false; panStartRef.current = null;
+      panStartRef.current = null;
       dragHandleRef.current = null; setLiveEditData(null);
     }
-  }, [finalizePinch]);
+  }, []);
 
   // Ctrl+scroll to zoom
   const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import * as pdfjsLib from 'pdfjs-dist';
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 import { PdfAnnotation, JobPrint, User, UserRole } from '../types.ts';
@@ -708,7 +708,9 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const [pageNumber, setPageNumber]     = useState(1);
   const [numPages, setNumPages]         = useState(0);
   const [zoomLevel, setZoomLevel]       = useState(1.0);
-  const [canvasSize, setCanvasSize]     = useState({ width: 0, height: 0 });
+  // Rendered pixel dimensions of each page's canvas, keyed by 1-based page number.
+  // Used to size the per-page SVG overlay and denormalize annotation coordinates.
+  const [pageSizes, setPageSizes]       = useState<Map<number, { width: number; height: number }>>(new Map());
   const [isDrawing, setIsDrawing]       = useState(false);
   const [drawStart, setDrawStart]       = useState<{ x: number; y: number } | null>(null);
   const [penPoints, setPenPoints]       = useState<Array<{ x: number; y: number; pressure?: number }>>([]);
@@ -737,13 +739,21 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const [scaleUnit, setScaleUnit] = useState('ft');
   const [editingAnnId, setEditingAnnId] = useState<string | null>(null);
 
-  const canvasRef     = useRef<HTMLCanvasElement>(null);
-  const containerRef  = useRef<HTMLDivElement>(null);
+  // Per-page DOM refs (continuous-scroll mode renders every page at once).
+  const pageCanvasRefs    = useRef<Map<number, HTMLCanvasElement>>(new Map());
+  const pageContainerRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  // The page the current pointer gesture is acting on — resolved at pointer-down
+  // from the target page container's data-page attribute. Drives getCoords, new
+  // annotation placement, and which page renders live drawing previews.
+  const activePageRef = useRef(1);
   const mainRef       = useRef<HTMLDivElement>(null);
   const textFieldRef  = useRef<HTMLInputElement>(null);
   const scaleInputRef = useRef<HTMLInputElement>(null);
   const pdfDocRef     = useRef<pdfjsLib.PDFDocumentProxy | null>(null);
-  const renderTaskRef = useRef<pdfjsLib.RenderTask | null>(null);
+  // Active pdf.js render tasks keyed by page number, so re-renders can cancel cleanly.
+  const renderTasksRef = useRef<Map<number, pdfjsLib.RenderTask>>(new Map());
+  // Monotonic token to discard results from superseded render passes (e.g. fast zooming).
+  const renderTokenRef = useRef(0);
   const drawingPtrRef = useRef<number | null>(null);
   const touchPtsRef   = useRef<Map<number, { x: number; y: number }>>(new Map());
   const isPinchRef    = useRef(false);
@@ -768,10 +778,6 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   // Stable ref to currentTool for use in non-reactive callbacks (e.g., touch listeners)
   const currentToolRef = useRef<ToolType>(currentTool);
   currentToolRef.current = currentTool;
-  // Scroll ratio saved just before canvas resize so useLayoutEffect can restore it
-  const scrollRestoreRef = useRef<{ ratioX: number; ratioY: number } | null>(null);
-  // Tracks the page number of the last completed render to detect page-change vs zoom-change
-  const lastRenderedPageRef = useRef(0);
 
   // Load annotations
   useEffect(() => {
@@ -834,55 +840,79 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     return () => { cancelled = true; };
   }, [print.storagePath, print.url]);
 
-  // Render page at current zoom
-  const renderPage = useCallback(async (pageNum: number, zoom: number) => {
-    if (!pdfDocRef.current || !canvasRef.current) return;
-    if (renderTaskRef.current) { renderTaskRef.current.cancel(); renderTaskRef.current = null; }
-    try {
-      const page  = await pdfDocRef.current.getPage(pageNum);
-      const avail = (mainRef.current?.clientWidth ?? window.innerWidth) - 48;
-      const base  = page.getViewport({ scale: 1 });
-      const scale = (Math.min(avail, 1400) / base.width) * zoom;
-      const vp    = page.getViewport({ scale });
-      const canvas = canvasRef.current;
-      // Only preserve scroll when re-rendering the same page (zoom change). When the
-      // page number changes the scroll container should reset to the top naturally.
-      if (mainRef.current && pageNum === lastRenderedPageRef.current) {
-        const m = mainRef.current;
-        const scrollH = m.scrollHeight - m.clientHeight;
-        const scrollW = m.scrollWidth  - m.clientWidth;
-        scrollRestoreRef.current = {
-          ratioX: scrollW > 0 ? m.scrollLeft / scrollW : 0,
-          ratioY: scrollH > 0 ? m.scrollTop  / scrollH : 0,
-        };
-      } else {
-        scrollRestoreRef.current = null;
-      }
-      lastRenderedPageRef.current = pageNum;
-      canvas.width = vp.width; canvas.height = vp.height;
-      setCanvasSize({ width: vp.width, height: vp.height });
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
-      const task = page.render({ canvasContext: ctx, viewport: vp });
-      renderTaskRef.current = task;
-      await task.promise;
-      renderTaskRef.current = null;
-    } catch { /* cancelled */ }
+  // Render every page at the current zoom into its own stacked canvas.
+  // Pages share a single column width so the document scrolls continuously.
+  const renderAllPages = useCallback(async (zoom: number) => {
+    const pdf = pdfDocRef.current;
+    if (!pdf) return;
+    const token = ++renderTokenRef.current;
+    const main  = mainRef.current;
+
+    // Preserve the scroll anchor across a zoom-driven re-render so the page the
+    // user is looking at stays roughly in view after every canvas resizes.
+    let ratioX = 0, ratioY = 0;
+    if (main) {
+      const scrollW = main.scrollWidth  - main.clientWidth;
+      const scrollH = main.scrollHeight - main.clientHeight;
+      ratioX = scrollW > 0 ? main.scrollLeft / scrollW : 0;
+      ratioY = scrollH > 0 ? main.scrollTop  / scrollH : 0;
+    }
+
+    const avail = (main?.clientWidth ?? window.innerWidth) - 48;
+    const sizes = new Map(pageSizes);
+    for (let p = 1; p <= pdf.numPages; p++) {
+      const canvas = pageCanvasRefs.current.get(p);
+      if (!canvas) continue;
+      const prev = renderTasksRef.current.get(p);
+      if (prev) { prev.cancel(); renderTasksRef.current.delete(p); }
+      try {
+        const page  = await pdf.getPage(p);
+        if (token !== renderTokenRef.current) return;
+        const base  = page.getViewport({ scale: 1 });
+        const scale = (Math.min(avail, 1400) / base.width) * zoom;
+        const vp    = page.getViewport({ scale });
+        canvas.width = vp.width; canvas.height = vp.height;
+        sizes.set(p, { width: vp.width, height: vp.height });
+        const ctx = canvas.getContext('2d');
+        if (!ctx) continue;
+        const task = page.render({ canvasContext: ctx, viewport: vp });
+        renderTasksRef.current.set(p, task);
+        await task.promise;
+        renderTasksRef.current.delete(p);
+      } catch { /* cancelled */ }
+    }
+    if (token !== renderTokenRef.current) return;
+    setPageSizes(sizes);
+
+    if (main) {
+      requestAnimationFrame(() => {
+        main.scrollLeft = ratioX * Math.max(0, main.scrollWidth  - main.clientWidth);
+        main.scrollTop  = ratioY * Math.max(0, main.scrollHeight - main.clientHeight);
+      });
+    }
+  // pageSizes intentionally omitted: it is seeded fresh each pass and including it
+  // would re-create the callback on every render it performs.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    if (!isLoadingPdf && pdfDocRef.current) renderPage(pageNumber, zoomLevel);
-  }, [pageNumber, zoomLevel, isLoadingPdf, renderPage]);
+    if (!isLoadingPdf && pdfDocRef.current) renderAllPages(zoomLevel);
+  }, [zoomLevel, isLoadingPdf, numPages, renderAllPages]);
 
-  // Restore scroll position after canvas resize (runs synchronously before paint)
-  useLayoutEffect(() => {
-    if (!scrollRestoreRef.current || !mainRef.current) return;
-    const { ratioX, ratioY } = scrollRestoreRef.current;
-    scrollRestoreRef.current = null;
-    const m = mainRef.current;
-    m.scrollLeft = ratioX * Math.max(0, m.scrollWidth  - m.clientWidth);
-    m.scrollTop  = ratioY * Math.max(0, m.scrollHeight - m.clientHeight);
-  }, [canvasSize]);
+  // Track the page most centered in the viewport so the header indicator stays accurate
+  // as the user scrolls through the document.
+  const handleScroll = useCallback(() => {
+    const main = mainRef.current;
+    if (!main) return;
+    const viewportCenter = main.scrollTop + main.clientHeight / 2;
+    let best = 1, bestDist = Infinity;
+    pageContainerRefs.current.forEach((el, p) => {
+      const center = el.offsetTop + el.offsetHeight / 2;
+      const dist = Math.abs(center - viewportCenter);
+      if (dist < bestDist) { bestDist = dist; best = p; }
+    });
+    setPageNumber(prev => (prev === best ? prev : best));
+  }, []);
 
   // Undo
   const handleUndo = useCallback(async () => {
@@ -913,11 +943,12 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     setCanUndo(true);
   }, []);
 
-  const getCoords = useCallback((clientX: number, clientY: number) => {
-    // Use the canvas element directly so coordinates map exactly to the
-    // rendered surface — avoids any potential size mismatch with the wrapper div.
-    if (!canvasRef.current) return { x: 0, y: 0 };
-    return getRelativeCoords(clientX, clientY, canvasRef.current);
+  const getCoords = useCallback((clientX: number, clientY: number, pageNum?: number) => {
+    // Map to the canvas of the page being interacted with so coordinates align
+    // exactly with the rendered surface, regardless of which stacked page it is.
+    const canvas = pageCanvasRefs.current.get(pageNum ?? activePageRef.current);
+    if (!canvas) return { x: 0, y: 0 };
+    return getRelativeCoords(clientX, clientY, canvas);
   }, []);
 
   // Stage annotation locally; persisted to DB only when the user clicks Save.
@@ -929,7 +960,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       id: generateTempId(), createdAt: Date.now(),
       printId: print.id, companyId: sessionUser.companyId,
       authorId: sessionUser.id, authorName: sessionUser.name,
-      pageNumber, toolType: tool, color: currentColor, strokeWidth,
+      pageNumber: activePageRef.current, toolType: tool, color: currentColor, strokeWidth,
       data: finalData as Record<string, unknown>,
     };
     setPendingAnnotations(prev => [...prev, staged]);
@@ -938,7 +969,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     redoStackRef.current = [];
     setCanUndo(true); setCanRedo(false);
     return staged;
-  }, [print.id, sessionUser, pageNumber, currentTool, currentColor, strokeWidth, opacity]);
+  }, [print.id, sessionUser, currentTool, currentColor, strokeWidth, opacity]);
 
   // Delete annotation — handle both staged (tmp-) and persisted items
   const handleDeleteAnnotation = useCallback(async (id: string) => {
@@ -1172,9 +1203,8 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   // only while a pen/mouse draw gesture is actively in progress (drawingPtrRef !== null).
   useEffect(() => {
     if (isLoadingPdf) return;
-    const container = containerRef.current;
     const main = mainRef.current;
-    if (!container || !main) return;
+    if (!main) return;
 
     let startX = 0, startY = 0, startSL = 0, startST = 0, panning = false;
 
@@ -1200,16 +1230,16 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
 
     const onTouchEnd = () => { panning = false; };
 
-    container.addEventListener('touchstart',  onTouchStart, { passive: false });
-    container.addEventListener('touchmove',   onTouchMove,  { passive: false });
-    container.addEventListener('touchend',    onTouchEnd,   { passive: true });
-    container.addEventListener('touchcancel', onTouchEnd,   { passive: true });
+    main.addEventListener('touchstart',  onTouchStart, { passive: false });
+    main.addEventListener('touchmove',   onTouchMove,  { passive: false });
+    main.addEventListener('touchend',    onTouchEnd,   { passive: true });
+    main.addEventListener('touchcancel', onTouchEnd,   { passive: true });
 
     return () => {
-      container.removeEventListener('touchstart',  onTouchStart);
-      container.removeEventListener('touchmove',   onTouchMove);
-      container.removeEventListener('touchend',    onTouchEnd);
-      container.removeEventListener('touchcancel', onTouchEnd);
+      main.removeEventListener('touchstart',  onTouchStart);
+      main.removeEventListener('touchmove',   onTouchMove);
+      main.removeEventListener('touchend',    onTouchEnd);
+      main.removeEventListener('touchcancel', onTouchEnd);
     };
   }, [isLoadingPdf]);
 
@@ -1217,6 +1247,12 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     setInputDevice(e.pointerType);
     touchPtsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    // Resolve which stacked page this gesture is acting on so coordinates,
+    // previews, and new annotations all bind to the correct page.
+    const pageNum = Number(e.currentTarget.dataset.page) || 1;
+    activePageRef.current = pageNum;
+    setPageNumber(pageNum);
 
     // Palm rejection: if pen is active, ignore new touch contacts
     if (drawingPtrRef.current !== null && e.pointerType === 'touch') return;
@@ -1248,7 +1284,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       drawingPtrRef.current = e.pointerId;
     }
 
-    const coords = getCoords(e.clientX, e.clientY);
+    const coords = getCoords(e.clientX, e.clientY, pageNum);
 
     if (currentTool === 'pan') {
       panStartRef.current = {
@@ -1260,7 +1296,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
 
     if (currentTool === 'select') {
-      const pageAnns = [...annotations, ...pendingAnnotations].filter(a => a.pageNumber === pageNumber);
+      const pageAnns = [...annotations, ...pendingAnnotations].filter(a => a.pageNumber === pageNum);
       // 1. Check if tapping a control-point handle on the selected annotation.
       //    Use selectedAnnIdRef (stable ref) so this callback never reads a stale closure value.
       //    Find the NEAREST handle (not the first) and only capture the event if the tap is NOT
@@ -1329,7 +1365,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
 
     if (currentTool === 'text') {
-      const container = containerRef.current;
+      const container = pageContainerRefs.current.get(pageNum);
       if (!container) return;
       const r = container.getBoundingClientRect();
       setTextInput({ px: e.clientX - r.left, py: e.clientY - r.top, rx: coords.x, ry: coords.y });
@@ -1348,7 +1384,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     setDrawStart(coords);
     if (currentTool === 'pen' || currentTool === 'highlighter')
       setPenPoints([{ x: coords.x, y: coords.y, pressure: e.pressure }]);
-  }, [currentTool, annotations, pendingAnnotations, pageNumber, getCoords]);
+  }, [currentTool, annotations, pendingAnnotations, getCoords]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     touchPtsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
@@ -1501,7 +1537,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
 
     // Callout: show text input at the text-box location (draw start = x1,y1)
     if (currentTool === 'callout') {
-      const container = containerRef.current;
+      const container = pageContainerRefs.current.get(activePageRef.current);
       if (!container) { setDrawStart(null); return; }
       const r = container.getBoundingClientRect();
       setTextInput({ px: e.clientX - r.left, py: e.clientY - r.top, rx: drawStart.x, ry: drawStart.y, calloutData: data });
@@ -1565,14 +1601,15 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     if (!scaleInput || !scaleValue) { setScaleInput(null); return; }
     const inputVal = parseFloat(scaleValue);
     if (isNaN(inputVal) || inputVal <= 0) { setScaleInput(null); return; }
-    const ar = canvasSize.width / (canvasSize.height || 1);
+    const activeSize = pageSizes.get(activePageRef.current) ?? { width: 0, height: 0 };
+    const ar = activeSize.width / (activeSize.height || 1);
     const dx = scaleInput.lineEnd.x - scaleInput.lineStart.x;
     const dy = scaleInput.lineEnd.y - scaleInput.lineStart.y;
     const normDist = Math.sqrt((dx * ar) ** 2 + dy ** 2);
     if (normDist < 0.001) { setScaleInput(null); return; }
     setScaleInfo({ unitsPerNormDist: inputVal / normDist, aspectRatio: ar, unit: scaleUnit });
     setScaleInput(null); setScaleValue(''); setCurrentTool('select');
-  }, [scaleInput, scaleValue, scaleUnit, canvasSize]);
+  }, [scaleInput, scaleValue, scaleUnit, pageSizes]);
 
   const flipAnnotationH = useCallback(() => {
     const selId = selectedAnnIdRef.current;
@@ -1615,8 +1652,10 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
 
   const handleDoubleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (currentTool !== 'select') return;
-    const coords = getCoords(e.clientX, e.clientY);
-    const pageAnns = [...annotations, ...pendingAnnotations].filter(a => a.pageNumber === pageNumber);
+    const pageNum = Number(e.currentTarget.dataset.page) || activePageRef.current;
+    activePageRef.current = pageNum;
+    const coords = getCoords(e.clientX, e.clientY, pageNum);
+    const pageAnns = [...annotations, ...pendingAnnotations].filter(a => a.pageNumber === pageNum);
     let nearest: PdfAnnotation | null = null;
     let nearestScore = 0.06;
     for (const ann of [...pageAnns].reverse()) {
@@ -1625,7 +1664,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       if (score < nearestScore) { nearestScore = score; nearest = ann; }
     }
     if (!nearest) return;
-    const container = containerRef.current;
+    const container = pageContainerRefs.current.get(pageNum);
     if (!container) return;
     const r = container.getBoundingClientRect();
     const d = nearest.data as AnyAnnotationData;
@@ -1637,7 +1676,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       setTextInput({ px: e.clientX - r.left, py: e.clientY - r.top, rx: d.x1 ?? coords.x, ry: d.y1 ?? coords.y, calloutData: { x1: d.x1, y1: d.y1, x2: d.x2, y2: d.y2 } as AnyAnnotationData });
     }
     setTimeout(() => textFieldRef.current?.focus(), 30);
-  }, [currentTool, annotations, pendingAnnotations, pageNumber, getCoords]);
+  }, [currentTool, annotations, pendingAnnotations, getCoords]);
 
   // Derived
   const allDisplayAnnotations = useMemo(
@@ -1657,13 +1696,8 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
     return map;
   }, [allDisplayAnnotations]);
-  const pageAnnotations = allDisplayAnnotations.filter(
-    a => a.pageNumber === pageNumber && (filterAuthorId === null || a.authorId === filterAuthorId)
-  );
-  const selectedAnn     = pageAnnotations.find(a => a.id === selectedAnnId) ?? null;
-  const penPreviewPath  = (currentTool === 'pen' || currentTool === 'highlighter') && penPoints.length > 1 && isDrawing
-    ? penPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x * canvasSize.width} ${p.y * canvasSize.height}`).join(' ')
-    : null;
+  // Selected annotation may live on any page; resolve it globally for the toolbar.
+  const selectedAnn     = allDisplayAnnotations.find(a => a.id === selectedAnnId) ?? null;
   const canDeleteAnn = (ann: PdfAnnotation) =>
     ann.authorId === sessionUser.id || sessionUser.role === UserRole.ADMIN || sessionUser.role === UserRole.SUPER_ADMIN;
   const isNavTool  = currentTool === 'select' || currentTool === 'pan' || currentTool === 'scale';
@@ -1680,6 +1714,331 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     } else {
       setCurrentTool(id); setTextInput(null); setSelectedAnnId(null);
     }
+  };
+
+  // Renders a single stacked page: its canvas + the SVG annotation overlay.
+  // Live drawing previews and the text/scale inputs render only on the page the
+  // current gesture is acting on (activePageRef); annotations render on every page.
+  const renderPageLayer = (pageNum: number) => {
+    const size = pageSizes.get(pageNum);
+    const w = size?.width ?? 0;
+    const h = size?.height ?? 0;
+    const isActive = activePageRef.current === pageNum;
+    const pageAnns = allDisplayAnnotations.filter(
+      a => a.pageNumber === pageNum && (filterAuthorId === null || a.authorId === filterAuthorId)
+    );
+    const sel = selectedAnn && selectedAnn.pageNumber === pageNum ? selectedAnn : null;
+    const penPreviewPath = isActive && (currentTool === 'pen' || currentTool === 'highlighter') && penPoints.length > 1 && isDrawing
+      ? penPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x * w} ${p.y * h}`).join(' ')
+      : null;
+
+    return (
+      <div
+        key={pageNum}
+        data-page={pageNum}
+        ref={el => { if (el) pageContainerRefs.current.set(pageNum, el); else pageContainerRefs.current.delete(pageNum); }}
+        className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 ${toolCursor}`}
+        style={{ width: w || '100%', touchAction: 'none' }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onDoubleClick={handleDoubleClick}
+      >
+        <canvas
+          ref={el => { if (el) pageCanvasRefs.current.set(pageNum, el); else pageCanvasRefs.current.delete(pageNum); }}
+          className="block"
+        />
+
+        <svg className="absolute inset-0 pointer-events-none"
+          width={w} height={h}
+          viewBox={`0 0 ${w} ${h}`}>
+
+          {pageAnns.map(ann => {
+            const data = (ann.id === selectedAnnId && liveEditData !== null)
+              ? liveEditData
+              : ann.data as AnyAnnotationData;
+            return renderAnnotationSvg({ ...ann, data }, w, h, ann.id, scaleInfo);
+          })}
+
+          {sel && currentTool === 'select' && (() => {
+            const displayData = liveEditData ?? sel.data as AnyAnnotationData;
+            const rotation    = (displayData.rotation as number | undefined) ?? 0;
+            const handles     = getHandlesNorm({ ...sel, data: displayData });
+            const bbox        = getAnnotationBBox(sel, displayData);
+            const SELECTION_BOX_PADDING = 8;
+            // Pixel coordinates of the bbox centre (used for the rotation transform)
+            const bboxCxPx = bbox ? (bbox.x + bbox.w / 2) * w : 0;
+            const bboxCyPx = bbox ? (bbox.y + bbox.h / 2) * h : 0;
+            const rotateHandle = handles.find(hh => hh.isRotateHandle);
+            return (
+              <g>
+                {/* Dashed bounding box — rotated with the annotation */}
+                {bbox && bbox.w > 0.005 && (
+                  <g transform={rotation ? `rotate(${rotation}, ${bboxCxPx}, ${bboxCyPx})` : undefined}>
+                    <rect
+                      x={bbox.x * w - SELECTION_BOX_PADDING}
+                      y={bbox.y * h - SELECTION_BOX_PADDING}
+                      width={bbox.w * w + SELECTION_BOX_PADDING * 2}
+                      height={bbox.h * h + SELECTION_BOX_PADDING * 2}
+                      fill="none" stroke="white" strokeWidth="1.5"
+                      strokeDasharray="5 3" opacity="0.5" rx="3" />
+                  </g>
+                )}
+                {/* Stem line from bbox top-centre to the rotate handle */}
+                {bbox && bbox.w > 0.005 && rotateHandle && (() => {
+                  // Compute the rotated top-centre of the bounding box
+                  const stemBaseX = bbox.x * w + (bbox.w * w) / 2;
+                  const stemBaseY = bbox.y * h - SELECTION_BOX_PADDING;
+                  if (rotation) {
+                    const rad = (rotation * Math.PI) / 180;
+                    const cos = Math.cos(rad), sin = Math.sin(rad);
+                    const dx = stemBaseX - bboxCxPx, dy = stemBaseY - bboxCyPx;
+                    const rx = bboxCxPx + dx * cos - dy * sin;
+                    const ry = bboxCyPx + dx * sin + dy * cos;
+                    return <line x1={rx} y1={ry} x2={rotateHandle.nx * w} y2={rotateHandle.ny * h}
+                      stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
+                  }
+                  return <line x1={stemBaseX} y1={stemBaseY} x2={rotateHandle.nx * w} y2={rotateHandle.ny * h}
+                    stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
+                })()}
+                {handles.map(hh => {
+                  const cx = hh.nx * w;
+                  const cy = hh.ny * h;
+                  const isCalloutArrowTip = sel.toolType === 'callout' && !hh.isMoveHandle && !hh.isRotateHandle && hh.index === 1;
+                  const handleFill = hh.isRotateHandle ? '#22c55e'
+                    : hh.isMoveHandle ? '#6366f1'
+                    : hh.isEdgeHandle ? '#0ea5e9'
+                    : isCalloutArrowTip ? '#f59e0b'
+                    : '#3b82f6';
+                  const edgeLabel = hh.index === EDGE_HANDLE_TOP ? 'top' : hh.index === EDGE_HANDLE_RIGHT ? 'right' : hh.index === EDGE_HANDLE_BOTTOM ? 'bottom' : 'left';
+                  const handleTitle = hh.isRotateHandle
+                    ? `Rotate — drag to rotate (${Math.round(rotation)}°), hold Shift for 15° snapping`
+                    : hh.isMoveHandle
+                      ? 'Move annotation'
+                      : hh.isEdgeHandle
+                        ? `Resize ${edgeLabel} edge — drag to resize on one axis`
+                        : sel.toolType === 'callout'
+                          ? hh.index === 0 ? 'Text box — drag to reposition' : 'Arrow tip — drag to repoint'
+                          : sel.toolType === 'arrow' || sel.toolType === 'double_arrow'
+                            ? hh.index === 0 ? 'Line start — drag to adjust' : 'Arrow head — drag to adjust'
+                            : `Endpoint ${hh.index + 1} — drag to reshape`;
+                  const r = hh.isRotateHandle || hh.isMoveHandle ? 9 : 8;
+                  return (
+                    <g key={`handle-${hh.index}`}>
+                      {/* Hit-area circle (invisible, larger) */}
+                      <circle cx={cx} cy={cy} r="18" fill="transparent">
+                        <title>{handleTitle}</title>
+                      </circle>
+                      {/* Edge handles: diamond (rotated square) shape */}
+                      {hh.isEdgeHandle ? (
+                        <rect
+                          x={cx - 6} y={cy - 6} width={12} height={12}
+                          fill={handleFill} stroke="white" strokeWidth="2"
+                          transform={`rotate(45, ${cx}, ${cy})`}
+                        />
+                      ) : (
+                        /* Visible handle circle */
+                        <circle cx={cx} cy={cy} r={r} fill={handleFill} stroke="white" strokeWidth="2.5" />
+                      )}
+                      {/* Rotate handle: circular-arrow icon */}
+                      {hh.isRotateHandle && (
+                        <g transform={`translate(${cx}, ${cy})`} stroke="white" strokeWidth="1.5" strokeLinecap="round" fill="none">
+                          <path d="M -4 -3 A 5 5 0 1 1 3.5 -3.5" />
+                          <polyline points="3.5,-3.5 5.5,-1.5 5.5,-5" />
+                        </g>
+                      )}
+                      {/* Move handle: cross icon */}
+                      {hh.isMoveHandle && (
+                        <g stroke="white" strokeWidth="1.5" strokeLinecap="round">
+                          <line x1={cx - 4} y1={cy} x2={cx + 4} y2={cy} />
+                          <line x1={cx} y1={cy - 4} x2={cx} y2={cy + 4} />
+                        </g>
+                      )}
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          })()}
+
+          {pageAnns.map(ann => {
+            const anchor = getAnnotationAnchor(ann);
+            if (!anchor) return null;
+            const initials  = getInitials(ann.authorName);
+            const bw        = initials.length * 7 + 10;
+            const bx        = anchor.x * w;
+            const by        = anchor.y * h;
+            const isPending = ann.id.startsWith('tmp-');
+            return (
+              <g key={`badge-${ann.id}`}>
+                <rect x={bx} y={by - 17} width={bw} height={17} rx="3"
+                  fill={ann.color} opacity={isPending ? 0.5 : 0.88}
+                  stroke={isPending ? 'white' : 'none'} strokeWidth={isPending ? 1 : 0}
+                  strokeDasharray={isPending ? '3 2' : undefined} />
+                <text x={bx + 5} y={by - 3} fontSize="11" fontFamily="monospace" fontWeight="bold" fill="white">
+                  {initials}
+                </text>
+              </g>
+            );
+          })}
+
+          {penPreviewPath && (
+            <path d={penPreviewPath} stroke={currentColor}
+              strokeWidth={currentTool === 'highlighter' ? strokeWidth * 5 : strokeWidth}
+              fill="none" strokeLinecap="round" strokeLinejoin="round"
+              opacity={currentTool === 'highlighter' ? opacity * 0.35 : opacity * 0.75} />
+          )}
+
+          {isActive && previewData && currentTool !== 'pen' && currentTool !== 'highlighter' && currentTool !== 'scale' &&
+            renderAnnotationSvg({ toolType: currentTool, color: currentColor, strokeWidth, data: previewData },
+              w, h, 'preview', scaleInfo)
+          }
+
+          {isActive && isDrawing && currentTool === 'scale' && previewData && (
+            <line
+              x1={(previewData.x1 ?? 0) * w} y1={(previewData.y1 ?? 0) * h}
+              x2={(previewData.x2 ?? 0) * w} y2={(previewData.y2 ?? 0) * h}
+              stroke="#fbbf24" strokeWidth="2" strokeDasharray="6 3" strokeLinecap="round" opacity="0.9"
+            />
+          )}
+
+          {isActive && scaleInput && (
+            <line
+              x1={scaleInput.lineStart.x * w} y1={scaleInput.lineStart.y * h}
+              x2={scaleInput.lineEnd.x * w} y2={scaleInput.lineEnd.y * h}
+              stroke="#fbbf24" strokeWidth="2.5" strokeDasharray="6 3" strokeLinecap="round"
+            />
+          )}
+
+          {/* Start-point crosshair while drawing lines / callout / shapes */}
+          {isActive && isDrawing && drawStart && !['pen', 'highlighter', 'text', 'stamp', 'select', 'pan'].includes(currentTool) && (
+            <g>
+              <circle cx={drawStart.x * w} cy={drawStart.y * h}
+                r="5" fill={currentColor} stroke="white" strokeWidth="2" opacity="0.9" />
+              <line x1={drawStart.x * w - 10} y1={drawStart.y * h}
+                x2={drawStart.x * w + 10} y2={drawStart.y * h}
+                stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
+              <line x1={drawStart.x * w} y1={drawStart.y * h - 10}
+                x2={drawStart.x * w} y2={drawStart.y * h + 10}
+                stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
+            </g>
+          )}
+
+          {/* Angle badge for line-type tools while drawing */}
+          {isActive && isDrawing && previewData && (
+            currentTool === 'line' || currentTool === 'dashed_line' ||
+            currentTool === 'arrow' || currentTool === 'double_arrow' ||
+            currentTool === 'dimension' || currentTool === 'callout'
+          ) && (() => {
+            const x2px = (previewData.x2 ?? 0) * w;
+            const y2px = (previewData.y2 ?? 0) * h;
+            const dx = ((previewData.x2 ?? 0) - (previewData.x1 ?? 0)) * w;
+            const dy = ((previewData.y2 ?? 0) - (previewData.y1 ?? 0)) * h;
+            const angleDeg = ((Math.round(Math.atan2(dy, dx) * 180 / Math.PI) % 360) + 360) % 360;
+            const bx = Math.min(x2px + 12, w - 52);
+            const by = y2px > 20 ? y2px - 8 : y2px + 26;
+            return (
+              <g opacity="0.92">
+                <rect x={bx} y={by - 13} width={44} height={16} rx="4" fill="rgba(0,0,0,0.72)" />
+                <text x={bx + 5} y={by - 1} fontSize="11" fill="white" fontFamily="monospace" fontWeight="bold">
+                  {angleDeg}°
+                </text>
+              </g>
+            );
+          })()}
+
+          {/* Ghost callout preview while the text input is open */}
+          {isActive && textInput && textInput.calloutData && (
+            renderAnnotationSvg({
+              toolType: 'callout', color: currentColor, strokeWidth,
+              data: { ...textInput.calloutData, text: textValue.trim() || ' ', fontSize },
+            }, w, h, 'callout-ghost')
+          )}
+
+          {/* Scale bar */}
+          {scaleInfo && w > 0 && (() => {
+            const targetPx = w * 0.15;
+            const rawUnits = (targetPx / h) * scaleInfo.unitsPerNormDist;
+            const nices = [0.25,0.5,1,2,5,10,20,25,50,100,200,500,1000];
+            const nice = nices.reduce((a, b) => Math.abs(b - rawUnits) < Math.abs(a - rawUnits) ? b : a);
+            const barPx = (nice / scaleInfo.unitsPerNormDist) * h;
+            const barX = 16, barY = h - 16;
+            const label = `${nice} ${scaleInfo.unit}`;
+            const lblW = label.length * 6 + 12;
+            return (
+              <g opacity="0.9">
+                <rect x={barX - 4} y={barY - 24} width={Math.max(barPx + 8, lblW + 8)} height={28} rx="4" fill="rgba(0,0,0,0.72)" />
+                <line x1={barX} y1={barY - 10} x2={barX + barPx} y2={barY - 10} stroke="white" strokeWidth="2" />
+                <line x1={barX} y1={barY - 16} x2={barX} y2={barY - 4} stroke="white" strokeWidth="2" />
+                <line x1={barX + barPx} y1={barY - 16} x2={barX + barPx} y2={barY - 4} stroke="white" strokeWidth="2" />
+                <text x={barX + barPx / 2} y={barY} textAnchor="middle" fill="white" fontSize="9" fontFamily="monospace" fontWeight="bold">{label}</text>
+              </g>
+            );
+          })()}
+        </svg>
+
+        {isActive && scaleInput && (
+          <div className="absolute bg-slate-900 border border-white/20 rounded-xl p-4 shadow-2xl z-20 w-60"
+            style={{ left: Math.min(w - 248, Math.max(0, scaleInput.lineEnd.x * w - 120)),
+                     top: Math.min(h - 120, Math.max(0, scaleInput.lineEnd.y * h + 16)) }}>
+            <p className="text-[10px] text-brand font-black uppercase tracking-widest mb-3">Set Scale Reference</p>
+            <p className="text-[9px] text-slate-400 mb-2">What length does this line represent?</p>
+            <div className="flex gap-2 mb-3">
+              <input ref={scaleInputRef} type="number" min="0.001" step="any" value={scaleValue}
+                onChange={e => setScaleValue(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') handleScaleConfirm(); if (e.key === 'Escape') setScaleInput(null); }}
+                placeholder="Distance"
+                className="flex-1 bg-slate-800 text-white rounded-lg px-2 py-1.5 text-sm border border-white/10 outline-none focus:border-brand min-w-0" />
+              <select value={scaleUnit} onChange={e => setScaleUnit(e.target.value)}
+                className="bg-slate-800 text-white rounded-lg px-2 text-sm border border-white/10 outline-none focus:border-brand shrink-0">
+                <option value="ft">ft</option>
+                <option value="in">in</option>
+                <option value="yd">yd</option>
+                <option value="m">m</option>
+                <option value="cm">cm</option>
+                <option value="mm">mm</option>
+              </select>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={handleScaleConfirm}
+                className="flex-1 bg-brand text-slate-900 rounded-lg py-1.5 text-[11px] font-black hover:brightness-110 transition-all">
+                Set Scale
+              </button>
+              <button onClick={() => { setScaleInput(null); setScaleValue(''); }}
+                className="px-3 bg-slate-800 text-slate-300 hover:bg-slate-700 rounded-lg py-1.5 text-[11px] font-black transition-all">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {isActive && textInput && (
+          <input
+            ref={textFieldRef}
+            type="text"
+            value={textValue}
+            onChange={e => setTextValue(e.target.value)}
+            onBlur={handleTextSubmit}
+            onKeyDown={e => {
+              if (e.key === 'Enter') handleTextSubmit();
+              if (e.key === 'Escape') { setTextInput(null); setTextValue(''); }
+            }}
+            className="absolute bg-black/50 backdrop-blur rounded px-2 py-1 border border-dashed outline-none z-10 font-bold"
+            style={{
+              left: textInput.calloutData
+                ? Math.min(w - 172, Math.max(4, textInput.rx * w - 80))
+                : textInput.px,
+              top: textInput.calloutData
+                ? Math.min(h - 40, Math.max(4, textInput.ry * h - fontSize - 14))
+                : textInput.py - 16,
+              color: currentColor, borderColor: currentColor, fontSize: fontSize + 'px', minWidth: '160px',
+            }}
+            placeholder={textInput.calloutData ? 'Callout text, then Enter…' : 'Type, then Enter…'}
+          />
+        )}
+      </div>
+    );
   };
 
   return (
@@ -1744,22 +2103,14 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
           </button>
         </div>
 
-        {/* Page navigation */}
+        {/* Page indicator — pages scroll continuously; this reflects the page in view */}
         {numPages > 1 && (
-          <div className="flex items-center gap-1 shrink-0">
-            <button onClick={() => setPageNumber(p => Math.max(1, p - 1))} disabled={pageNumber <= 1}
-              className="p-2.5 bg-slate-800 text-white rounded-xl disabled:opacity-40 hover:bg-slate-700 transition-all min-w-[44px] min-h-[44px] flex items-center justify-center">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
-              </svg>
-            </button>
-            <span className="text-white text-xs font-bold min-w-[3.5rem] text-center">{pageNumber}/{numPages}</span>
-            <button onClick={() => setPageNumber(p => Math.min(numPages, p + 1))} disabled={pageNumber >= numPages}
-              className="p-2.5 bg-slate-800 text-white rounded-xl disabled:opacity-40 hover:bg-slate-700 transition-all min-w-[44px] min-h-[44px] flex items-center justify-center">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
+          <div className="flex items-center gap-1.5 shrink-0 px-3 min-h-[44px] bg-slate-800 rounded-xl"
+            title="Scroll to move through pages">
+            <svg className="w-3.5 h-3.5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7M4 5v14" transform="rotate(90 12 12)" />
+            </svg>
+            <span className="text-white text-xs font-bold whitespace-nowrap">Page {pageNumber} / {numPages}</span>
           </div>
         )}
 
@@ -2131,7 +2482,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       )}
 
       {/* ── Canvas area ── */}
-      <div ref={mainRef} className="flex-1 min-h-0 overflow-auto flex flex-col items-center p-4 gap-4">
+      <div ref={mainRef} onScroll={handleScroll} className="flex-1 min-h-0 overflow-auto flex flex-col items-center p-4 gap-4">
 
         {annLoadErr && (
           <div className="w-full max-w-3xl flex items-center gap-3 px-4 py-3 bg-amber-500/10 border border-amber-500/30 rounded-xl shrink-0">
@@ -2175,308 +2526,8 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
           </div>
         )}
 
-        {!isLoadingPdf && !pdfError && (
-          <div
-            ref={containerRef}
-            className={`relative shadow-2xl rounded-lg overflow-hidden shrink-0 ${toolCursor}`}
-            style={{ width: canvasSize.width || '100%', touchAction: 'none' }}
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            onPointerCancel={handlePointerCancel}
-            onDoubleClick={handleDoubleClick}
-          >
-            <canvas ref={canvasRef} className="block" />
-
-            <svg className="absolute inset-0 pointer-events-none"
-              width={canvasSize.width} height={canvasSize.height}
-              viewBox={`0 0 ${canvasSize.width} ${canvasSize.height}`}>
-
-              {pageAnnotations.map(ann => {
-                const data = (ann.id === selectedAnnId && liveEditData !== null)
-                  ? liveEditData
-                  : ann.data as AnyAnnotationData;
-                return renderAnnotationSvg({ ...ann, data }, canvasSize.width, canvasSize.height, ann.id, scaleInfo);
-              })}
-
-              {selectedAnn && currentTool === 'select' && (() => {
-                const displayData = liveEditData ?? selectedAnn.data as AnyAnnotationData;
-                const rotation    = (displayData.rotation as number | undefined) ?? 0;
-                const handles     = getHandlesNorm({ ...selectedAnn, data: displayData });
-                const bbox        = getAnnotationBBox(selectedAnn, displayData);
-                const SELECTION_BOX_PADDING = 8;
-                // Pixel coordinates of the bbox centre (used for the rotation transform)
-                const bboxCxPx = bbox ? (bbox.x + bbox.w / 2) * canvasSize.width  : 0;
-                const bboxCyPx = bbox ? (bbox.y + bbox.h / 2) * canvasSize.height : 0;
-                const rotateHandle = handles.find(h => h.isRotateHandle);
-                return (
-                  <g>
-                    {/* Dashed bounding box — rotated with the annotation */}
-                    {bbox && bbox.w > 0.005 && (
-                      <g transform={rotation ? `rotate(${rotation}, ${bboxCxPx}, ${bboxCyPx})` : undefined}>
-                        <rect
-                          x={bbox.x * canvasSize.width - SELECTION_BOX_PADDING}
-                          y={bbox.y * canvasSize.height - SELECTION_BOX_PADDING}
-                          width={bbox.w * canvasSize.width + SELECTION_BOX_PADDING * 2}
-                          height={bbox.h * canvasSize.height + SELECTION_BOX_PADDING * 2}
-                          fill="none" stroke="white" strokeWidth="1.5"
-                          strokeDasharray="5 3" opacity="0.5" rx="3" />
-                      </g>
-                    )}
-                    {/* Stem line from bbox top-centre to the rotate handle */}
-                    {bbox && bbox.w > 0.005 && rotateHandle && (() => {
-                      // Compute the rotated top-centre of the bounding box
-                      const stemBaseX = bbox.x * canvasSize.width + (bbox.w * canvasSize.width) / 2;
-                      const stemBaseY = bbox.y * canvasSize.height - SELECTION_BOX_PADDING;
-                      if (rotation) {
-                        const rad = (rotation * Math.PI) / 180;
-                        const cos = Math.cos(rad), sin = Math.sin(rad);
-                        const dx = stemBaseX - bboxCxPx, dy = stemBaseY - bboxCyPx;
-                        const rx = bboxCxPx + dx * cos - dy * sin;
-                        const ry = bboxCyPx + dx * sin + dy * cos;
-                        return <line x1={rx} y1={ry} x2={rotateHandle.nx * canvasSize.width} y2={rotateHandle.ny * canvasSize.height}
-                          stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
-                      }
-                      return <line x1={stemBaseX} y1={stemBaseY} x2={rotateHandle.nx * canvasSize.width} y2={rotateHandle.ny * canvasSize.height}
-                        stroke="white" strokeWidth="1" strokeDasharray="3 2" opacity="0.35" />;
-                    })()}
-                    {handles.map(h => {
-                      const cx = h.nx * canvasSize.width;
-                      const cy = h.ny * canvasSize.height;
-                      const isCalloutArrowTip = selectedAnn.toolType === 'callout' && !h.isMoveHandle && !h.isRotateHandle && h.index === 1;
-                      const handleFill = h.isRotateHandle ? '#22c55e'
-                        : h.isMoveHandle ? '#6366f1'
-                        : h.isEdgeHandle ? '#0ea5e9'
-                        : isCalloutArrowTip ? '#f59e0b'
-                        : '#3b82f6';
-                      const edgeLabel = h.index === EDGE_HANDLE_TOP ? 'top' : h.index === EDGE_HANDLE_RIGHT ? 'right' : h.index === EDGE_HANDLE_BOTTOM ? 'bottom' : 'left';
-                      const handleTitle = h.isRotateHandle
-                        ? `Rotate — drag to rotate (${Math.round(rotation)}°), hold Shift for 15° snapping`
-                        : h.isMoveHandle
-                          ? 'Move annotation'
-                          : h.isEdgeHandle
-                            ? `Resize ${edgeLabel} edge — drag to resize on one axis`
-                            : selectedAnn.toolType === 'callout'
-                              ? h.index === 0 ? 'Text box — drag to reposition' : 'Arrow tip — drag to repoint'
-                              : selectedAnn.toolType === 'arrow' || selectedAnn.toolType === 'double_arrow'
-                                ? h.index === 0 ? 'Line start — drag to adjust' : 'Arrow head — drag to adjust'
-                                : `Endpoint ${h.index + 1} — drag to reshape`;
-                      const r = h.isRotateHandle || h.isMoveHandle ? 9 : 8;
-                      return (
-                        <g key={`handle-${h.index}`}>
-                          {/* Hit-area circle (invisible, larger) */}
-                          <circle cx={cx} cy={cy} r="18" fill="transparent">
-                            <title>{handleTitle}</title>
-                          </circle>
-                          {/* Edge handles: diamond (rotated square) shape */}
-                          {h.isEdgeHandle ? (
-                            <rect
-                              x={cx - 6} y={cy - 6} width={12} height={12}
-                              fill={handleFill} stroke="white" strokeWidth="2"
-                              transform={`rotate(45, ${cx}, ${cy})`}
-                            />
-                          ) : (
-                            /* Visible handle circle */
-                            <circle cx={cx} cy={cy} r={r} fill={handleFill} stroke="white" strokeWidth="2.5" />
-                          )}
-                          {/* Rotate handle: circular-arrow icon */}
-                          {h.isRotateHandle && (
-                            <g transform={`translate(${cx}, ${cy})`} stroke="white" strokeWidth="1.5" strokeLinecap="round" fill="none">
-                              <path d="M -4 -3 A 5 5 0 1 1 3.5 -3.5" />
-                              <polyline points="3.5,-3.5 5.5,-1.5 5.5,-5" />
-                            </g>
-                          )}
-                          {/* Move handle: cross icon */}
-                          {h.isMoveHandle && (
-                            <g stroke="white" strokeWidth="1.5" strokeLinecap="round">
-                              <line x1={cx - 4} y1={cy} x2={cx + 4} y2={cy} />
-                              <line x1={cx} y1={cy - 4} x2={cx} y2={cy + 4} />
-                            </g>
-                          )}
-                        </g>
-                      );
-                    })}
-                  </g>
-                );
-              })()}
-
-              {pageAnnotations.map(ann => {
-                const anchor = getAnnotationAnchor(ann);
-                if (!anchor) return null;
-                const initials  = getInitials(ann.authorName);
-                const bw        = initials.length * 7 + 10;
-                const bx        = anchor.x * canvasSize.width;
-                const by        = anchor.y * canvasSize.height;
-                const isPending = ann.id.startsWith('tmp-');
-                return (
-                  <g key={`badge-${ann.id}`}>
-                    <rect x={bx} y={by - 17} width={bw} height={17} rx="3"
-                      fill={ann.color} opacity={isPending ? 0.5 : 0.88}
-                      stroke={isPending ? 'white' : 'none'} strokeWidth={isPending ? 1 : 0}
-                      strokeDasharray={isPending ? '3 2' : undefined} />
-                    <text x={bx + 5} y={by - 3} fontSize="11" fontFamily="monospace" fontWeight="bold" fill="white">
-                      {initials}
-                    </text>
-                  </g>
-                );
-              })}
-
-              {penPreviewPath && (
-                <path d={penPreviewPath} stroke={currentColor}
-                  strokeWidth={currentTool === 'highlighter' ? strokeWidth * 5 : strokeWidth}
-                  fill="none" strokeLinecap="round" strokeLinejoin="round"
-                  opacity={currentTool === 'highlighter' ? opacity * 0.35 : opacity * 0.75} />
-              )}
-
-              {previewData && currentTool !== 'pen' && currentTool !== 'highlighter' && currentTool !== 'scale' &&
-                renderAnnotationSvg({ toolType: currentTool, color: currentColor, strokeWidth, data: previewData },
-                  canvasSize.width, canvasSize.height, 'preview', scaleInfo)
-              }
-
-              {isDrawing && currentTool === 'scale' && previewData && (
-                <line
-                  x1={(previewData.x1 ?? 0) * canvasSize.width} y1={(previewData.y1 ?? 0) * canvasSize.height}
-                  x2={(previewData.x2 ?? 0) * canvasSize.width} y2={(previewData.y2 ?? 0) * canvasSize.height}
-                  stroke="#fbbf24" strokeWidth="2" strokeDasharray="6 3" strokeLinecap="round" opacity="0.9"
-                />
-              )}
-
-              {scaleInput && (
-                <line
-                  x1={scaleInput.lineStart.x * canvasSize.width} y1={scaleInput.lineStart.y * canvasSize.height}
-                  x2={scaleInput.lineEnd.x * canvasSize.width} y2={scaleInput.lineEnd.y * canvasSize.height}
-                  stroke="#fbbf24" strokeWidth="2.5" strokeDasharray="6 3" strokeLinecap="round"
-                />
-              )}
-
-              {/* Start-point crosshair while drawing lines / callout / shapes */}
-              {isDrawing && drawStart && !['pen', 'highlighter', 'text', 'stamp', 'select', 'pan'].includes(currentTool) && (
-                <g>
-                  <circle cx={drawStart.x * canvasSize.width} cy={drawStart.y * canvasSize.height}
-                    r="5" fill={currentColor} stroke="white" strokeWidth="2" opacity="0.9" />
-                  <line x1={drawStart.x * canvasSize.width - 10} y1={drawStart.y * canvasSize.height}
-                    x2={drawStart.x * canvasSize.width + 10} y2={drawStart.y * canvasSize.height}
-                    stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
-                  <line x1={drawStart.x * canvasSize.width} y1={drawStart.y * canvasSize.height - 10}
-                    x2={drawStart.x * canvasSize.width} y2={drawStart.y * canvasSize.height + 10}
-                    stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
-                </g>
-              )}
-
-              {/* Angle badge for line-type tools while drawing */}
-              {isDrawing && previewData && (
-                currentTool === 'line' || currentTool === 'dashed_line' ||
-                currentTool === 'arrow' || currentTool === 'double_arrow' ||
-                currentTool === 'dimension' || currentTool === 'callout'
-              ) && (() => {
-                const x2px = (previewData.x2 ?? 0) * canvasSize.width;
-                const y2px = (previewData.y2 ?? 0) * canvasSize.height;
-                const dx = ((previewData.x2 ?? 0) - (previewData.x1 ?? 0)) * canvasSize.width;
-                const dy = ((previewData.y2 ?? 0) - (previewData.y1 ?? 0)) * canvasSize.height;
-                const angleDeg = ((Math.round(Math.atan2(dy, dx) * 180 / Math.PI) % 360) + 360) % 360;
-                const bx = Math.min(x2px + 12, canvasSize.width - 52);
-                const by = y2px > 20 ? y2px - 8 : y2px + 26;
-                return (
-                  <g opacity="0.92">
-                    <rect x={bx} y={by - 13} width={44} height={16} rx="4" fill="rgba(0,0,0,0.72)" />
-                    <text x={bx + 5} y={by - 1} fontSize="11" fill="white" fontFamily="monospace" fontWeight="bold">
-                      {angleDeg}°
-                    </text>
-                  </g>
-                );
-              })()}
-
-              {/* Ghost callout preview while the text input is open */}
-              {textInput && textInput.calloutData && (
-                renderAnnotationSvg({
-                  toolType: 'callout', color: currentColor, strokeWidth,
-                  data: { ...textInput.calloutData, text: textValue.trim() || '\u00a0', fontSize },
-                }, canvasSize.width, canvasSize.height, 'callout-ghost')
-              )}
-
-              {/* Scale bar */}
-              {scaleInfo && canvasSize.width > 0 && (() => {
-                const targetPx = canvasSize.width * 0.15;
-                const rawUnits = (targetPx / canvasSize.height) * scaleInfo.unitsPerNormDist;
-                const nices = [0.25,0.5,1,2,5,10,20,25,50,100,200,500,1000];
-                const nice = nices.reduce((a, b) => Math.abs(b - rawUnits) < Math.abs(a - rawUnits) ? b : a);
-                const barPx = (nice / scaleInfo.unitsPerNormDist) * canvasSize.height;
-                const barX = 16, barY = canvasSize.height - 16;
-                const label = `${nice} ${scaleInfo.unit}`;
-                const lblW = label.length * 6 + 12;
-                return (
-                  <g opacity="0.9">
-                    <rect x={barX - 4} y={barY - 24} width={Math.max(barPx + 8, lblW + 8)} height={28} rx="4" fill="rgba(0,0,0,0.72)" />
-                    <line x1={barX} y1={barY - 10} x2={barX + barPx} y2={barY - 10} stroke="white" strokeWidth="2" />
-                    <line x1={barX} y1={barY - 16} x2={barX} y2={barY - 4} stroke="white" strokeWidth="2" />
-                    <line x1={barX + barPx} y1={barY - 16} x2={barX + barPx} y2={barY - 4} stroke="white" strokeWidth="2" />
-                    <text x={barX + barPx / 2} y={barY} textAnchor="middle" fill="white" fontSize="9" fontFamily="monospace" fontWeight="bold">{label}</text>
-                  </g>
-                );
-              })()}
-            </svg>
-
-            {scaleInput && (
-              <div className="absolute bg-slate-900 border border-white/20 rounded-xl p-4 shadow-2xl z-20 w-60"
-                style={{ left: Math.min(canvasSize.width - 248, Math.max(0, scaleInput.lineEnd.x * canvasSize.width - 120)),
-                         top: Math.min(canvasSize.height - 120, Math.max(0, scaleInput.lineEnd.y * canvasSize.height + 16)) }}>
-                <p className="text-[10px] text-brand font-black uppercase tracking-widest mb-3">Set Scale Reference</p>
-                <p className="text-[9px] text-slate-400 mb-2">What length does this line represent?</p>
-                <div className="flex gap-2 mb-3">
-                  <input ref={scaleInputRef} type="number" min="0.001" step="any" value={scaleValue}
-                    onChange={e => setScaleValue(e.target.value)}
-                    onKeyDown={e => { if (e.key === 'Enter') handleScaleConfirm(); if (e.key === 'Escape') setScaleInput(null); }}
-                    placeholder="Distance"
-                    className="flex-1 bg-slate-800 text-white rounded-lg px-2 py-1.5 text-sm border border-white/10 outline-none focus:border-brand min-w-0" />
-                  <select value={scaleUnit} onChange={e => setScaleUnit(e.target.value)}
-                    className="bg-slate-800 text-white rounded-lg px-2 text-sm border border-white/10 outline-none focus:border-brand shrink-0">
-                    <option value="ft">ft</option>
-                    <option value="in">in</option>
-                    <option value="yd">yd</option>
-                    <option value="m">m</option>
-                    <option value="cm">cm</option>
-                    <option value="mm">mm</option>
-                  </select>
-                </div>
-                <div className="flex gap-2">
-                  <button onClick={handleScaleConfirm}
-                    className="flex-1 bg-brand text-slate-900 rounded-lg py-1.5 text-[11px] font-black hover:brightness-110 transition-all">
-                    Set Scale
-                  </button>
-                  <button onClick={() => { setScaleInput(null); setScaleValue(''); }}
-                    className="px-3 bg-slate-800 text-slate-300 hover:bg-slate-700 rounded-lg py-1.5 text-[11px] font-black transition-all">
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {textInput && (
-              <input
-                ref={textFieldRef}
-                type="text"
-                value={textValue}
-                onChange={e => setTextValue(e.target.value)}
-                onBlur={handleTextSubmit}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') handleTextSubmit();
-                  if (e.key === 'Escape') { setTextInput(null); setTextValue(''); }
-                }}
-                className="absolute bg-black/50 backdrop-blur rounded px-2 py-1 border border-dashed outline-none z-10 font-bold"
-                style={{
-                  left: textInput.calloutData
-                    ? Math.min(canvasSize.width - 172, Math.max(4, textInput.rx * canvasSize.width - 80))
-                    : textInput.px,
-                  top: textInput.calloutData
-                    ? Math.min(canvasSize.height - 40, Math.max(4, textInput.ry * canvasSize.height - fontSize - 14))
-                    : textInput.py - 16,
-                  color: currentColor, borderColor: currentColor, fontSize: fontSize + 'px', minWidth: '160px',
-                }}
-                placeholder={textInput.calloutData ? 'Callout text, then Enter…' : 'Type, then Enter…'}
-              />
-            )}
-          </div>
-        )}
+        {!isLoadingPdf && !pdfError &&
+          Array.from({ length: numPages }, (_, i) => renderPageLayer(i + 1))}
 
         {showLog && (
           <div className="w-full max-w-3xl bg-slate-900/80 border border-white/10 rounded-2xl p-4 shrink-0">

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1159,7 +1159,17 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const touchPtsRef   = useRef<Map<number, { x: number; y: number }>>(new Map());
   const isPinchRef    = useRef(false);
   const pinchDistRef  = useRef(0);
-  const pinchZoomRef  = useRef(1.0);
+  // Wrapper around the page column that receives a transient CSS transform during a
+  // pinch (smooth, GPU-composited) so we don't re-rasterize pages on every frame.
+  const zoomLayerRef  = useRef<HTMLDivElement>(null);
+  const pinchStartFocalRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const pinchCurrentFocalRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const pinchOriginRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const pinchScaleRef = useRef(1);
+  // The page + normalized point under the pinch focus, used to re-anchor scroll once
+  // the new zoom is committed and the pages are re-rasterized.
+  const pinchAnchorRef = useRef<{ pageNum: number; nx: number; ny: number } | null>(null);
+  const pendingZoomAnchorRef = useRef<{ pageNum: number; nx: number; ny: number; fx: number; fy: number } | null>(null);
   const panStartRef   = useRef<{ x: number; y: number; sl: number; st: number } | null>(null);
   const undoStackRef  = useRef<PdfAnnotation[]>([]);
   const redoStackRef  = useRef<Omit<PdfAnnotation, 'id' | 'createdAt'>[]>([]);
@@ -1354,11 +1364,31 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     visiblePagesRef.current.forEach(p => renderPage(p, true));
   }, [zoomLevel, availWidth, isLoadingPdf, renderPage]);
 
-  // Keep the same scroll anchor when page sizes change (zoom / resize) so the user
-  // stays on the page they were viewing rather than jumping to the top.
+  // Keep the same scroll anchor when page sizes change (zoom / resize). After a pinch
+  // we re-anchor on the focal point so the spot under the fingers stays fixed; for
+  // button/keyboard zoom and resizes we preserve the vertical scroll fraction.
   useLayoutEffect(() => {
     const main = mainRef.current;
     if (!main) return;
+    const anchor = pendingZoomAnchorRef.current;
+    if (anchor) {
+      pendingZoomAnchorRef.current = null;
+      const el = pageContainerRefs.current.get(anchor.pageNum);
+      if (el) {
+        const cr = main.getBoundingClientRect();
+        const r  = el.getBoundingClientRect();
+        // Focal point in scroll-content coordinates (invariant under the current scroll).
+        const focalContentX = (r.left - cr.left) + main.scrollLeft + anchor.nx * r.width;
+        const focalContentY = (r.top  - cr.top)  + main.scrollTop  + anchor.ny * r.height;
+        const maxL = Math.max(0, main.scrollWidth  - main.clientWidth);
+        const maxT = Math.max(0, main.scrollHeight - main.clientHeight);
+        main.scrollLeft = Math.max(0, Math.min(maxL, focalContentX - (anchor.fx - cr.left)));
+        main.scrollTop  = Math.max(0, Math.min(maxT, focalContentY - (anchor.fy - cr.top)));
+        const sh = main.scrollHeight - main.clientHeight;
+        scrollRatioRef.current = sh > 0 ? main.scrollTop / sh : 0;
+        return;
+      }
+    }
     const sh = main.scrollHeight - main.clientHeight;
     if (sh > 0) main.scrollTop = scrollRatioRef.current * sh;
   }, [zoomLevel, availWidth]);
@@ -1879,18 +1909,63 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     touchPtsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     shiftPressedRef.current = e.shiftKey;
 
-    // Pinch-to-zoom: two touch points
+    // Pinch-to-zoom: two touch points. Apply a transient GPU transform to the page
+    // column during the gesture (smooth, no re-render); the real zoom + re-rasterize
+    // happens once, on release, anchored at the pinch focus.
     if (touchPtsRef.current.size >= 2) {
       const [a, b] = [...touchPtsRef.current.values()];
       const dist = Math.hypot(a.x - b.x, a.y - b.y);
+      const fx = (a.x + b.x) / 2, fy = (a.y + b.y) / 2;
+      const layer = zoomLayerRef.current;
       if (!isPinchRef.current) {
-        isPinchRef.current = true; pinchDistRef.current = dist; pinchZoomRef.current = zoomLevel;
+        // Cancel any single-finger draw that was in progress when the pinch began.
+        if (drawingPtrRef.current !== null) {
+          drawingPtrRef.current = null;
+          setIsDrawing(false); setPenPoints([]); setPreviewData(null); setDrawStart(null);
+        }
+        isPinchRef.current = true;
+        pinchDistRef.current = dist;
+        pinchScaleRef.current = 1;
+        pinchStartFocalRef.current = { x: fx, y: fy };
+        pinchCurrentFocalRef.current = { x: fx, y: fy };
+        // Resolve the page + normalized point under the focus for post-zoom re-anchoring.
+        let anchorEl = (document.elementFromPoint(fx, fy) as HTMLElement | null)?.closest('[data-page]') as HTMLElement | null;
+        if (!anchorEl) {
+          pageContainerRefs.current.forEach(c => {
+            const cr = c.getBoundingClientRect();
+            if (fx >= cr.left && fx <= cr.right && fy >= cr.top && fy <= cr.bottom) anchorEl = c;
+          });
+        }
+        if (anchorEl) {
+          const r = anchorEl.getBoundingClientRect();
+          pinchAnchorRef.current = {
+            pageNum: Number(anchorEl.dataset.page) || 1,
+            nx: r.width ? Math.max(0, Math.min(1, (fx - r.left) / r.width)) : 0.5,
+            ny: r.height ? Math.max(0, Math.min(1, (fy - r.top) / r.height)) : 0.5,
+          };
+        } else {
+          pinchAnchorRef.current = null;
+        }
+        if (layer) {
+          const zr = layer.getBoundingClientRect();
+          pinchOriginRef.current = { x: fx - zr.left, y: fy - zr.top };
+          layer.style.transformOrigin = `${pinchOriginRef.current.x}px ${pinchOriginRef.current.y}px`;
+          layer.style.willChange = 'transform';
+        }
       } else {
-        setZoomLevel(Math.max(0.25, Math.min(4.0, pinchZoomRef.current * (dist / (pinchDistRef.current || 1)))));
+        pinchCurrentFocalRef.current = { x: fx, y: fy };
+        const rawS = dist / (pinchDistRef.current || 1);
+        const targetZoom = Math.max(0.25, Math.min(4.0, zoomRef.current * rawS));
+        const s = targetZoom / (zoomRef.current || 1);
+        pinchScaleRef.current = s;
+        if (layer) {
+          const dx = fx - pinchStartFocalRef.current.x;
+          const dy = fy - pinchStartFocalRef.current.y;
+          layer.style.transform = `translate(${dx}px, ${dy}px) scale(${s})`;
+        }
       }
       return;
     }
-    isPinchRef.current = false;
 
     // Handle drag: update annotation geometry live while dragging a control point
     if (dragHandleRef.current && drawingPtrRef.current === e.pointerId) {
@@ -1954,9 +2029,35 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
   }, [currentTool, isDrawing, drawStart, getCoords, zoomLevel, annotations, pendingAnnotations]);
 
-  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    touchPtsRef.current.delete(e.pointerId);
+  // Commit a pinch gesture: turn the transient transform into a real zoom level and
+  // queue a focal re-anchor so the point under the fingers stays put after re-layout.
+  const finalizePinch = useCallback(() => {
+    if (!isPinchRef.current) return;
     isPinchRef.current = false;
+    const layer = zoomLayerRef.current;
+    if (layer) { layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = ''; }
+    const s = pinchScaleRef.current;
+    pinchScaleRef.current = 1;
+    const anchor = pinchAnchorRef.current;
+    pinchAnchorRef.current = null;
+    if (Math.abs(s - 1) < 0.002) return; // negligible change
+    const newZoom = Math.max(0.25, Math.min(4.0, (zoomRef.current || 1) * s));
+    if (Math.abs(newZoom - zoomRef.current) < 0.0005) return;
+    if (anchor) {
+      const f = pinchCurrentFocalRef.current;
+      pendingZoomAnchorRef.current = { pageNum: anchor.pageNum, nx: anchor.nx, ny: anchor.ny, fx: f.x, fy: f.y };
+    }
+    setZoomLevel(newZoom);
+  }, []);
+
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // A finger lifting ends a pinch — commit the zoom now.
+    if (isPinchRef.current) {
+      touchPtsRef.current.delete(e.pointerId);
+      finalizePinch();
+      return;
+    }
+    touchPtsRef.current.delete(e.pointerId);
     if (drawingPtrRef.current !== e.pointerId) return;
     drawingPtrRef.current = null; panStartRef.current = null;
 
@@ -2039,17 +2140,19 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     // Keep the current drawing tool active so the user can draw another annotation.
     // Only select the just-placed item so its bounding box is visible.
     setSelectedAnnId(placed.id);
-  }, [isDrawing, drawStart, currentTool, penPoints, getCoords, commitAnnotation, stampType, liveEditData, updateAnnotation]);
+  }, [isDrawing, drawStart, currentTool, penPoints, getCoords, commitAnnotation, stampType, liveEditData, updateAnnotation, finalizePinch]);
 
   const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     touchPtsRef.current.delete(e.pointerId);
+    // Pinch interrupted — commit whatever zoom was reached so the view doesn't snap back.
+    if (isPinchRef.current) { finalizePinch(); return; }
     if (drawingPtrRef.current === e.pointerId) {
       drawingPtrRef.current = null;
       setIsDrawing(false); setPenPoints([]); setPreviewData(null); setDrawStart(null);
       isPinchRef.current = false; panStartRef.current = null;
       dragHandleRef.current = null; setLiveEditData(null);
     }
-  }, []);
+  }, [finalizePinch]);
 
   // Ctrl+scroll to zoom
   const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
@@ -2747,8 +2850,9 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
           </div>
         )}
 
-        {!isLoadingPdf && !pdfError &&
-          Array.from({ length: numPages }, (_, i) => {
+        {!isLoadingPdf && !pdfError && (
+          <div ref={zoomLayerRef} className="flex flex-col items-center gap-4 origin-top">
+          {Array.from({ length: numPages }, (_, i) => {
             const p = i + 1;
             const { width: w, height: h } = getDisplaySize(p);
             const active = activePage === p;
@@ -2785,6 +2889,8 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
               />
             );
           })}
+          </div>
+        )}
 
         {showLog && (
           <div className="w-full max-w-3xl bg-slate-900/80 border border-white/10 rounded-2xl p-4 shrink-0">

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -4,6 +4,7 @@ import * as pdfjsLib from 'pdfjs-dist';
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 import { PdfAnnotation, JobPrint, User, UserRole } from '../types.ts';
 import { apiService } from '../services/apiService.ts';
+import { buildMarkedUpPdf } from './pdfExport.tsx';
 
 // Use workerSrc (URL) so pdfjs manages its own Worker lifecycle.
 // This is the standard approach: avoids shared-worker bad-state after errors
@@ -14,7 +15,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 // Types & constants
 // ─────────────────────────────────────────────────────────────
 
-type ToolType =
+export type ToolType =
   | 'select' | 'pan'
   | 'pen' | 'highlighter'
   | 'text' | 'callout' | 'stamp'
@@ -34,7 +35,7 @@ const STAMP_COLORS: Record<StampType, string> = {
   'VOID':          '#6b7280',
 };
 
-interface AnyAnnotationData extends Record<string, unknown> {
+export interface AnyAnnotationData extends Record<string, unknown> {
   points?:    Array<{ x: number; y: number; pressure?: number }>;
   x?:         number;
   y?:         number;
@@ -47,7 +48,7 @@ interface AnyAnnotationData extends Record<string, unknown> {
   rotation?:  number;  // rotation in degrees (clockwise, 0 = no rotation)
 }
 
-interface ScaleInfo {
+export interface ScaleInfo {
   unitsPerNormDist: number;  // real units per canonical normalized distance
   aspectRatio: number;       // canvas W/H (fixed for PDF page)
   unit: string;
@@ -420,7 +421,7 @@ const renderAnnotationContent = (
 
 // Wraps renderAnnotationContent with an SVG rotation transform when the
 // annotation's data.rotation field is set.
-const renderAnnotationSvg = (
+export const renderAnnotationSvg = (
   ann: { toolType: ToolType; color: string; strokeWidth: number; data: AnyAnnotationData },
   w: number, h: number, key: string,
   scaleInfo?: ScaleInfo | null,
@@ -1119,6 +1120,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const [annLoadErr, setAnnLoadErr]     = useState<string | null>(null);
   const [actionErr, setActionErr]       = useState<string | null>(null);
   const [isSaving, setIsSaving]         = useState(false);
+  const [exportProgress, setExportProgress] = useState<number | null>(null); // 0–1 while exporting, else null
   const [showLog, setShowLog]           = useState(false);
   const [isLoadingPdf, setIsLoadingPdf] = useState(true);
   const [pdfError, setPdfError]         = useState<string | null>(null);
@@ -1137,6 +1139,9 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   // Per-page DOM refs (continuous-scroll mode renders every page at once).
   const pageCanvasRefs    = useRef<Map<number, HTMLCanvasElement>>(new Map());
   const pageContainerRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  // The lazy-render IntersectionObserver, held in a ref so pages can be observed the
+  // moment they mount (not only when the observer effect runs).
+  const pageObserverRef = useRef<IntersectionObserver | null>(null);
   // The page the current pointer gesture is acting on — resolved at pointer-down
   // from the target page container's data-page attribute. Drives getCoords, new
   // annotation placement, and which page renders live drawing previews.
@@ -1145,10 +1150,13 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   const textFieldRef  = useRef<HTMLInputElement>(null);
   const scaleInputRef = useRef<HTMLInputElement>(null);
   const pdfDocRef     = useRef<pdfjsLib.PDFDocumentProxy | null>(null);
+  // Raw bytes of the source PDF, kept for exporting a flattened/marked-up copy.
+  const pdfBytesRef = useRef<ArrayBuffer | null>(null);
   // Active pdf.js render tasks keyed by page number, so re-renders can cancel cleanly.
   const renderTasksRef = useRef<Map<number, pdfjsLib.RenderTask>>(new Map());
-  // Zoom level at which each page's canvas was last painted (to skip redundant renders).
-  const renderedZoomRef = useRef<Map<number, number>>(new Map());
+  // Render signature (zoom + column width) at which each page's canvas was last
+  // painted, so redundant re-renders are skipped but stale-resolution ones are not.
+  const renderedZoomRef = useRef<Map<number, string>>(new Map());
   // Pages currently intersecting the viewport (plus the observer's prerender buffer).
   const visiblePagesRef = useRef<Set<number>>(new Set());
   // Scroll position as a fraction of scrollable height, kept current so zoom can restore it.
@@ -1264,6 +1272,9 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         return;
       }
       try {
+        // Keep an independent copy of the raw bytes for export — pdf.js may transfer
+        // (detach) the buffer it is handed to its worker.
+        pdfBytesRef.current = buffer.slice(0);
         const pdf = await pdfjsLib.getDocument({ data: new Uint8Array(buffer) }).promise;
         if (!cancelled) {
           pdfDocRef.current = pdf;
@@ -1296,7 +1307,11 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     const canvas = pageCanvasRefs.current.get(pageNum);
     if (!pdf || !canvas) return;
     const zoom = zoomRef.current;
-    if (!force && renderedZoomRef.current.get(pageNum) === zoom) return;
+    const avail = (availWidthRef.current || (mainRef.current?.clientWidth ?? window.innerWidth) - 48);
+    // Cache key includes width so a column-width change (rotation, resize) re-rasterizes
+    // even at the same zoom level, never leaving a stale-resolution bitmap.
+    const sig = `${zoom}:${Math.round(avail)}`;
+    if (!force && renderedZoomRef.current.get(pageNum) === sig) return;
     const prev = renderTasksRef.current.get(pageNum);
     if (prev) { prev.cancel(); renderTasksRef.current.delete(pageNum); }
     try {
@@ -1310,7 +1325,6 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         next[pageNum - 1] = { width: base.width, height: base.height };
         return next;
       });
-      const avail = (availWidthRef.current || (mainRef.current?.clientWidth ?? window.innerWidth) - 48);
       // Render at the device pixel ratio so pages are crisp on Retina/mobile screens.
       // The CSS size stays the display size (canvas is stretched to its container), while
       // the bitmap is denser. Cap the longest side so high zoom can't allocate a huge
@@ -1329,7 +1343,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       renderTasksRef.current.set(pageNum, task);
       await task.promise;
       renderTasksRef.current.delete(pageNum);
-      renderedZoomRef.current.set(pageNum, zoom);
+      renderedZoomRef.current.set(pageNum, sig);
     } catch { /* cancelled */ }
   }, []);
 
@@ -1367,8 +1381,9 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         else { visiblePagesRef.current.delete(p); clearPage(p); }
       }
     }, { root: main, rootMargin: '1200px 0px 1200px 0px', threshold: 0 });
+    pageObserverRef.current = io;
     pageContainerRefs.current.forEach(el => io.observe(el));
-    return () => io.disconnect();
+    return () => { io.disconnect(); pageObserverRef.current = null; };
   }, [isLoadingPdf, numPages, renderPage, clearPage]);
 
   // Re-render the currently visible pages when zoom or column width changes.
@@ -1419,13 +1434,14 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       const sh = main.scrollHeight - main.clientHeight;
       scrollRatioRef.current = sh > 0 ? main.scrollTop / sh : 0;
 
-      // Walk cumulative page heights (container p-4 = 16px padding, gap-4 = 16px gap)
-      // to find the page under the viewport centre without forcing layout per page.
-      const PAD = 16, GAP = 16;
+      // Walk cumulative page heights (gap-4 = 16px between pages) to find the page under
+      // the viewport centre without forcing layout per page. Seed the starting offset
+      // from the page column's actual position so error banners above it don't skew it.
+      const GAP = 16;
       const colW = Math.min(availWidthRef.current || 0, 1400) * zoomRef.current;
       const dims = pageDimsRef.current;
       const center = main.scrollTop + main.clientHeight / 2;
-      let top = PAD, best = 1;
+      let top = zoomLayerRef.current ? zoomLayerRef.current.offsetTop : 16, best = 1;
       for (let i = 0; i < dims.length; i++) {
         const dim = dims[i];
         const hgt = dim && colW > 0 ? colW * (dim.height / dim.width) : 0;
@@ -1477,7 +1493,14 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   // Stable ref-registration callbacks so memoized PageLayers never re-render from
   // receiving a fresh ref function each render.
   const registerContainer = useCallback((p: number, el: HTMLDivElement | null) => {
-    if (el) pageContainerRefs.current.set(p, el); else pageContainerRefs.current.delete(p);
+    if (el) {
+      pageContainerRefs.current.set(p, el);
+      pageObserverRef.current?.observe(el); // observe immediately if the observer exists
+    } else {
+      const prev = pageContainerRefs.current.get(p);
+      if (prev) pageObserverRef.current?.unobserve(prev);
+      pageContainerRefs.current.delete(p);
+    }
   }, []);
   const registerCanvas = useCallback((p: number, el: HTMLCanvasElement | null) => {
     if (el) pageCanvasRefs.current.set(p, el); else pageCanvasRefs.current.delete(p);
@@ -1624,6 +1647,41 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     }
     setIsSaving(false);
   }, [pendingAnnotations]);
+
+  // Download a flattened copy of the PDF with all current markups burned in.
+  const handleExport = useCallback(async () => {
+    const bytes = pdfBytesRef.current;
+    if (!bytes || exportProgress !== null) return;
+    const marks = [...annotationsRef.current, ...pendingAnnotationsRef.current]
+      .filter(a => (a.toolType as string) !== 'scale');
+    if (marks.length === 0) {
+      setActionErr('No markups to export yet — add some annotations first.');
+      return;
+    }
+    setExportProgress(0);
+    try {
+      const out = await buildMarkedUpPdf({
+        pdfBytes: bytes,
+        annotations: marks,
+        scaleInfo,
+        onProgress: (f) => setExportProgress(f),
+      });
+      // pdf-lib returns a Uint8Array; copy into a fresh buffer so Blob gets a clean ArrayBuffer.
+      const blob = new Blob([out.slice()], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      const base = print.fileName.replace(/\.pdf$/i, '');
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${base} (marked up).pdf`;
+      document.body.appendChild(link);
+      link.click();
+      setTimeout(() => { document.body.removeChild(link); URL.revokeObjectURL(url); }, 1000);
+    } catch (e: unknown) {
+      setActionErr('Export failed: ' + (e instanceof Error ? e.message : 'unknown error'));
+    } finally {
+      setExportProgress(null);
+    }
+  }, [exportProgress, scaleInfo, print.fileName]);
 
   const duplicateAnnotation = useCallback(() => {
     const selId = selectedAnnIdRef.current;
@@ -1945,6 +2003,17 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       activeTouchCountRef.current = e.touches.length;
       // A finger lifting out of a two-finger gesture commits the zoom.
       if (isPinchRef.current && e.touches.length < 2) finalizePinch();
+      // After a pinch leaves exactly one finger down, hand off to scrolling so that
+      // finger isn't "dead" until lifted and re-touched.
+      if (e.touches.length === 1) {
+        const isNavTool = currentToolRef.current === 'pan' || currentToolRef.current === 'select';
+        if (isNavTool && drawingPtrRef.current === null) {
+          panning = true;
+          startX = e.touches[0].clientX; startY = e.touches[0].clientY;
+          startSL = main.scrollLeft; startST = main.scrollTop;
+          lastX = startX; lastY = startY; lastT = performance.now(); vx = 0; vy = 0;
+        }
+      }
       if (e.touches.length === 0) {
         const t = e.changedTouches[0];
         const now = performance.now();
@@ -2187,7 +2256,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     } else if (currentTool !== 'stamp' && currentTool !== 'select' && currentTool !== 'text') {
       setPreviewData({ x1: drawStart.x, y1: drawStart.y, x2: coords.x, y2: coords.y });
     }
-  }, [currentTool, isDrawing, drawStart, getCoords, zoomLevel, annotations, pendingAnnotations]);
+  }, [currentTool, isDrawing, drawStart, getCoords, annotations, pendingAnnotations]);
 
   const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     touchPtsRef.current.delete(e.pointerId);
@@ -2580,6 +2649,26 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
           {pendingAnnotations.length > 0 ? `Save (${pendingAnnotations.length})` : 'Save'}
         </button>
 
+        {/* Download marked-up PDF */}
+        <button onClick={handleExport}
+          disabled={isLoadingPdf || !!pdfError || exportProgress !== null}
+          className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[10px] font-black uppercase tracking-wider transition-all shrink-0 min-h-[44px] bg-brand text-slate-900 hover:brightness-110 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed"
+          title="Download a copy of this PDF with the markups burned in">
+          {exportProgress !== null ? (
+            <>
+              <span className="w-3.5 h-3.5 border-2 border-slate-900/40 border-t-slate-900 rounded-full animate-spin" />
+              {Math.round(exportProgress * 100)}%
+            </>
+          ) : (
+            <>
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Download
+            </>
+          )}
+        </button>
+
         {scaleInfo && (
           <div className="flex items-center gap-1 shrink-0">
             <button
@@ -2942,7 +3031,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       )}
 
       {/* ── Canvas area ── */}
-      <div ref={mainRef} onScroll={handleScroll} className="flex-1 min-h-0 overflow-auto flex flex-col items-center p-4 gap-4">
+      <div ref={mainRef} onScroll={handleScroll} className="relative flex-1 min-h-0 overflow-auto flex flex-col items-center p-4 gap-4">
 
         {annLoadErr && (
           <div className="w-full max-w-3xl flex items-center gap-3 px-4 py-3 bg-amber-500/10 border border-amber-500/30 rounded-xl shrink-0">

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1414,6 +1414,14 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
   useLayoutEffect(() => {
     const main = mainRef.current;
     if (!main) return;
+    // Clear any leftover pinch / double-tap transform now that the new zoom has laid
+    // out. Doing it here (before reading any rects, and before the browser paints)
+    // means the view goes straight from "scaled old layout" to "new layout" with no
+    // intermediate old-zoom frame, and getBoundingClientRect below reads true sizes.
+    const layer = zoomLayerRef.current;
+    if (layer && layer.style.transform) {
+      layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = '';
+    }
     const anchor = pendingZoomAnchorRef.current;
     if (anchor) {
       pendingZoomAnchorRef.current = null;
@@ -1862,24 +1870,39 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
 
   // Commit a pinch: turn the transient transform into a real zoom level and queue a
   // focal re-anchor so the point under the fingers stays put after re-layout.
+  // IMPORTANT: we do NOT clear the transform here. If we did, the view would snap
+  // back to the *old* zoom for one frame before the new zoom renders, causing a
+  // visible jump. Instead the transform is left in place and cleared inside the
+  // zoom layout-effect, after the new page sizes are laid out — so the swap from
+  // "scaled old layout" to "new layout" happens in a single paint with no flicker.
+  const clearZoomTransform = useCallback(() => {
+    const layer = zoomLayerRef.current;
+    if (layer) { layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = ''; }
+  }, []);
+
   const finalizePinch = useCallback(() => {
     if (!isPinchRef.current) return;
     isPinchRef.current = false;
-    const layer = zoomLayerRef.current;
-    if (layer) { layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = ''; }
     const s = pinchScaleRef.current;
     pinchScaleRef.current = 1;
     const anchor = pinchAnchorRef.current;
     pinchAnchorRef.current = null;
-    if (Math.abs(s - 1) < 0.002) return; // negligible change
     const newZoom = Math.max(0.25, Math.min(4.0, (zoomRef.current || 1) * s));
-    if (Math.abs(newZoom - zoomRef.current) < 0.0005) return;
+    // No meaningful change (or clamped to the same level): drop the transient
+    // transform now, since no re-render — and therefore no layout-effect — will run.
+    if (Math.abs(s - 1) < 0.002 || Math.abs(newZoom - zoomRef.current) < 0.0005) {
+      clearZoomTransform();
+      return;
+    }
     if (anchor) {
       const f = pinchCurrentFocalRef.current;
       pendingZoomAnchorRef.current = { pageNum: anchor.pageNum, nx: anchor.nx, ny: anchor.ny, fx: f.x, fy: f.y };
+    } else {
+      // No focal page resolved — clear now and just re-zoom without re-anchoring.
+      clearZoomTransform();
     }
     setZoomLevel(newZoom);
-  }, []);
+  }, [clearZoomTransform]);
 
   // Touch-based pan + pinch for mobile (native touch events: e.touches is authoritative).
   // Single finger over a nav tool scrolls; two fingers pinch-zoom. Pen/mouse drawing is
@@ -1932,7 +1955,8 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         layer.style.transform = `scale(${1 + (ratio - 1) * ease(t)})`;
         if (t < 1) { momentumId = requestAnimationFrame(step); return; }
         momentumId = 0;
-        layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = '';
+        // Leave the transform applied; the zoom layout-effect clears it after the new
+        // size lays out, so there's no one-frame snap back to the old zoom.
         if (anchor) pendingZoomAnchorRef.current = { ...anchor, fx: clientX, fy: clientY };
         setZoomLevel(targetZoom);
       };

--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1311,8 +1311,17 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         return next;
       });
       const avail = (availWidthRef.current || (mainRef.current?.clientWidth ?? window.innerWidth) - 48);
-      const scale = (Math.min(avail, 1400) / base.width) * zoom;
-      const vp = page.getViewport({ scale });
+      // Render at the device pixel ratio so pages are crisp on Retina/mobile screens.
+      // The CSS size stays the display size (canvas is stretched to its container), while
+      // the bitmap is denser. Cap the longest side so high zoom can't allocate a huge
+      // canvas (which would exhaust memory or exceed the browser's max canvas size).
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const MAX_CANVAS_PX = 4096;
+      const fitScale = (Math.min(avail, 1400) / base.width) * zoom;
+      let renderScale = fitScale * dpr;
+      const over = Math.max((base.width * renderScale) / MAX_CANVAS_PX, (base.height * renderScale) / MAX_CANVAS_PX, 1);
+      renderScale /= over;
+      const vp = page.getViewport({ scale: renderScale });
       canvas.width = vp.width; canvas.height = vp.height;
       const ctx = canvas.getContext('2d');
       if (!ctx) return;
@@ -1807,9 +1816,83 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     if (!main) return;
 
     let startX = 0, startY = 0, startSL = 0, startST = 0, panning = false;
+    // Velocity tracking for flick momentum (finger px / ms).
+    let lastX = 0, lastY = 0, lastT = 0, vx = 0, vy = 0;
+    let touchStartT = 0;
+    // Double-tap tracking (pan tool only).
+    let lastTapT = 0, lastTapX = 0, lastTapY = 0;
+    let momentumId = 0;
+    const stopMomentum = () => {
+      if (momentumId) { cancelAnimationFrame(momentumId); momentumId = 0; }
+      // Clear any leftover zoom-animation transform so an interrupted gesture is clean.
+      const layer = zoomLayerRef.current;
+      if (layer && !isPinchRef.current) { layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = ''; }
+    };
+
+    // Smoothly zoom toward a point (double-tap). Animates a transform, then commits
+    // the real zoom + focal anchor, reusing momentumId so a new touch cancels it.
+    const animateZoomTo = (clientX: number, clientY: number) => {
+      const layer = zoomLayerRef.current;
+      const curZoom = zoomRef.current;
+      const targetZoom = curZoom > 1.05 ? 1.0 : 2.0; // toggle fit ⇄ 2×
+      const ratio = targetZoom / (curZoom || 1);
+      if (!layer || Math.abs(ratio - 1) < 0.01) return;
+      let targetEl = (document.elementFromPoint(clientX, clientY) as HTMLElement | null)?.closest('[data-page]') as HTMLElement | null;
+      if (!targetEl) { pageContainerRefs.current.forEach(c => { const r = c.getBoundingClientRect(); if (clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom) targetEl = c; }); }
+      let anchor: { pageNum: number; nx: number; ny: number } | null = null;
+      if (targetEl) {
+        const r = targetEl.getBoundingClientRect();
+        anchor = {
+          pageNum: Number(targetEl.dataset.page) || 1,
+          nx: Math.max(0, Math.min(1, (clientX - r.left) / (r.width || 1))),
+          ny: Math.max(0, Math.min(1, (clientY - r.top) / (r.height || 1))),
+        };
+      }
+      const zr = layer.getBoundingClientRect();
+      layer.style.transformOrigin = `${clientX - zr.left}px ${clientY - zr.top}px`;
+      layer.style.willChange = 'transform';
+      const dur = 200, t0 = performance.now();
+      const ease = (t: number) => 1 - Math.pow(1 - t, 3);
+      const step = (now: number) => {
+        const t = Math.min(1, (now - t0) / dur);
+        layer.style.transform = `scale(${1 + (ratio - 1) * ease(t)})`;
+        if (t < 1) { momentumId = requestAnimationFrame(step); return; }
+        momentumId = 0;
+        layer.style.transform = ''; layer.style.transformOrigin = ''; layer.style.willChange = '';
+        if (anchor) pendingZoomAnchorRef.current = { ...anchor, fx: clientX, fy: clientY };
+        setZoomLevel(targetZoom);
+      };
+      momentumId = requestAnimationFrame(step);
+    };
+
+    // After a flick, keep scrolling with decaying velocity for a native feel.
+    const startMomentum = () => {
+      // Scroll moves opposite to the finger; ignore tiny/slow releases.
+      let sx = -vx, sy = -vy;
+      if (Math.hypot(sx, sy) < 0.05) return;
+      const FRICTION = 0.94;           // velocity retained per 16ms frame
+      const MIN_SPEED = 0.015;         // px/ms — stop threshold
+      let prev = performance.now();
+      const step = (now: number) => {
+        const dt = Math.min(now - prev, 32); prev = now;
+        const decay = Math.pow(FRICTION, dt / 16);
+        sx *= decay; sy *= decay;
+        const maxL = Math.max(0, main.scrollWidth - main.clientWidth);
+        const maxT = Math.max(0, main.scrollHeight - main.clientHeight);
+        const nextL = Math.max(0, Math.min(maxL, main.scrollLeft + sx * dt));
+        const nextT = Math.max(0, Math.min(maxT, main.scrollTop + sy * dt));
+        if (nextL === main.scrollLeft) sx = 0;
+        if (nextT === main.scrollTop) sy = 0;
+        main.scrollLeft = nextL; main.scrollTop = nextT;
+        if (Math.hypot(sx, sy) < MIN_SPEED) { momentumId = 0; return; }
+        momentumId = requestAnimationFrame(step);
+      };
+      momentumId = requestAnimationFrame(step);
+    };
 
     const onTouchStart = (e: TouchEvent) => {
       activeTouchCountRef.current = e.touches.length;
+      stopMomentum();
       if (e.touches.length >= 2) {
         panning = false;
         beginPinch(
@@ -1828,6 +1911,8 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       startY  = e.touches[0].clientY;
       startSL = main.scrollLeft;
       startST = main.scrollTop;
+      lastX = startX; lastY = startY; lastT = performance.now(); vx = 0; vy = 0;
+      touchStartT = performance.now();
     };
 
     const onTouchMove = (e: TouchEvent) => {
@@ -1843,15 +1928,44 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       // One finger → scroll (only while a pan/select gesture is active).
       if (!panning || e.touches.length !== 1 || drawingPtrRef.current !== null) { panning = false; return; }
       e.preventDefault();
-      main.scrollLeft = startSL - (e.touches[0].clientX - startX);
-      main.scrollTop  = startST - (e.touches[0].clientY - startY);
+      const cx = e.touches[0].clientX, cy = e.touches[0].clientY;
+      main.scrollLeft = startSL - (cx - startX);
+      main.scrollTop  = startST - (cy - startY);
+      const now = performance.now();
+      const dt = now - lastT;
+      if (dt > 0) {
+        // Blend for a slightly smoothed velocity estimate.
+        vx = 0.7 * ((cx - lastX) / dt) + 0.3 * vx;
+        vy = 0.7 * ((cy - lastY) / dt) + 0.3 * vy;
+        lastX = cx; lastY = cy; lastT = now;
+      }
     };
 
     const onTouchEnd = (e: TouchEvent) => {
       activeTouchCountRef.current = e.touches.length;
       // A finger lifting out of a two-finger gesture commits the zoom.
       if (isPinchRef.current && e.touches.length < 2) finalizePinch();
-      if (e.touches.length === 0) panning = false;
+      if (e.touches.length === 0) {
+        const t = e.changedTouches[0];
+        const now = performance.now();
+        // Detect a tap: a short, near-stationary single-finger touch.
+        const moved = t ? Math.hypot(t.clientX - startX, t.clientY - startY) : Infinity;
+        const wasTap = panning && t != null && moved < 12 && now - touchStartT < 250;
+        // Double-tap (pan tool only) zooms toward the tapped point.
+        if (wasTap && currentToolRef.current === 'pan') {
+          if (now - lastTapT < 300 && Math.hypot(t.clientX - lastTapX, t.clientY - lastTapY) < 40) {
+            lastTapT = 0;
+            animateZoomTo(t.clientX, t.clientY);
+            panning = false;
+            return;
+          }
+          lastTapT = now; lastTapX = t.clientX; lastTapY = t.clientY;
+        }
+        // Released a single-finger scroll — fling with momentum if it was moving and
+        // the gesture didn't go stale (last sample within ~50ms of release).
+        if (panning && !wasTap && now - lastT < 50) startMomentum();
+        panning = false;
+      }
     };
 
     main.addEventListener('touchstart',  onTouchStart, { passive: false });
@@ -1860,6 +1974,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     main.addEventListener('touchcancel', onTouchEnd,   { passive: true });
 
     return () => {
+      stopMomentum();
       main.removeEventListener('touchstart',  onTouchStart);
       main.removeEventListener('touchmove',   onTouchMove);
       main.removeEventListener('touchend',    onTouchEnd);

--- a/components/pdfExport.tsx
+++ b/components/pdfExport.tsx
@@ -1,0 +1,134 @@
+// Export a marked-up copy of a PDF: the original pages are kept intact (vector,
+// selectable text) and a crisp annotation layer is overlaid on each page that has
+// markups. The annotation layer is rendered with the *exact* same SVG renderer the
+// editor uses on screen, so the download matches what the user sees.
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { PDFDocument, degrees } from 'pdf-lib';
+import { renderAnnotationSvg, type AnyAnnotationData, type ScaleInfo, type ToolType } from './PdfMarkupEditor.tsx';
+import type { PdfAnnotation } from '../types.ts';
+
+export interface ExportOptions {
+  pdfBytes: ArrayBuffer;
+  annotations: PdfAnnotation[];
+  scaleInfo?: ScaleInfo | null;
+  /** Called with 0–1 as each page is processed. */
+  onProgress?: (fraction: number) => void;
+}
+
+// Rasterize a single page's annotations to a transparent PNG at the given pixel size.
+async function rasterizeAnnotations(
+  anns: PdfAnnotation[],
+  pxW: number,
+  pxH: number,
+  scaleInfo?: ScaleInfo | null,
+): Promise<Uint8Array | null> {
+  const svg = (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={pxW}
+      height={pxH}
+      viewBox={`0 0 ${pxW} ${pxH}`}
+    >
+      {anns.map(a =>
+        renderAnnotationSvg(
+          { toolType: a.toolType as ToolType, color: a.color, strokeWidth: a.strokeWidth, data: a.data as AnyAnnotationData },
+          pxW, pxH, a.id, scaleInfo,
+        ),
+      )}
+    </svg>
+  );
+
+  const markup = renderToStaticMarkup(svg);
+  const blob = new Blob([markup], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = await loadImage(url);
+    const canvas = document.createElement('canvas');
+    canvas.width = pxW;
+    canvas.height = pxH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    ctx.drawImage(img, 0, 0, pxW, pxH);
+    const pngBlob = await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, 'image/png'));
+    if (!pngBlob) return null;
+    return new Uint8Array(await pngBlob.arrayBuffer());
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to rasterize annotation layer'));
+    img.src = src;
+  });
+}
+
+// Draw a full-page overlay image, compensating for the page's own rotation so the
+// markup stays aligned (the editor draws annotations on the visually-rotated page).
+function drawFullPageOverlay(
+  page: ReturnType<PDFDocument['getPages']>[number],
+  img: Parameters<ReturnType<PDFDocument['getPages']>[number]['drawImage']>[0],
+  rotation: number,
+) {
+  const { width, height } = page.getSize();
+  if (rotation === 90) {
+    page.drawImage(img, { x: width, y: 0, width: height, height: width, rotate: degrees(90) });
+  } else if (rotation === 180) {
+    page.drawImage(img, { x: width, y: height, width, height, rotate: degrees(180) });
+  } else if (rotation === 270) {
+    page.drawImage(img, { x: 0, y: height, width: height, height: width, rotate: degrees(270) });
+  } else {
+    page.drawImage(img, { x: 0, y: 0, width, height });
+  }
+}
+
+export async function buildMarkedUpPdf(opts: ExportOptions): Promise<Uint8Array> {
+  const { pdfBytes, annotations, scaleInfo, onProgress } = opts;
+  const pdfDoc = await PDFDocument.load(pdfBytes);
+  const pages = pdfDoc.getPages();
+
+  // Group annotations by 1-based page number, dropping the scale-calibration row.
+  const byPage = new Map<number, PdfAnnotation[]>();
+  for (const a of annotations) {
+    if ((a.toolType as ToolType) === 'scale') continue;
+    const list = byPage.get(a.pageNumber);
+    if (list) list.push(a); else byPage.set(a.pageNumber, [a]);
+  }
+
+  // Resolution multiplier for the raster overlay (≈ retina). Capped so a single
+  // page can't produce an enormous PNG.
+  const OVERSAMPLE = 2;
+  const MAX_SIDE = 4096;
+
+  for (let i = 0; i < pages.length; i++) {
+    const page = pages[i];
+    const anns = byPage.get(i + 1);
+    if (anns && anns.length) {
+      const rotation = ((page.getRotation().angle % 360) + 360) % 360;
+      const { width, height } = page.getSize();
+      // Displayed (visual) dimensions account for 90/270 rotation.
+      const dispW = rotation === 90 || rotation === 270 ? height : width;
+      const dispH = rotation === 90 || rotation === 270 ? width : height;
+      let pxW = Math.round(dispW * OVERSAMPLE);
+      let pxH = Math.round(dispH * OVERSAMPLE);
+      const over = Math.max(pxW / MAX_SIDE, pxH / MAX_SIDE, 1);
+      pxW = Math.round(pxW / over);
+      pxH = Math.round(pxH / over);
+
+      const png = await rasterizeAnnotations(anns, pxW, pxH, scaleInfo);
+      if (png) {
+        const embedded = await pdfDoc.embedPng(png);
+        drawFullPageOverlay(page, embedded, rotation);
+      }
+    }
+    onProgress?.((i + 1) / pages.length);
+    // Yield so the progress UI can paint between pages.
+    await new Promise(r => setTimeout(r, 0));
+  }
+
+  return pdfDoc.save();
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jspdf-autotable": "^5.0.8",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.546.0",
+    "pdf-lib": "^1.17.1",
     "pdfjs-dist": "4.4.168",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",


### PR DESCRIPTION
Replace the one-page-at-a-time view (with prev/next page buttons) in the
As-Built markup editor with a continuous vertical scroll that renders every
page stacked, like a normal PDF viewer.

- Render all pages into their own stacked canvases at the current zoom,
  cancelling/superseding in-flight render tasks via a render token.
- Bind drawing, selection, handles, and coordinate mapping to the page the
  pointer is acting on (resolved from each page container's data-page),
  instead of a single global active page.
- Each page gets its own SVG annotation overlay; live previews and the
  text/scale inputs render on the active page only.
- Touch-pan now scrolls the whole document; pinch-zoom re-renders all pages
  and preserves the scroll anchor.
- Header shows a "Page N / total" indicator that tracks the page in view via
  a scroll listener; the prev/next buttons are removed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dt4YYi6vd86nE2HoSzw8km