### PR TITLE
Fix equipment modal appearing off-screen when list is scrolled

### DIFF
--- a/index.css
+++ b/index.css
@@ -49,7 +49,7 @@ body {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
 }
-.view-transition { animation: viewEnter 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+.view-transition { animation: viewEnter 0.3s cubic-bezier(0.16, 1, 0.3, 1); }
 
 @keyframes statusPulse {
   0%, 100% { box-shadow: 0 0 0 0 currentColor; opacity: 1; }


### PR DESCRIPTION
The .view-transition class applied animation-fill-mode: forwards to the
<main> element, which left transform: translateY(0) active after the
enter animation completed. A persistent CSS transform on an ancestor
causes position: fixed descendants to be positioned relative to that
ancestor instead of the viewport — so when the user scrolled down and
opened the Move modal, it rendered at the top of the scrollable content
rather than the visible viewport.

Removing forwards lets <main> return to its natural (transform-free)
state after the animation, restoring correct fixed-position behaviour
for all modals.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019EBpxHfKfoNkYViYeNStiP