### PR TITLE
Fix ticket staying PENDING a day past its Work Valid Date

### DIFF
--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -60,8 +60,9 @@ export const getTicketStatus = (ticket: DigTicket): TicketStatus => {
   if (ticket.refreshRequested) return TicketStatus.REFRESH_NEEDED;
 
   const now = new Date();
-  // Ticket clears at 11:59 PM on workDate, so the first day crews can dig is workDate + 1
-  const start = parseDateLocal(addDaysToDateStr(ticket.workDate, 1), false);
+  // Ticket clears at 12:00 AM on the Work Valid Date (workDate), which is the
+  // first moment crews can dig. (workDate defaults to callInDate + 2 days.)
+  const start = parseDateLocal(ticket.workDate, false);
   const exp = parseDateLocal(ticket.expires, true);
   
   // Calculate days remaining relative to the start of "now" for simpler day-based logic


### PR DESCRIPTION
## Problem

A ticket whose **Work Valid Date is today** was still displayed as `PENDING` and only cleared to `VALID` at 12 AM the *next* day — the "should have been clear at 12 am today but it's still pending" report.

## Root cause

In `utils/dateUtils.ts`, `getTicketStatus()` computed the validity start as `workDate + 1`:

```js
const start = parseDateLocal(addDaysToDateStr(ticket.workDate, 1), false); // workDate + 1
```

A ticket is `VALID` once `now >= start`, otherwise it falls through to `PENDING`. With `start = workDate + 1` at midnight, the ticket stayed `PENDING` for an extra full day.

This contradicted the app's own definitions:
- The form field is labeled **"Work Valid Date"** — work is valid *on* that date.
- The function header comment states the ticket *"becomes valid at midnight two days after the call-in date"*, and `workDate` auto-fills as `callInDate + 2`. The old code effectively made it `callInDate + 3`.

## Fix

```js
const start = parseDateLocal(ticket.workDate, false); // 12:00 AM on the Work Valid Date
```

Tickets now clear to `VALID` at midnight of their Work Valid Date, so a ticket valid today reads as clear starting 12 AM today.

## Notes
- `addDaysToDateStr` is still used elsewhere (dig-by-date fallback), so no dead import.
- A stale nested copy at `DigTrackPro/DigTrackPro-main/` has the same old logic but is not part of the built/deployed app, so it was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMb1qH364kGYVthjgZrgku)_