### PR TITLE
Fix equipment popup list not scrollable when pin has many items

### DIFF
--- a/components/EquipmentMapView.tsx
+++ b/components/EquipmentMapView.tsx
@@ -425,7 +425,7 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
             ">Set location on map</button>
             <div style="font-size:9px;color:#64748b;margin-bottom:4px;">Tap the button, then tap the map — or drag this pin.</div>
           ` : ''}
-          <div style="margin-top:4px;">${itemsHtml}</div>
+          <div style="margin-top:4px;max-height:200px;overflow-y:auto;">${itemsHtml}</div>
         </div>`;
 
       // Shops can be repositioned by hand — drag the pin and we persist the new


### PR DESCRIPTION
Add max-height and overflow-y:auto to the items list container inside
the Leaflet popup so users can scroll through all equipment at a location.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019RCsMs39JP29792owyfczk