### PR TITLE
Separate job name from site contact on jobs

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -370,9 +370,11 @@ const App: React.FC = () => {
     const newJob: Job = { 
       id: crypto.randomUUID(), 
       companyId: sessionUser!.companyId,
-      jobNumber: ticketData.jobNumber, 
-      customer: ticketData.siteContact || 'Auto-Detected Client', 
-      address: ticketData.street, 
+      jobNumber: ticketData.jobNumber,
+      jobName: '',
+      customer: '',
+      siteContact: ticketData.siteContact || '',
+      address: ticketData.street,
       city: ticketData.city, 
       state: ticketData.state, 
       county: ticketData.county, 
@@ -597,7 +599,7 @@ const App: React.FC = () => {
     const jobTickets = tickets.filter(t => t.jobNumber === jobNumber && !t.isArchived);
     if (jobTickets.length === 0) return;
     const firstTkt = jobTickets[0];
-    const newJob: Job = { id: crypto.randomUUID(), companyId: sessionUser!.companyId, jobNumber: jobNumber, customer: firstTkt.siteContact || 'Client', address: firstTkt.street, city: firstTkt.city, state: firstTkt.state, county: firstTkt.county, createdAt: Date.now(), isComplete: false };
+    const newJob: Job = { id: crypto.randomUUID(), companyId: sessionUser!.companyId, jobNumber: jobNumber, jobName: '', customer: '', siteContact: firstTkt.siteContact || '', address: firstTkt.street, city: firstTkt.city, state: firstTkt.state, county: firstTkt.county, createdAt: Date.now(), isComplete: false };
     try {
       const saved = await apiService.saveJob(newJob);
       setJobs(prev => [...prev, saved]);
@@ -955,7 +957,7 @@ const App: React.FC = () => {
                         <tr className={`border-b ${isDarkMode ? 'border-white/[0.05] bg-white/[0.015]' : 'border-slate-100 bg-slate-50/80'}`}>
                           <th className={`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>Job #</th>
                           <th className={`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>Tickets</th>
-                          <th className={`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>Client / Location</th>
+                          <th className={`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>Job Name / Location</th>
                           <th className={`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] text-center ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>Status</th>
                           <th className={`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] text-right ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>Dig By</th>
                           <th className={`px-5 py-4 text-[9px] font-black uppercase tracking-[0.18em] text-center ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>Dig Begun?</th>
@@ -994,7 +996,7 @@ const App: React.FC = () => {
                                   <span className={`text-[10px] font-black uppercase px-2 py-1 rounded-lg ${isDarkMode ? 'bg-white/[0.04] text-slate-500' : 'bg-slate-100 text-slate-500'}`}>{jobTickets.length}</span>
                                 </td>
                                 <td className="px-5 py-4">
-                                  <p className={`text-[12px] font-bold truncate max-w-[200px] ${isDarkMode ? 'text-slate-200' : 'text-slate-800'}`}>{jobEntity?.customer || 'Direct Client'}</p>
+                                  <p className={`text-[12px] font-bold truncate max-w-[200px] ${isDarkMode ? 'text-slate-200' : 'text-slate-800'}`}>{jobEntity?.jobName || `Job #${jobNum}`}</p>
                                   <p className={`text-[10px] truncate max-w-[200px] mt-0.5 ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>{jobEntity?.city || 'Field Location'}</p>
                                 </td>
                                 <td className="px-5 py-4 text-center">

--- a/components/AsBuiltView.tsx
+++ b/components/AsBuiltView.tsx
@@ -32,7 +32,7 @@ export const AsBuiltView: React.FC<AsBuiltViewProps> = ({ jobs, sessionUser, isA
     const q = search.toLowerCase();
     const matchesSearch =
       job.jobNumber.toLowerCase().includes(q) ||
-      job.customer.toLowerCase().includes(q) ||
+      (job.jobName || '').toLowerCase().includes(q) ||
       job.address.toLowerCase().includes(q);
     if (!matchesSearch) return false;
     if (hideNoPdfs) {
@@ -249,7 +249,7 @@ export const AsBuiltView: React.FC<AsBuiltViewProps> = ({ jobs, sessionUser, isA
                         Job #{job.jobNumber}
                       </p>
                       <p className={`text-xs truncate ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
-                        {job.customer} — {job.address}, {job.city}
+                        {job.jobName ? `${job.jobName} — ` : ''}{job.address}, {job.city}
                       </p>
                     </div>
 

--- a/components/EquipmentMapView.tsx
+++ b/components/EquipmentMapView.tsx
@@ -264,7 +264,7 @@ const EquipmentMapView: React.FC<EquipmentMapViewProps> = ({
           placement = {
             key, kind: 'job',
             label: `Job #${job.jobNumber}`,
-            sublabel: geoQuery || job.customer || '',
+            sublabel: geoQuery || job.jobName || '',
             items: [], geo,
           };
           // Prefer coords already resolved on one of the job's dig tickets.
@@ -803,7 +803,7 @@ const RelocateModal: React.FC<RelocateModalProps> = ({
             <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">Job</p>
             <select className={inputCls} value={jobId} onChange={e => setJobId(e.target.value)}>
               <option value="">— Select job —</option>
-              {activeJobs.map(j => <option key={j.id} value={j.id}>#{j.jobNumber} — {j.customer}</option>)}
+              {activeJobs.map(j => <option key={j.id} value={j.id}>#{j.jobNumber}{j.jobName ? ` — ${j.jobName}` : ''}</option>)}
             </select>
             {activeJobs.length === 0 && <p className={d('text-[10px] text-slate-600', 'text-[10px] text-slate-400')}>No active jobs available.</p>}
           </div>

--- a/components/InventoryView.tsx
+++ b/components/InventoryView.tsx
@@ -736,7 +736,7 @@ const ItemFormModal: React.FC<ItemFormProps> = ({ item, locations, users, jobs, 
               <select className={inputCls} value={currentJobId} onChange={e => setCurrentJobId(e.target.value)}>
                 <option value="">— Select job —</option>
                 {jobs.filter(j => !j.isComplete).map(j => (
-                  <option key={j.id} value={j.id}>#{j.jobNumber} — {j.customer}</option>
+                  <option key={j.id} value={j.id}>#{j.jobNumber}{j.jobName ? ` — ${j.jobName}` : ""}</option>
                 ))}
               </select>
             )}
@@ -1028,7 +1028,7 @@ const MovementModal: React.FC<MovementModalProps> = ({ item, locations, users, j
             <select className={inputCls} value={jobId} onChange={e => setJobId(e.target.value)}>
               <option value="">— Select job —</option>
               {jobs.filter(j => !j.isComplete).map(j => (
-                <option key={j.id} value={j.id}>#{j.jobNumber} — {j.customer}</option>
+                <option key={j.id} value={j.id}>#{j.jobNumber}{j.jobName ? ` — ${j.jobName}` : ""}</option>
               ))}
             </select>
           </div>
@@ -1082,7 +1082,7 @@ const MovementModal: React.FC<MovementModalProps> = ({ item, locations, users, j
             <p className="text-[9px] font-black uppercase tracking-widest text-slate-500">Linked Job (optional)</p>
             <select className={inputCls} value={jobId} onChange={e => setJobId(e.target.value)}>
               <option value="">— No job —</option>
-              {jobs.filter(j => !j.isComplete).map(j => <option key={j.id} value={j.id}>#{j.jobNumber} — {j.customer}</option>)}
+              {jobs.filter(j => !j.isComplete).map(j => <option key={j.id} value={j.id}>#{j.jobNumber}{j.jobName ? ` — ${j.jobName}` : ""}</option>)}
             </select>
           </div>
         )}

--- a/components/JobForm.tsx
+++ b/components/JobForm.tsx
@@ -12,7 +12,7 @@ interface JobFormProps {
 
 const JobForm: React.FC<JobFormProps> = ({ onSave, onClose, initialData, isDarkMode }) => {
   const [formData, setFormData] = useState({
-    jobNumber: '', customer: '', address: '', city: '', state: '', county: '',
+    jobNumber: '', jobName: '', customer: '', siteContact: '', address: '', city: '', state: '', county: '',
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -20,7 +20,9 @@ const JobForm: React.FC<JobFormProps> = ({ onSave, onClose, initialData, isDarkM
     if (initialData) {
       setFormData({
         jobNumber: initialData.jobNumber,
-        customer: initialData.customer,
+        jobName: initialData.jobName || '',
+        customer: initialData.customer || '',
+        siteContact: initialData.siteContact || '',
         address: initialData.address,
         city: initialData.city,
         state: initialData.state,
@@ -59,8 +61,8 @@ const JobForm: React.FC<JobFormProps> = ({ onSave, onClose, initialData, isDarkM
               <input required className={`w-full px-3 py-2 border rounded-lg text-xs font-bold outline-none focus:ring-4 focus:ring-brand/10 transition-all ${isDarkMode ? 'bg-white/5 border-white/10 text-white' : 'bg-slate-50 border-slate-200 text-slate-900'}`} value={formData.jobNumber} onChange={e => setFormData({...formData, jobNumber: e.target.value})} placeholder="e.g. 25-001" />
             </div>
             <div className="space-y-1">
-              <label className="text-[9px] font-black uppercase text-slate-400">Customer</label>
-              <input required className={`w-full px-3 py-2 border rounded-lg text-xs font-bold outline-none focus:ring-4 focus:ring-brand/10 transition-all ${isDarkMode ? 'bg-white/5 border-white/10 text-white' : 'bg-slate-50 border-slate-200 text-slate-900'}`} value={formData.customer} onChange={e => setFormData({...formData, customer: e.target.value})} placeholder="Client Name" />
+              <label className="text-[9px] font-black uppercase text-slate-400">Job Name</label>
+              <input required className={`w-full px-3 py-2 border rounded-lg text-xs font-bold outline-none focus:ring-4 focus:ring-brand/10 transition-all ${isDarkMode ? 'bg-white/5 border-white/10 text-white' : 'bg-slate-50 border-slate-200 text-slate-900'}`} value={formData.jobName} onChange={e => setFormData({...formData, jobName: e.target.value})} placeholder="e.g. Prairie Ridge Phase 2" />
             </div>
           </div>
 
@@ -84,8 +86,13 @@ const JobForm: React.FC<JobFormProps> = ({ onSave, onClose, initialData, isDarkM
             </div>
           </div>
 
-          <button 
-            type="submit" 
+          <div className="space-y-1">
+            <label className="text-[9px] font-black uppercase text-slate-400">Site Contact</label>
+            <input className={`w-full px-3 py-2 border rounded-lg text-xs font-bold outline-none focus:ring-4 focus:ring-brand/10 transition-all ${isDarkMode ? 'bg-white/5 border-white/10 text-white' : 'bg-slate-50 border-slate-200 text-slate-900'}`} value={formData.siteContact} onChange={e => setFormData({...formData, siteContact: e.target.value})} placeholder="On-site contact name / phone" />
+          </div>
+
+          <button
+            type="submit"
             disabled={isSubmitting}
             className="w-full bg-brand text-[#0f172a] py-3 rounded-xl font-black text-[10px] uppercase tracking-widest shadow-lg shadow-brand/10 mt-2 transition-all hover:scale-[1.01] active:scale-95 disabled:opacity-50"
           >

--- a/components/JobReview.tsx
+++ b/components/JobReview.tsx
@@ -98,7 +98,7 @@ export const JobReview: React.FC<JobReviewProps> = ({ tickets, jobs, isDarkMode,
                     >
                       Job #{jobNum}
                     </button>
-                    <p className={`text-[10px] font-bold uppercase tracking-widest mt-1 truncate max-w-[180px] ${isDarkMode ? 'text-slate-400' : 'text-slate-700'}`}>{jobEntity?.customer || 'Unknown Client'}</p>
+                    <p className={`text-[10px] font-bold uppercase tracking-widest mt-1 truncate max-w-[180px] ${isDarkMode ? 'text-slate-400' : 'text-slate-700'}`}>{jobEntity?.jobName || `Job #${jobNum}`}</p>
                   </div>
                   {isComplete && <div className="bg-emerald-500/10 text-emerald-500 px-2 py-0.5 rounded text-[8px] font-black uppercase">Complete</div>}
                 </div>
@@ -152,7 +152,7 @@ export const JobReview: React.FC<JobReviewProps> = ({ tickets, jobs, isDarkMode,
             <thead className={`${isDarkMode ? 'bg-black/20' : 'bg-slate-50'} border-b border-black/5`}>
               <tr>
                 <th className="px-6 py-4 text-[9px] font-black uppercase tracking-[0.2em] text-slate-500">Job Reference</th>
-                <th className="px-6 py-4 text-[9px] font-black uppercase tracking-[0.2em] text-slate-500">Customer</th>
+                <th className="px-6 py-4 text-[9px] font-black uppercase tracking-[0.2em] text-slate-500">Job Name</th>
                 <th className="px-6 py-4 text-[9px] font-black uppercase tracking-[0.2em] text-slate-500">Status</th>
                 <th className="px-6 py-4 text-[9px] font-black uppercase tracking-[0.2em] text-slate-500 text-right">Tickets</th>
               </tr>
@@ -183,7 +183,7 @@ export const JobReview: React.FC<JobReviewProps> = ({ tickets, jobs, isDarkMode,
                           </button>
                         </div>
                       </td>
-                      <td className="px-6 py-4 text-xs font-bold">{jobEntity?.customer || 'Direct'}</td>
+                      <td className="px-6 py-4 text-xs font-bold">{jobEntity?.jobName || `Job #${jobNum}`}</td>
                       <td className="px-6 py-4">
                         <span className={`px-2 py-0.5 rounded text-[8px] font-black uppercase ${jobEntity?.isComplete ? 'bg-emerald-500/10 text-emerald-500' : 'bg-blue-500/10 text-blue-500'}`}>
                           {jobEntity?.isComplete ? 'Closed' : 'Active'}

--- a/components/JobSummaryModal.tsx
+++ b/components/JobSummaryModal.tsx
@@ -52,8 +52,8 @@ export const JobSummaryModal: React.FC<JobSummaryModalProps> = ({
           {/* Main Info Card */}
           <div className="space-y-4">
             <div className="space-y-1">
-              <label className="text-[9px] font-black uppercase tracking-widest text-slate-400">Customer / Entity</label>
-              <p className={`text-base font-black uppercase tracking-tight ${isDarkMode ? 'text-white' : 'text-slate-950'}`}>{job.customer}</p>
+              <label className="text-[9px] font-black uppercase tracking-widest text-slate-400">Job Name</label>
+              <p className={`text-base font-black uppercase tracking-tight ${isDarkMode ? 'text-white' : 'text-slate-950'}`}>{job.jobName || `Job #${job.jobNumber}`}</p>
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1">
@@ -65,6 +65,12 @@ export const JobSummaryModal: React.FC<JobSummaryModalProps> = ({
                 <p className={`text-[11px] font-bold ${isDarkMode ? 'text-slate-300' : 'text-slate-950'}`}>{job.city}, {job.state}</p>
               </div>
             </div>
+            {job.siteContact && (
+              <div className="space-y-1">
+                <label className="text-[9px] font-black uppercase tracking-widest text-slate-400">Site Contact</label>
+                <p className={`text-[11px] font-bold ${isDarkMode ? 'text-slate-300' : 'text-slate-950'}`}>{job.siteContact}</p>
+              </div>
+            )}
           </div>
 
           {/* Job Prints Preview */}

--- a/components/PhotoManager.tsx
+++ b/components/PhotoManager.tsx
@@ -100,7 +100,7 @@ const PhotoManager: React.FC<PhotoManagerProps> = ({
       .filter(j =>
         !q ||
         j.jobNumber.toLowerCase().includes(q) ||
-        j.customer.toLowerCase().includes(q) ||
+        (j.jobName || '').toLowerCase().includes(q) ||
         j.address.toLowerCase().includes(q) ||
         j.city.toLowerCase().includes(q),
       )
@@ -337,7 +337,7 @@ const PhotoManager: React.FC<PhotoManagerProps> = ({
                   </svg>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className={`font-black text-sm uppercase tracking-wider truncate ${tp}`}>{currentJob.customer}</p>
+                  <p className={`font-black text-sm uppercase tracking-wider truncate ${tp}`}>{currentJob.jobName || `Job #${currentJob.jobNumber}`}</p>
                   <p className={`text-xs truncate ${ts}`}>{currentJob.address}, {currentJob.city}</p>
                 </div>
                 {currentJob.isComplete && (
@@ -570,7 +570,7 @@ const PhotoManager: React.FC<PhotoManagerProps> = ({
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0">
                           <p className={`font-black text-xs uppercase tracking-wider ${tp}`}>Job #{job.jobNumber}</p>
-                          <p className={`text-[11px] font-semibold truncate ${ts} mt-0.5`}>{job.customer}</p>
+                          <p className={`text-[11px] font-semibold truncate ${ts} mt-0.5`}>{job.jobName || '—'}</p>
                           <p className={`text-[10px] truncate ${tm}`}>{job.address}, {job.city}</p>
                         </div>
                         <div className={`w-7 h-7 rounded-lg flex items-center justify-center shrink-0 transition-colors ${dm ? 'bg-white/5 group-hover:bg-brand/10' : 'bg-slate-100 group-hover:bg-brand/10'}`}>

--- a/components/timetracking/TimeTrackingView.tsx
+++ b/components/timetracking/TimeTrackingView.tsx
@@ -56,7 +56,7 @@ export default function TimeTrackingView({ sessionUser, jobs, isDarkMode }: Time
       .map(j => ({
         kind: 'dig' as const,
         ref: j.id,
-        label: `${j.jobNumber} — ${j.customer || [j.address, j.city].filter(Boolean).join(', ') || 'Dig job'}`,
+        label: `${j.jobNumber} — ${j.jobName || [j.address, j.city].filter(Boolean).join(', ') || 'Dig job'}`,
       }));
     const svc: ClockableJob[] = serviceJobs.map(j => ({
       kind: 'service' as const,

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -85,11 +85,13 @@ create table if not exists profiles (
 );
 
 create table if not exists jobs (
-    id uuid primary key, 
+    id uuid primary key,
     company_id uuid references companies(id) not null,
-    job_number text, 
-    customer text, 
-    address text, 
+    job_number text,
+    job_name text,
+    customer text,
+    site_contact text,
+    address text,
     city text, 
     state text, 
     county text, 
@@ -279,7 +281,13 @@ ALTER TABLE tickets ADD COLUMN IF NOT EXISTS bbox_lng2 double precision;
 ALTER TABLE tickets ADD COLUMN IF NOT EXISTS bbox_lat3 double precision;
 ALTER TABLE tickets ADD COLUMN IF NOT EXISTS bbox_lng3 double precision;
 ALTER TABLE tickets ADD COLUMN IF NOT EXISTS bbox_lat4 double precision;
-ALTER TABLE tickets ADD COLUMN IF NOT EXISTS bbox_lng4 double precision;`;
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS bbox_lng4 double precision;
+
+-- Migration: separate job name from site contact on existing installations
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS job_name text;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS site_contact text;
+-- Existing rows stored the parsed site contact in "customer"; move it to site_contact.
+UPDATE jobs SET site_contact = customer WHERE site_contact IS NULL AND customer IS NOT NULL;`;
 
 const generateUUID = () => crypto.randomUUID();
 
@@ -287,7 +295,9 @@ const mapJob = (data: any): Job => ({
   id: data.id,
   companyId: data.company_id,
   jobNumber: data.job_number || 'UNKNOWN',
+  jobName: data.job_name || '',
   customer: data.customer || '',
+  siteContact: data.site_contact || '',
   address: data.address || '',
   city: data.city || '',
   state: data.state || '',
@@ -387,7 +397,9 @@ export const apiService = {
       id: job.id,
       company_id: job.companyId,
       job_number: job.jobNumber,
+      job_name: job.jobName,
       customer: job.customer,
+      site_contact: job.siteContact,
       address: job.address,
       city: job.city,
       state: job.state,

--- a/supabase/migrations/20260623000000_add_job_name_and_site_contact.sql
+++ b/supabase/migrations/20260623000000_add_job_name_and_site_contact.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- Migration: Separate job name from site contact on jobs
+--
+-- Previously the ticket parser dropped the extracted "site contact" into the
+-- jobs.customer column, so the dashboard showed the on-site contact where a
+-- job/client label was expected. This migration:
+--   * adds jobs.job_name   — a user-entered name shown throughout the app in
+--                            place of the old client/customer label, and
+--   * adds jobs.site_contact — where the parsed on-site contact now lives.
+--
+-- PURELY ADDITIVE. Both columns are nullable. Existing rows had the site
+-- contact stored in "customer", so we backfill site_contact from customer to
+-- preserve that information in the correct field. job_name is left blank for
+-- existing jobs and can be filled in from the Update Job Profile screen.
+-- =============================================================================
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS job_name text,
+  ADD COLUMN IF NOT EXISTS site_contact text;
+
+UPDATE public.jobs
+  SET site_contact = customer
+  WHERE site_contact IS NULL AND customer IS NOT NULL;

--- a/types.ts
+++ b/types.ts
@@ -131,7 +131,10 @@ export interface Job {
   id: string;
   companyId: string;
   jobNumber: string;
+  jobName: string;
+  /** @deprecated Legacy field. Site contact info is now tracked via `siteContact`. */
   customer: string;
+  siteContact: string;
   address: string;
   city: string;
   state: string;


### PR DESCRIPTION
The ticket parser was dropping the extracted site contact into the job's
"customer" field, so the dashboard and job screens showed the on-site
contact where a job/client label belonged.

- Add `jobName` (user-entered) and `siteContact` to the Job model + jobs
  table, and stop routing parsed site contact into `customer`.
- Update Job (Profile) form: replace the Customer field with a Job Name
  field and add a Site Contact field.
- Show Job Name in place of client/customer throughout the app
  (dashboard, job review, summary, photos, as-built, map, inventory,
  time tracking).
- Backfill site_contact from the legacy customer value for existing rows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VdF6iEUc4AgPdaWfR531nY