### PR TITLE
Fix cross-company leak in time-tracking admin RLS policies

### DIFF
--- a/supabase/add_inbound_time_entries.sql
+++ b/supabase/add_inbound_time_entries.sql
@@ -62,7 +62,7 @@ CREATE POLICY "admin_update_time_entries" ON inbound_ticket_time_entries
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = inbound_ticket_time_entries.company_id)
     )
   )
   WITH CHECK (
@@ -70,6 +70,6 @@ CREATE POLICY "admin_update_time_entries" ON inbound_ticket_time_entries
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = inbound_ticket_time_entries.company_id)
     )
   );

--- a/supabase/fix_admin_clockout_policy.sql
+++ b/supabase/fix_admin_clockout_policy.sql
@@ -15,7 +15,7 @@ CREATE POLICY "admin_update_time_entries" ON inbound_ticket_time_entries
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = inbound_ticket_time_entries.company_id)
     )
   )
   WITH CHECK (
@@ -23,6 +23,6 @@ CREATE POLICY "admin_update_time_entries" ON inbound_ticket_time_entries
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = inbound_ticket_time_entries.company_id)
     )
   );

--- a/supabase/migrations/20260618000000_add_time_tracking.sql
+++ b/supabase/migrations/20260618000000_add_time_tracking.sql
@@ -118,7 +118,7 @@ CREATE POLICY "time_entries_admin_all" ON time_entries
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_entries.company_id)
     )
   )
   WITH CHECK (
@@ -126,7 +126,7 @@ CREATE POLICY "time_entries_admin_all" ON time_entries
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_entries.company_id)
     )
   );
 

--- a/supabase/migrations/20260619000000_add_foreman_crews.sql
+++ b/supabase/migrations/20260619000000_add_foreman_crews.sql
@@ -62,7 +62,7 @@ CREATE POLICY "time_clock_crews_admin_manage" ON time_clock_crews
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_clock_crews.company_id)
     )
   )
   WITH CHECK (
@@ -70,7 +70,7 @@ CREATE POLICY "time_clock_crews_admin_manage" ON time_clock_crews
       SELECT 1 FROM profiles p
       WHERE p.id = auth.uid()
         AND p.role IN ('ADMIN', 'SUPER_ADMIN')
-        AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_clock_crews.company_id)
     )
   );
 

--- a/supabase/migrations/20260623000000_fix_time_entries_company_gating.sql
+++ b/supabase/migrations/20260623000000_fix_time_entries_company_gating.sql
@@ -1,0 +1,82 @@
+-- =============================================================================
+-- Migration: Fix cross-company leak in time-tracking admin RLS policies
+--
+-- The admin policies on time_entries, time_clock_crews, and
+-- inbound_ticket_time_entries were written as:
+--
+--     (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
+--
+-- The intent was "an ADMIN may only reach rows in their OWN company". But
+-- because BOTH `profiles` and the target table expose a `company_id` column,
+-- Postgres resolved the unqualified `company_id` to the inner subquery's
+-- `profiles.company_id` (p.company_id) -- turning the predicate into
+-- `p.company_id = p.company_id`, which is ALWAYS TRUE. The effect: any ADMIN
+-- (not just SUPER_ADMIN) could read/manage EVERY company's time entries and
+-- crews -- e.g. seeing another company's clock-in info.
+--
+-- Fix: qualify the comparison with the TARGET TABLE's company_id column so the
+-- ADMIN branch is correctly scoped to the admin's own company.
+-- =============================================================================
+
+-- ── time_entries: admins manage their own company's entries; SUPER_ADMIN spans all
+DROP POLICY IF EXISTS "time_entries_admin_all" ON time_entries;
+CREATE POLICY "time_entries_admin_all" ON time_entries
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_entries.company_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_entries.company_id)
+    )
+  );
+
+-- ── time_clock_crews: admins manage their own company's crews; SUPER_ADMIN spans all
+DROP POLICY IF EXISTS "time_clock_crews_admin_manage" ON time_clock_crews;
+CREATE POLICY "time_clock_crews_admin_manage" ON time_clock_crews
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_clock_crews.company_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = time_clock_crews.company_id)
+    )
+  );
+
+-- ── inbound_ticket_time_entries: admins clock out only their own company's techs
+DROP POLICY IF EXISTS "admin_update_time_entries" ON inbound_ticket_time_entries;
+CREATE POLICY "admin_update_time_entries" ON inbound_ticket_time_entries
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = inbound_ticket_time_entries.company_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = inbound_ticket_time_entries.company_id)
+    )
+  );


### PR DESCRIPTION
## Problem

An ADMIN of one company could see clock-in info (and other time-tracking data) belonging to **other companies' employees** — it was not company-gated like the rest of the app.

## Root cause

This was a broken RLS gate at the database level, not a missing one in the app. The admin policies on `time_entries`, `time_clock_crews`, and `inbound_ticket_time_entries` were written as:

```sql
AND (p.role = 'SUPER_ADMIN' OR p.company_id = company_id)
```

The intent was *"an ADMIN may only reach rows in their own company."* But both `profiles` **and** the target tables expose a `company_id` column, so Postgres bound the unqualified `company_id` to the inner subquery's `profiles.company_id` — collapsing the predicate to `p.company_id = p.company_id`, which is **always true**. Net effect: any **ADMIN** (not just SUPER_ADMIN) could read/manage **every** company's time-tracking data.

Confirmed against the live DB — three policies carried the tautology:
- `time_entries.time_entries_admin_all` — the reported clock-in leak
- `time_clock_crews.time_clock_crews_admin_manage`
- `inbound_ticket_time_entries.admin_update_time_entries` (same bug, cross-company write)

## Fix

Qualify the comparison with the target table's own `company_id` column (e.g. `p.company_id = time_entries.company_id`) so the ADMIN branch is scoped to the admin's own company. SUPER_ADMIN still spans all companies.

- Added migration `supabase/migrations/20260623000000_fix_time_entries_company_gating.sql` (drops + recreates the three policies)
- Corrected the original source SQL files so the flaw can't reappear if they're re-run:
  - `supabase/migrations/20260618000000_add_time_tracking.sql`
  - `supabase/migrations/20260619000000_add_foreman_crews.sql`
  - `supabase/add_inbound_time_entries.sql`
  - `supabase/fix_admin_clockout_policy.sql`

## Deploy note

⚠️ The corrective migration still needs to be applied to the **live** database — direct application from the working session was blocked by an approval gate. Run `20260623000000_fix_time_entries_company_gating.sql` via the Supabase SQL Editor (or your migration pipeline) to close the leak in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KchvGkhCfTF9FjcBiwu5Xj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KchvGkhCfTF9FjcBiwu5Xj)_