### PR TITLE
Add sorting to inventory equipment list

### DIFF
--- a/components/InventoryView.tsx
+++ b/components/InventoryView.tsx
@@ -51,7 +51,7 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
   const [isLoading, setIsLoading] = useState(true);
   const [typeFilter, setTypeFilter] = useState<InventoryItemType | 'ALL'>('ALL');
   const [search, setSearch] = useState('');
-  const [sortKey, setSortKey] = useState<'name' | 'type' | 'location'>('name');
+  const [sortKey, setSortKey] = useState<'name' | 'unit' | 'type' | 'location'>('name');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
 
   // Item form state
@@ -129,6 +129,11 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
       let cmp = 0;
       if (sortKey === 'name') {
         cmp = a.name.localeCompare(b.name);
+      } else if (sortKey === 'unit') {
+        if (!a.unitNumber && !b.unitNumber) cmp = 0;
+        else if (!a.unitNumber) cmp = 1;
+        else if (!b.unitNumber) cmp = -1;
+        else cmp = a.unitNumber.localeCompare(b.unitNumber, undefined, { numeric: true, sensitivity: 'base' });
       } else if (sortKey === 'type') {
         cmp = a.itemType.localeCompare(b.itemType);
       } else if (sortKey === 'location') {
@@ -140,7 +145,7 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
     });
   }, [filteredItems, sortKey, sortDir, locationMap]);
 
-  const handleSort = (key: 'name' | 'type' | 'location') => {
+  const handleSort = (key: 'name' | 'unit' | 'type' | 'location') => {
     if (sortKey === key) setSortDir(prev => prev === 'asc' ? 'desc' : 'asc');
     else { setSortKey(key); setSortDir('asc'); }
   };
@@ -243,27 +248,50 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
                 <thead>
                   <tr className={d('border-b', 'border-white/[0.05] bg-white/[0.015]', 'border-slate-100 bg-slate-50/80')}>
                     {([
-                      { label: 'Name', key: 'name' as const },
-                      { label: 'Type', key: 'type' as const },
-                      { label: 'Location / Assignee', key: 'location' as const },
-                      { label: 'Details', key: null },
-                      { label: 'Actions', key: null },
-                    ] as { label: string; key: 'name' | 'type' | 'location' | null }[]).map(h => (
+                      { label: 'Name', key: 'name' as const, secondary: { key: 'unit' as const, label: 'Unit #' } },
+                      { label: 'Type', key: 'type' as const, secondary: null },
+                      { label: 'Location / Assignee', key: 'location' as const, secondary: null },
+                      { label: 'Details', key: null, secondary: null },
+                      { label: 'Actions', key: null, secondary: null },
+                    ] as { label: string; key: 'name' | 'unit' | 'type' | 'location' | null; secondary: { key: 'name' | 'unit' | 'type' | 'location'; label: string } | null }[]).map(h => (
                       <th
                         key={h.label}
-                        onClick={h.key ? () => handleSort(h.key!) : undefined}
-                        className={d(
-                          `px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] ${h.label === 'Actions' ? 'text-right' : ''} ${h.key ? 'cursor-pointer select-none' : ''}`,
-                          `text-slate-600 ${h.key ? 'hover:text-slate-300' : ''}`,
-                          `text-slate-400 ${h.key ? 'hover:text-slate-600' : ''}`,
-                        )}
+                        className={`px-5 py-4 ${h.label === 'Actions' ? 'text-right' : ''}`}
                       >
-                        {h.label}
-                        {h.key && (
-                          <span className={`ml-1 ${sortKey === h.key ? (isDarkMode ? 'text-brand' : 'text-brand') : 'opacity-30'}`}>
-                            {sortKey === h.key && sortDir === 'asc' ? '↑' : '↓'}
-                          </span>
-                        )}
+                        <div className="flex items-center gap-2">
+                          {h.key ? (
+                            <button
+                              onClick={() => handleSort(h.key!)}
+                              className={d(
+                                'text-[9px] font-black uppercase tracking-[0.18em] select-none transition-colors',
+                                `${sortKey === h.key ? 'text-brand' : 'text-slate-600 hover:text-slate-300'}`,
+                                `${sortKey === h.key ? 'text-brand' : 'text-slate-400 hover:text-slate-600'}`,
+                              )}
+                            >
+                              {h.label}
+                              <span className={`ml-1 ${sortKey === h.key ? '' : 'opacity-30'}`}>
+                                {sortKey === h.key && sortDir === 'asc' ? '↑' : '↓'}
+                              </span>
+                            </button>
+                          ) : (
+                            <span className={d('text-[9px] font-black uppercase tracking-[0.18em]', 'text-slate-600', 'text-slate-400')}>{h.label}</span>
+                          )}
+                          {h.secondary && (
+                            <button
+                              onClick={() => handleSort(h.secondary!.key)}
+                              className={d(
+                                'text-[9px] font-black uppercase tracking-[0.18em] select-none transition-colors',
+                                `${sortKey === h.secondary.key ? 'text-brand' : 'text-slate-700 hover:text-slate-300'}`,
+                                `${sortKey === h.secondary.key ? 'text-brand' : 'text-slate-300 hover:text-slate-600'}`,
+                              )}
+                            >
+                              {h.secondary.label}
+                              <span className={`ml-1 ${sortKey === h.secondary.key ? '' : 'opacity-30'}`}>
+                                {sortKey === h.secondary.key && sortDir === 'asc' ? '↑' : '↓'}
+                              </span>
+                            </button>
+                          )}
+                        </div>
                       </th>
                     ))}
                   </tr>

--- a/components/InventoryView.tsx
+++ b/components/InventoryView.tsx
@@ -51,6 +51,8 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
   const [isLoading, setIsLoading] = useState(true);
   const [typeFilter, setTypeFilter] = useState<InventoryItemType | 'ALL'>('ALL');
   const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<'name' | 'type' | 'location'>('name');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
 
   // Item form state
   const [showItemForm, setShowItemForm] = useState(false);
@@ -121,6 +123,27 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
       return true;
     });
   }, [items, typeFilter, search]);
+
+  const sortedItems = useMemo(() => {
+    return [...filteredItems].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === 'name') {
+        cmp = a.name.localeCompare(b.name);
+      } else if (sortKey === 'type') {
+        cmp = a.itemType.localeCompare(b.itemType);
+      } else if (sortKey === 'location') {
+        const aLoc = (a.currentLocationId ? locationMap.get(a.currentLocationId)?.name : '') || '';
+        const bLoc = (b.currentLocationId ? locationMap.get(b.currentLocationId)?.name : '') || '';
+        cmp = aLoc.localeCompare(bLoc);
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [filteredItems, sortKey, sortDir, locationMap]);
+
+  const handleSort = (key: 'name' | 'type' | 'location') => {
+    if (sortKey === key) setSortDir(prev => prev === 'asc' ? 'desc' : 'asc');
+    else { setSortKey(key); setSortDir('asc'); }
+  };
 
   const d = (cls: string, dark: string, light: string) => isDarkMode ? `${cls} ${dark}` : `${cls} ${light}`;
 
@@ -219,13 +242,34 @@ export const InventoryView: React.FC<InventoryViewProps> = ({ sessionUser, users
               <table className="w-full text-left">
                 <thead>
                   <tr className={d('border-b', 'border-white/[0.05] bg-white/[0.015]', 'border-slate-100 bg-slate-50/80')}>
-                    {['Name', 'Type', 'Location / Assignee', 'Details', 'Actions'].map(h => (
-                      <th key={h} className={d(`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] ${h === 'Actions' ? 'text-right' : ''}`, 'text-slate-600', 'text-slate-400')}>{h}</th>
+                    {([
+                      { label: 'Name', key: 'name' as const },
+                      { label: 'Type', key: 'type' as const },
+                      { label: 'Location / Assignee', key: 'location' as const },
+                      { label: 'Details', key: null },
+                      { label: 'Actions', key: null },
+                    ] as { label: string; key: 'name' | 'type' | 'location' | null }[]).map(h => (
+                      <th
+                        key={h.label}
+                        onClick={h.key ? () => handleSort(h.key!) : undefined}
+                        className={d(
+                          `px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] ${h.label === 'Actions' ? 'text-right' : ''} ${h.key ? 'cursor-pointer select-none' : ''}`,
+                          `text-slate-600 ${h.key ? 'hover:text-slate-300' : ''}`,
+                          `text-slate-400 ${h.key ? 'hover:text-slate-600' : ''}`,
+                        )}
+                      >
+                        {h.label}
+                        {h.key && (
+                          <span className={`ml-1 ${sortKey === h.key ? (isDarkMode ? 'text-brand' : 'text-brand') : 'opacity-30'}`}>
+                            {sortKey === h.key && sortDir === 'asc' ? '↑' : '↓'}
+                          </span>
+                        )}
+                      </th>
                     ))}
                   </tr>
                 </thead>
                 <tbody className={d('divide-y', 'divide-white/[0.03]', 'divide-slate-50')}>
-                  {filteredItems.map(item => {
+                  {sortedItems.map(item => {
                     const loc = item.currentLocationId ? locationMap.get(item.currentLocationId) : null;
                     const assignee = item.currentAssigneeId ? userMap.get(item.currentAssigneeId) : null;
                     const job = item.currentJobId ? jobMap.get(item.currentJobId) : null;


### PR DESCRIPTION
## Summary

- Clicking **Name**, **Unit #**, **Type**, or **Location/Assignee** column headers sorts the equipment list by that field
- Clicking the active sort column toggles between ascending (↑) and descending (↓)
- Unit # uses numeric locale sort so values like 1b, 2, 10, 22b order correctly; items without a unit number sort to the end
- Active sort column is highlighted in brand color; inactive sortable columns show a faded indicator

## Test plan

- [ ] Open the Inventory tab → Items view
- [ ] Click **Name** header — list sorts A→Z; click again for Z→A
- [ ] Click **Unit #** header — list sorts by unit number numerically; items without a unit number appear at the end
- [ ] Click **Type** header — Equipment and Material groups together
- [ ] Click **Location / Assignee** header — sorts by location name
- [ ] Confirm sort indicator (↑/↓) highlights on the active column and is dimmed on others
- [ ] Confirm filtering (All / Equipment / Materials + search) still works with sorting active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cfvNDTf1674ngzUqiw2nn

---
_Generated by [Claude Code](https://claude.ai/code/session_011cfvNDTf1674ngzUqiw2nn)_