### PR TITLE
Skip weekends in the scheduler by default

### DIFF
--- a/components/scheduling/ScheduleImportModal.tsx
+++ b/components/scheduling/ScheduleImportModal.tsx
@@ -1,0 +1,384 @@
+import { useMemo, useRef, useState } from 'react';
+import * as XLSX from 'xlsx';
+import { X, FileSpreadsheet, CheckCircle, AlertCircle, Sparkles } from 'lucide-react';
+import type { Crew, JobOption } from './Scheduler.tsx';
+
+// A single normalized row parsed from the uploaded spreadsheet. `valid` rows are
+// the ones that will actually be turned into schedule blocks on import.
+export interface ScheduleImportRow {
+  crewName:     string;
+  jobNumber:    string;
+  location:     string;
+  startDate:    string;   // ISO YYYY-MM-DD ('' when unparseable)
+  durationDays: number;
+  rawStart:     string;   // original cell text, kept for error display
+  valid:        boolean;
+  error?:       string;
+}
+
+interface ScheduleImportModalProps {
+  crews: Crew[];
+  jobs:  JobOption[];
+  onImport: (rows: ScheduleImportRow[]) => void;
+  onClose: () => void;
+}
+
+// ── Header matching ───────────────────────────────────────────────────────────
+function norm(s: string) { return s.toLowerCase().replace(/[\s_\-\/\.#()]/g, ''); }
+function findKey(keys: string[], candidates: string[]): string | undefined {
+  return keys.find(k => candidates.includes(norm(k)));
+}
+
+// ── Date parsing ─────────────────────────────────────────────────────────────
+const pad = (n: string | number) => String(n).padStart(2, '0');
+
+function dateToISO(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Parse a spreadsheet date cell — handles JS Date objects, ISO, and US-style strings. */
+function parseFlexibleDate(v: unknown): string | null {
+  if (v == null || v === '') return null;
+  if (v instanceof Date && !isNaN(v.getTime())) return dateToISO(v);
+
+  const s = String(v).trim();
+  if (!s) return null;
+
+  // ISO: YYYY-MM-DD (or with time)
+  let m = s.match(/^(\d{4})-(\d{1,2})-(\d{1,2})/);
+  if (m) return `${m[1]}-${pad(m[2])}-${pad(m[3])}`;
+
+  // US: M/D/YYYY, M-D-YY, etc.
+  m = s.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})/);
+  if (m) {
+    let year = parseInt(m[3], 10);
+    if (year < 100) year += 2000;
+    return `${year}-${pad(m[1])}-${pad(m[2])}`;
+  }
+
+  // Fallback to the engine's own parser (e.g. "June 26 2026")
+  const d = new Date(s);
+  if (!isNaN(d.getTime())) return dateToISO(d);
+  return null;
+}
+
+function parseNumber(v: unknown): number | null {
+  if (v == null || v === '') return null;
+  const cleaned = String(v).replace(/[^0-9.]/g, '');
+  if (!cleaned) return null;
+  const n = parseFloat(cleaned);
+  return isNaN(n) ? null : n;
+}
+
+async function parseSpreadsheet(file: File): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const data = new Uint8Array(e.target!.result as ArrayBuffer);
+        // cellDates lets real date cells come through as JS Date objects.
+        const wb = XLSX.read(data, { type: 'array', cellDates: true });
+        const ws = wb.Sheets[wb.SheetNames[0]];
+        resolve(XLSX.utils.sheet_to_json<Record<string, unknown>>(ws, { defval: '' }));
+      } catch (err) { reject(err); }
+    };
+    reader.onerror = reject;
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+function toScheduleRows(
+  raw: Record<string, unknown>[],
+  jobs: JobOption[],
+): ScheduleImportRow[] {
+  const jobByNumber = new Map(jobs.map(j => [j.jobNumber.toLowerCase(), j]));
+
+  return raw.map(row => {
+    const keys = Object.keys(row);
+    const crewKey  = findKey(keys, ['crew', 'crewname', 'team', 'crewid', 'assignedcrew', 'crews']);
+    const jobKey   = findKey(keys, ['job', 'jobnumber', 'jobno', 'jobid', 'number', 'wo', 'workorder', 'ticket', 'jobnum']);
+    const locKey   = findKey(keys, ['location', 'address', 'site', 'jobsite', 'jobname', 'place', 'description']);
+    const startKey = findKey(keys, ['startdate', 'start', 'date', 'begindate', 'scheduleddate', 'startday', 'day']);
+    const daysKey  = findKey(keys, ['days', 'duration', 'durationdays', 'length', 'numdays', 'estimateddays', 'estdays', 'jobdays', 'workdays']);
+
+    const crewName  = crewKey ? String(row[crewKey] ?? '').trim() : '';
+    const jobNumber = jobKey  ? String(row[jobKey]  ?? '').trim() : '';
+    const rawStart  = startKey ? String(row[startKey] ?? '').trim() : '';
+    const startDate = startKey ? parseFlexibleDate(row[startKey]) : null;
+
+    const matchedJob = jobByNumber.get(jobNumber.toLowerCase());
+    const location  = locKey ? String(row[locKey] ?? '').trim() : (matchedJob?.location ?? '');
+    const parsedDays = daysKey ? parseNumber(row[daysKey]) : null;
+    const durationDays = Math.max(1, Math.round(parsedDays ?? matchedJob?.estimatedDays ?? 1));
+
+    // Validate
+    let error: string | undefined;
+    if (!crewName)        error = 'Missing crew';
+    else if (!jobNumber)  error = 'Missing job number';
+    else if (!startDate)  error = rawStart ? `Unrecognized date "${rawStart}"` : 'Missing start date';
+
+    return {
+      crewName,
+      jobNumber,
+      location,
+      startDate: startDate ?? '',
+      durationDays,
+      rawStart,
+      valid: !error,
+      error,
+    };
+  }).filter(r => r.crewName || r.jobNumber || r.rawStart); // drop fully-blank rows
+}
+
+function downloadTemplate() {
+  const header  = 'crew,jobNumber,location,startDate,days';
+  const example = [
+    'Alpha Crew,J-1001,123 Main St,2026-07-06,5',
+    'Beta Crew,J-1002,456 Oak Ave,2026-07-06,3',
+    'Alpha Crew,J-1003,789 Pine Rd,2026-07-13,7',
+  ].join('\n');
+  const blob = new Blob([`${header}\n${example}`], { type: 'text/csv' });
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement('a');
+  a.href     = url;
+  a.download = 'schedule-template.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+const fmtDate = (iso: string): string => {
+  if (!iso) return '';
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+export default function ScheduleImportModal({ crews, jobs, onImport, onClose }: ScheduleImportModalProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [rows,       setRows]       = useState<ScheduleImportRow[] | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const existingCrewNames = useMemo(
+    () => new Set(crews.map(c => c.name.trim().toLowerCase())),
+    [crews],
+  );
+  const existingJobNumbers = useMemo(
+    () => new Set(jobs.map(j => j.jobNumber.toLowerCase())),
+    [jobs],
+  );
+
+  const validRows   = rows?.filter(r => r.valid) ?? [];
+  const invalidRows = rows?.filter(r => !r.valid) ?? [];
+
+  const newCrewCount = useMemo(() => {
+    const names = new Set<string>();
+    validRows.forEach(r => {
+      const key = r.crewName.toLowerCase();
+      if (!existingCrewNames.has(key)) names.add(key);
+    });
+    return names.size;
+  }, [validRows, existingCrewNames]);
+
+  const newJobCount = useMemo(() => {
+    const nums = new Set<string>();
+    validRows.forEach(r => {
+      const key = r.jobNumber.toLowerCase();
+      if (!existingJobNumbers.has(key)) nums.add(key);
+    });
+    return nums.size;
+  }, [validRows, existingJobNumbers]);
+
+  const processFile = async (file: File) => {
+    setRows(null);
+    setParseError(null);
+    try {
+      const raw = await parseSpreadsheet(file);
+      setRows(toScheduleRows(raw, jobs));
+    } catch {
+      setParseError('Could not parse this file. Make sure it is a valid CSV or Excel spreadsheet.');
+    }
+  };
+
+  const handleFiles = (files: FileList | null) => { if (files?.length) processFile(files[0]); };
+
+  const doImport = () => {
+    if (validRows.length === 0) return;
+    onImport(validRows);
+    onClose();
+  };
+
+  const overlay = 'fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm';
+  const thCls = 'px-3 py-2 text-left text-[10px] font-bold uppercase tracking-wider text-slate-400 border-b border-slate-200';
+  const tdCls = 'px-3 py-1.5 border-b border-slate-100 text-sm text-slate-700';
+
+  return (
+    <div className={overlay} onClick={onClose}>
+      <div
+        className="w-full max-w-2xl bg-white rounded-2xl border border-slate-200 shadow-2xl p-6 max-h-[90vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2.5">
+            <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-brand/10 text-brand">
+              <FileSpreadsheet size={16} />
+            </span>
+            <div>
+              <h2 className="text-lg font-bold text-slate-900">Import Schedule</h2>
+              <p className="text-xs text-slate-500">Upload a CSV or spreadsheet of scheduled jobs</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-500 hover:bg-rose-500/10 transition"><X size={18} /></button>
+        </div>
+
+        {/* Drop zone (shown until a file is parsed) */}
+        {!rows && (
+          <>
+            <div
+              className={[
+                'border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition',
+                isDragging ? 'border-brand bg-brand/5' : 'border-slate-300 hover:border-slate-400',
+              ].join(' ')}
+              onDragOver={e => { e.preventDefault(); setIsDragging(true); }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={e => { e.preventDefault(); setIsDragging(false); handleFiles(e.dataTransfer.files); }}
+              onClick={() => fileRef.current?.click()}
+            >
+              <FileSpreadsheet size={40} className="mx-auto mb-3 text-brand opacity-80" />
+              <p className="font-semibold text-slate-800">Drop your schedule here</p>
+              <p className="text-sm mt-1 text-slate-500">or click to browse — CSV, XLSX, or XLS</p>
+              <input
+                ref={fileRef}
+                type="file"
+                className="hidden"
+                accept=".csv,.xlsx,.xls"
+                onChange={e => handleFiles(e.target.files)}
+              />
+            </div>
+
+            <div className="mt-3 text-xs text-slate-500 text-center">
+              Expected columns:{' '}
+              <code className="font-mono">crew</code>,{' '}
+              <code className="font-mono">jobNumber</code>,{' '}
+              <code className="font-mono">location</code>,{' '}
+              <code className="font-mono">startDate</code>,{' '}
+              <code className="font-mono">days</code>
+              {' · '}
+              <button className="underline hover:opacity-75" onClick={e => { e.stopPropagation(); downloadTemplate(); }}>
+                Download template
+              </button>
+            </div>
+            <p className="mt-2 text-[11px] text-slate-400 text-center">
+              Crews and jobs that don't exist yet will be created automatically.
+            </p>
+
+            {parseError && (
+              <div className="flex items-start gap-2 p-3 mt-3 rounded-lg bg-rose-50 border border-rose-200 text-rose-700 text-sm">
+                <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                <span>{parseError}</span>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Preview */}
+        {rows && rows.length > 0 && (
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <CheckCircle size={16} className="text-emerald-500 shrink-0" />
+              <span className="text-sm font-medium text-slate-700">
+                {validRows.length} job{validRows.length !== 1 ? 's' : ''} ready to import
+              </span>
+              {(newCrewCount > 0 || newJobCount > 0) && (
+                <span className="inline-flex items-center gap-1 text-xs text-brand bg-brand/10 px-2 py-0.5 rounded-full">
+                  <Sparkles size={11} />
+                  {[
+                    newCrewCount > 0 ? `${newCrewCount} new crew${newCrewCount !== 1 ? 's' : ''}` : null,
+                    newJobCount > 0 ? `${newJobCount} new job${newJobCount !== 1 ? 's' : ''}` : null,
+                  ].filter(Boolean).join(' · ')}
+                </span>
+              )}
+              {invalidRows.length > 0 && (
+                <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full">
+                  {invalidRows.length} skipped
+                </span>
+              )}
+              <button onClick={() => { setRows(null); setParseError(null); }} className="ml-auto text-xs underline text-slate-500">
+                Change file
+              </button>
+            </div>
+
+            <div className="overflow-auto max-h-64 rounded-lg border border-slate-200">
+              <table className="w-full">
+                <thead className="bg-slate-50 sticky top-0">
+                  <tr>
+                    <th className={thCls}>Crew</th>
+                    <th className={thCls}>Job #</th>
+                    <th className={thCls}>Location</th>
+                    <th className={thCls}>Start</th>
+                    <th className={`${thCls} text-right`}>Days</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r, i) => {
+                    const isNewCrew = r.crewName && !existingCrewNames.has(r.crewName.toLowerCase());
+                    const isNewJob  = r.jobNumber && !existingJobNumbers.has(r.jobNumber.toLowerCase());
+                    return (
+                      <tr key={i} className={r.valid ? '' : 'bg-amber-50/60'}>
+                        <td className={tdCls}>
+                          <span className="inline-flex items-center gap-1.5">
+                            {r.crewName || <span className="text-slate-400">—</span>}
+                            {isNewCrew && r.valid && <span className="text-[9px] font-bold text-brand bg-brand/10 px-1.5 py-0.5 rounded">NEW</span>}
+                          </span>
+                        </td>
+                        <td className={tdCls}>
+                          <span className="inline-flex items-center gap-1.5">
+                            {r.jobNumber || <span className="text-slate-400">—</span>}
+                            {isNewJob && r.valid && <span className="text-[9px] font-bold text-violet-600 bg-violet-100 px-1.5 py-0.5 rounded">NEW</span>}
+                          </span>
+                        </td>
+                        <td className={`${tdCls} max-w-[180px] truncate`} title={r.location}>{r.location || <span className="text-slate-400">—</span>}</td>
+                        <td className={tdCls}>
+                          {r.valid
+                            ? fmtDate(r.startDate)
+                            : <span className="inline-flex items-center gap-1 text-amber-600"><AlertCircle size={12} /> {r.error}</span>}
+                        </td>
+                        <td className={`${tdCls} text-right tabular-nums`}>{r.durationDays}d</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex gap-3">
+              <button onClick={onClose} className="flex-1 py-2 rounded-lg border border-slate-300 text-sm font-semibold text-slate-600 hover:bg-slate-50 transition">
+                Cancel
+              </button>
+              <button
+                onClick={doImport}
+                disabled={validRows.length === 0}
+                className="flex-1 py-2 rounded-lg bg-brand text-white text-sm font-semibold disabled:opacity-50 transition hover:opacity-90"
+              >
+                Import {validRows.length} job{validRows.length !== 1 ? 's' : ''}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Empty parse result */}
+        {rows && rows.length === 0 && (
+          <div className="text-sm text-center py-6 space-y-2 text-slate-500">
+            <p>No rows found. Make sure the file has a header row with at least:</p>
+            <p>
+              <code className="font-mono text-xs">crew</code>{', '}
+              <code className="font-mono text-xs">jobNumber</code>{', '}
+              <code className="font-mono text-xs">startDate</code>
+            </p>
+            <button className="underline text-xs mt-1" onClick={() => { setRows(null); setParseError(null); }}>Try another file</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -746,10 +746,12 @@ interface DayPromptState {
 
 const DayPromptModal = ({
   state,
+  skipWeekends,
   onConfirm,
   onClose,
 }: {
   state: DayPromptState;
+  skipWeekends: boolean;
   onConfirm: (days: number) => void;
   onClose: () => void;
 }) => {
@@ -776,17 +778,21 @@ const DayPromptModal = ({
         <h3 className="text-base font-bold text-slate-900 mb-1">{title}</h3>
         <p className="text-xs text-slate-500 mb-4">{description}</p>
         <label className="block text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1.5">
-          Number of Days
+          {skipWeekends ? 'Number of Working Days' : 'Number of Days'}
         </label>
         <select
           value={days}
           onChange={e => setDays(parseInt(e.target.value))}
-          className="w-full border border-slate-200 rounded-lg px-3 py-2.5 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-brand/10 mb-4 bg-white"
+          className="w-full border border-slate-200 rounded-lg px-3 py-2.5 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-brand/10 mb-1.5 bg-white"
         >
           {Array.from({ length: 30 }, (_, i) => i + 1).map(d => (
             <option key={d} value={d}>{d} day{d !== 1 ? 's' : ''}</option>
           ))}
         </select>
+        {skipWeekends && (
+          <p className="text-[11px] text-slate-400 mb-4">Counted in working days — weekends are skipped.</p>
+        )}
+        {!skipWeekends && <div className="mb-4" />}
         <div className="flex gap-3">
           <button
             onClick={onClose}
@@ -1252,11 +1258,13 @@ const ManageJobsModal = ({
 const AddBlockModal = ({
   crews,
   jobs,
+  skipWeekends,
   onAdd,
   onClose,
 }: {
   crews: Crew[];
   jobs: JobOption[];
+  skipWeekends: boolean;
   onAdd: (block: ScheduleBlock) => void;
   onClose: () => void;
 }) => {
@@ -1495,7 +1503,7 @@ const AddBlockModal = ({
 
             <div style={{ width: 110 }}>
               <label className="block text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1.5">
-                Duration (days)
+                {skipWeekends ? 'Working days' : 'Duration (days)'}
               </label>
               <select
                 value={durationDays}
@@ -1509,6 +1517,32 @@ const AddBlockModal = ({
               </select>
             </div>
           </div>
+
+          {/* Schedule preview — makes clear the duration is counted in working
+              days (Mon–Fri) and shows where the job lands with weekends skipped. */}
+          {/^\d{4}-\d{2}-\d{2}$/.test(startDate) && durationDays >= 1 && (() => {
+            const effStart = skipWeekends ? snapToWeekday(startDate) : startDate;
+            const endISO   = skipWeekends
+              ? nthWorkingDay(effStart, durationDays)
+              : addDays(startDate, durationDays - 1);
+            return (
+              <p className="text-xs text-slate-500 bg-slate-50 rounded-lg px-3 py-2">
+                {skipWeekends ? (
+                  <>
+                    <span className="font-semibold text-slate-700">{durationDays} working day{durationDays !== 1 ? 's' : ''}</span>
+                    {' · '}weekends skipped
+                    <br />
+                    {effStart !== startDate && (
+                      <span className="text-amber-600">Starts {fmtLong(effStart)} (moved off weekend)<br /></span>
+                    )}
+                    Ends <span className="font-semibold text-slate-700">{fmtLong(endISO)}</span>
+                  </>
+                ) : (
+                  <>Ends <span className="font-semibold text-slate-700">{fmtLong(endISO)}</span></>
+                )}
+              </p>
+            );
+          })()}
 
           {selectedJob && (
             <p className="text-xs text-slate-500 bg-slate-50 rounded-lg px-3 py-2">
@@ -3208,6 +3242,7 @@ export default function Scheduler({
       {dayPrompt && (
         <DayPromptModal
           state={dayPrompt}
+          skipWeekends={skipWeekends}
           onConfirm={
             dayPrompt.action === 'extend'
               ? handleExtendConfirm
@@ -3261,6 +3296,7 @@ export default function Scheduler({
         <AddBlockModal
           crews={crewsState}
           jobs={jobsState}
+          skipWeekends={skipWeekends}
           onAdd={rawBlock => {
             const block = skipWeekends
               ? { ...rawBlock, startDate: snapToWeekday(rawBlock.startDate) }

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useReducer, useRef, useCallback, useEffect } from 'react';
-import { Plus, X, ChevronLeft, ChevronRight, Clock, Calendar, Pencil, Trash2, Briefcase, Users, Wrench, GripHorizontal, RotateCcw, Search } from 'lucide-react';
+import { Plus, X, ChevronLeft, ChevronRight, Clock, Calendar, Pencil, Trash2, Briefcase, Users, Wrench, GripHorizontal, RotateCcw, Search, Upload } from 'lucide-react';
 import { supabase } from '../../lib/supabaseClient.ts';
 import { scheduleService } from '../../services/scheduleService.ts';
+import ScheduleImportModal, { type ScheduleImportRow } from './ScheduleImportModal.tsx';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -242,6 +243,7 @@ type BaseAction =
   | { type: 'INSERT_DELAY';       blockId: string; days: number }
   | { type: 'EXTEND_JOB';         blockId: string; days: number }
   | { type: 'ADD_BLOCK';          block: ScheduleBlock }
+  | { type: 'ADD_BLOCKS';         blocks: ScheduleBlock[] }
   | { type: 'ADD_BLOCK_PUSH';     block: ScheduleBlock; shiftDays: number }
   | { type: 'DELETE_BLOCK';       id: string }
   | { type: 'REPLACE_ALL';        blocks: ScheduleBlock[] }
@@ -360,6 +362,9 @@ function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
 
     case 'ADD_BLOCK':
       return [...state, action.block];
+
+    case 'ADD_BLOCKS':
+      return [...state, ...action.blocks];
 
     case 'ADD_BLOCK_PUSH': {
       // Push only crew blocks that actually overlap with the new block
@@ -2059,6 +2064,7 @@ export default function Scheduler({
   const [dayPrompt,         setDayPrompt]         = useState<DayPromptState | null>(null);
   const [tooltip,           setTooltip]           = useState<TooltipState | null>(null);
   const [showAddModal,      setShowAddModal]      = useState(false);
+  const [showImportModal,   setShowImportModal]   = useState(false);
   const [showManageCrews,   setShowManageCrews]   = useState(false);
   const [showManageJobs,    setShowManageJobs]    = useState(false);
 
@@ -2475,6 +2481,56 @@ export default function Scheduler({
     dispatchWithHistory({ type: 'EXTEND_JOB', blockId: dayPrompt.blockId, days });
   };
 
+  // ── Spreadsheet import ───────────────────────────────────────────────────────
+  // Turn parsed rows into schedule blocks, creating any crews and job options
+  // they reference that don't exist yet. Crew/job state updates auto-persist via
+  // the existing save effects, and the block-save effect upserts referenced crews
+  // before blocks so the FK constraint is always satisfied.
+  const handleImport = useCallback((rows: ScheduleImportRow[]) => {
+    const skip = skipWeekendsRef.current;
+
+    // Resolve crews by name (case-insensitive), creating new ones as needed.
+    const crewIdByName = new Map<string, string>(
+      crewsState.map(c => [c.name.trim().toLowerCase(), c.id]),
+    );
+    const newCrews: Crew[] = [];
+    for (const r of rows) {
+      const key = r.crewName.trim().toLowerCase();
+      if (!crewIdByName.has(key)) {
+        const crew: Crew = { id: `crew-${crypto.randomUUID()}`, name: r.crewName.trim(), size: 1, memberIds: [] };
+        crewIdByName.set(key, crew.id);
+        newCrews.push(crew);
+      }
+    }
+
+    // Collect new job options referenced by the import.
+    const existingJobNums = new Set(jobsState.map(j => j.jobNumber.toLowerCase()));
+    const newJobs: JobOption[] = [];
+    const seenNewJobs = new Set<string>();
+    for (const r of rows) {
+      const key = r.jobNumber.toLowerCase();
+      if (!existingJobNums.has(key) && !seenNewJobs.has(key)) {
+        seenNewJobs.add(key);
+        newJobs.push({ jobNumber: r.jobNumber, location: r.location, estimatedDays: r.durationDays });
+      }
+    }
+
+    // Build the blocks, snapping start dates off weekends when that mode is on.
+    const importedBlocks: ScheduleBlock[] = rows.map(r => ({
+      id:           `block-${crypto.randomUUID()}`,
+      crewId:       crewIdByName.get(r.crewName.trim().toLowerCase())!,
+      jobNumber:    r.jobNumber,
+      startDate:    skip ? snapToWeekday(r.startDate) : r.startDate,
+      durationDays: Math.max(1, r.durationDays),
+      type:         'job',
+      extended:     false,
+    }));
+
+    if (newCrews.length > 0) setCrewsState(prev => [...prev, ...newCrews]);
+    if (newJobs.length > 0)   setJobsState(prev => [...prev, ...newJobs]);
+    if (importedBlocks.length > 0) dispatchWithHistory({ type: 'ADD_BLOCKS', blocks: importedBlocks });
+  }, [crewsState, jobsState, dispatchWithHistory]);
+
   // ── Build month-label spans for header ──────────────────────────────────────
 
   const monthLabels: { label: string; startCol: number; span: number }[] = [];
@@ -2647,6 +2703,14 @@ export default function Scheduler({
             }`}
           >
             <Wrench className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Equipment</span>
+          </button>
+          <button
+            onClick={() => setShowImportModal(true)}
+            aria-label="Import schedule from spreadsheet"
+            title="Import schedule from a CSV or spreadsheet"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-slate-200 text-xs font-semibold rounded-lg transition-colors border border-white/10"
+          >
+            <Upload className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Import</span>
           </button>
           <button
             onClick={() => setShowAddModal(true)}
@@ -3130,6 +3194,15 @@ export default function Scheduler({
             }
           }}
           onClose={() => setShowAddModal(false)}
+        />
+      )}
+
+      {showImportModal && (
+        <ScheduleImportModal
+          crews={crewsState}
+          jobs={jobsState}
+          onImport={handleImport}
+          onClose={() => setShowImportModal(false)}
         />
       )}
 

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -126,29 +126,93 @@ const fmtLong = (iso: string): string =>
 
 const todayISO = toISO(new Date());
 
-/** Returns true when two schedule intervals [aStart, aStart+aDays) and [bStart, bStart+bDays) overlap. */
+// ═══════════════════════════════════════════════════════════════════════════════
+// WEEKEND-AWARE SCHEDULING HELPERS
+// ═══════════════════════════════════════════════════════════════════════════════
+// When "skip weekends" is enabled, durations count working days (Mon–Fri) only
+// and blocks never start on a Saturday or Sunday. Every helper accepts a `skip`
+// flag and degrades to plain calendar math when it's false, so both modes share
+// one code path through the reducer and render logic.
+
+const isWeekendDate = (d: Date): boolean => d.getDay() === 0 || d.getDay() === 6;
+
+/** Snap an ISO date forward to the next weekday (Monday) when it lands on a weekend. */
+const snapToWeekday = (iso: string): string => {
+  const d = parseDate(iso);
+  while (isWeekendDate(d)) d.setDate(d.getDate() + 1);
+  return toISO(d);
+};
+
+/** Date of the n-th working day of a span, counting `start` as day 1 (start is snapped to a weekday). */
+const nthWorkingDay = (start: string, n: number): string => {
+  const d = parseDate(start);
+  while (isWeekendDate(d)) d.setDate(d.getDate() + 1);
+  let count = 1;
+  while (count < n) {
+    d.setDate(d.getDate() + 1);
+    if (!isWeekendDate(d)) count++;
+  }
+  return toISO(d);
+};
+
+/** Count the working days in the inclusive calendar range [start, end]. */
+const countWorkingDays = (start: string, end: string): number => {
+  if (end < start) return 0;
+  const d = parseDate(start);
+  const last = parseDate(end);
+  let count = 0;
+  while (d <= last) {
+    if (!isWeekendDate(d)) count++;
+    d.setDate(d.getDate() + 1);
+  }
+  return count;
+};
+
+/** Number of calendar columns a block occupies on the grid (spans weekends when skipping). */
+const blockSpanDays = (start: string, durationDays: number, skip: boolean): number =>
+  skip ? diffDays(nthWorkingDay(start, durationDays), start) + 1 : durationDays;
+
+/** First calendar day after a block ends (its next available start), weekday-snapped when skipping. */
+const blockEndExclusive = (start: string, durationDays: number, skip: boolean): string =>
+  skip ? snapToWeekday(addDays(nthWorkingDay(start, durationDays), 1)) : addDays(start, durationDays);
+
+/** Shift an ISO date forward by `n` working days (or calendar days when not skipping). */
+const shiftSchedDays = (start: string, n: number, skip: boolean): string => {
+  if (!skip || n <= 0) return addDays(start, n);
+  const d = parseDate(start);
+  let remaining = n;
+  while (remaining > 0) {
+    d.setDate(d.getDate() + 1);
+    if (!isWeekendDate(d)) remaining--;
+  }
+  return toISO(d);
+};
+
+/** Returns true when two schedule intervals overlap, accounting for weekend skipping. */
 const blocksOverlap = (
   aStart: string, aDays: number,
   bStart: string, bDays: number,
+  skip: boolean,
 ): boolean => {
-  const aEnd = addDays(aStart, aDays);
-  const bEnd = addDays(bStart, bDays);
+  const aEnd = blockEndExclusive(aStart, aDays, skip);
+  const bEnd = blockEndExclusive(bStart, bDays, skip);
   return aStart < bEnd && bStart < aEnd;
 };
 
-/** Returns blocks of the same crew that overlap with [startDate, startDate+durationDays), excluding excludeId. */
+/** Returns blocks of the same crew that overlap with the given interval, excluding excludeId. */
 const findOverlapConflicts = (
   blocks: ScheduleBlock[],
   crewId: string,
   startDate: string,
   durationDays: number,
+  skip: boolean,
   excludeId?: string,
 ): ScheduleBlock[] =>
   blocks.filter(
     b =>
       b.crewId === crewId &&
       b.id !== excludeId &&
-      blocksOverlap(startDate, durationDays, b.startDate, b.durationDays),
+      blocksOverlap(startDate, durationDays, b.startDate, b.durationDays, skip),
   );
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -172,7 +236,7 @@ const MOCK_BLOCK_IDS = new Set(INITIAL_BLOCKS.map(b => b.id));
 // REDUCER
 // ═══════════════════════════════════════════════════════════════════════════════
 
-type Action =
+type BaseAction =
   | { type: 'MOVE_BLOCK';         id: string; crewId: string; startDate: string }
   | { type: 'MOVE_BLOCK_PUSH';    id: string; crewId: string; startDate: string; shiftDays: number }
   | { type: 'INSERT_DELAY';       blockId: string; days: number }
@@ -185,17 +249,22 @@ type Action =
   | { type: 'UNASSIGN_EQUIPMENT'; blockId: string; equipmentId: string }
   | { type: 'SHIFT_CREW';         crewId: string; fromDate: string; days: number };
 
+// `skipWeekends` is injected at dispatch time so the pure reducer can do
+// weekday-aware date math without reading component state directly.
+type Action = BaseAction & { skipWeekends?: boolean };
+
 /** Push all blocks for a crew that start on or after `fromDate` forward by `shiftDays`. */
 function shiftAfter(
   blocks: ScheduleBlock[],
   crewId: string,
   fromDate: string,
   shiftDays: number,
+  skip: boolean,
   excludeId?: string,
 ): ScheduleBlock[] {
   return blocks.map(b => {
     if (b.crewId === crewId && b.id !== excludeId && b.startDate >= fromDate) {
-      return { ...b, startDate: addDays(b.startDate, shiftDays) };
+      return { ...b, startDate: shiftSchedDays(b.startDate, shiftDays, skip) };
     }
     return b;
   });
@@ -212,9 +281,10 @@ function pushConflictingForward(
   crewId: string,
   newStart: string,
   newDuration: number,
+  skip: boolean,
   excludeId?: string,
 ): ScheduleBlock[] {
-  const newEnd = addDays(newStart, newDuration);
+  const newEnd = blockEndExclusive(newStart, newDuration, skip);
 
   const crewBlocks = blocks
     .filter(b => b.crewId === crewId && b.id !== excludeId)
@@ -225,8 +295,9 @@ function pushConflictingForward(
 
   for (const b of crewBlocks) {
     if (b.startDate >= newStart && b.startDate < pushBoundary) {
-      updates.set(b.id, pushBoundary);
-      pushBoundary = addDays(pushBoundary, b.durationDays);
+      const placed = skip ? snapToWeekday(pushBoundary) : pushBoundary;
+      updates.set(b.id, placed);
+      pushBoundary = blockEndExclusive(placed, b.durationDays, skip);
     }
   }
 
@@ -237,6 +308,7 @@ function pushConflictingForward(
 }
 
 function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
+  const skip = action.skipWeekends ?? false;
   switch (action.type) {
     case 'MOVE_BLOCK':
       return state.map(b =>
@@ -253,7 +325,7 @@ function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
           ? { ...b, crewId: action.crewId, startDate: action.startDate }
           : b,
       );
-      return pushConflictingForward(moved, action.crewId, action.startDate, action.shiftDays, action.id);
+      return pushConflictingForward(moved, action.crewId, action.startDate, action.shiftDays, skip, action.id);
     }
 
     case 'INSERT_DELAY': {
@@ -269,21 +341,21 @@ function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
         extended: false,
       };
       // Shift the target job AND every subsequent crew block forward by `days`
-      const shifted = shiftAfter(state, job.crewId, job.startDate, action.days);
+      const shifted = shiftAfter(state, job.crewId, job.startDate, action.days, skip);
       return [...shifted, delay];
     }
 
     case 'EXTEND_JOB': {
       const job = state.find(b => b.id === action.blockId);
       if (!job || job.type !== 'job') return state;
-      const oldEnd = addDays(job.startDate, job.durationDays);
+      const oldEnd = blockEndExclusive(job.startDate, job.durationDays, skip);
       const withExtended = state.map(b =>
         b.id === action.blockId
           ? { ...b, durationDays: b.durationDays + action.days, extended: true }
           : b,
       );
       // Shift blocks that begin at or after the job's original end date
-      return shiftAfter(withExtended, job.crewId, oldEnd, action.days, action.blockId);
+      return shiftAfter(withExtended, job.crewId, oldEnd, action.days, skip, action.blockId);
     }
 
     case 'ADD_BLOCK':
@@ -293,7 +365,7 @@ function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
       // Push only crew blocks that actually overlap with the new block
       // (cascading as needed), then insert the new block.
       const shifted = pushConflictingForward(
-        state, action.block.crewId, action.block.startDate, action.block.durationDays,
+        state, action.block.crewId, action.block.startDate, action.block.durationDays, skip,
       );
       return [...shifted, action.block];
     }
@@ -321,7 +393,7 @@ function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
     case 'SHIFT_CREW':
       return state.map(b =>
         b.crewId === action.crewId && b.startDate >= action.fromDate
-          ? { ...b, startDate: addDays(b.startDate, action.days) }
+          ? { ...b, startDate: shiftSchedDays(b.startDate, action.days, skip) }
           : b,
       );
 
@@ -524,9 +596,11 @@ interface TooltipState {
   y: number;
 }
 
-const BlockTooltip = ({ tip }: { tip: TooltipState }) => {
+const BlockTooltip = ({ tip, skipWeekends }: { tip: TooltipState; skipWeekends: boolean }) => {
   const { block, job, crew } = tip;
-  const endDate = addDays(block.startDate, block.durationDays - 1);
+  const endDate = skipWeekends
+    ? nthWorkingDay(block.startDate, block.durationDays)
+    : addDays(block.startDate, block.durationDays - 1);
   return (
     <div
       className="fixed z-50 pointer-events-none"
@@ -1727,6 +1801,20 @@ export default function Scheduler({
   const [view, setView]    = useState<'week' | 'month'>('week');
   const [viewOffset, setViewOffset] = useState(0); // days from default start
 
+  // Skip weekends: durations count working days (Mon–Fri) and blocks never start
+  // on a weekend. Defaults on, persisted so the choice survives reloads. Can be
+  // turned off for the occasional weekend crew.
+  const [skipWeekends, setSkipWeekends] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    const saved = window.localStorage.getItem('scheduler-skip-weekends');
+    return saved === null ? true : saved === 'true';
+  });
+  useEffect(() => {
+    try { window.localStorage.setItem('scheduler-skip-weekends', String(skipWeekends)); } catch { /* ignore */ }
+  }, [skipWeekends]);
+  const skipWeekendsRef = useRef(skipWeekends);
+  skipWeekendsRef.current = skipWeekends;
+
   // Guards to avoid saving before the initial Supabase load completes
   const dbLoadedRef = useRef(false);
 
@@ -1947,6 +2035,7 @@ export default function Scheduler({
     blockId:      string;
     startX:       number;
     origDuration: number;
+    origStart:    string;
     crewId:       string;
   } | null>(null);
 
@@ -2016,7 +2105,7 @@ export default function Scheduler({
   const dispatchWithHistory = useCallback((action: Action) => {
     undoHistoryRef.current = [...undoHistoryRef.current.slice(-19), blocksRef.current];
     setCanUndo(true);
-    dispatch(action);
+    dispatch({ ...action, skipWeekends: skipWeekendsRef.current });
   }, [dispatch]);
 
   /** Restore the most recent snapshot from undo history. */
@@ -2080,7 +2169,9 @@ export default function Scheduler({
     // Position within the grid area (subtract the fixed crew-label column)
     const xInGrid    = xInContent - CREW_COL_W;
     const dayIndex   = Math.floor(xInGrid / dayWidth);
-    const newStart   = addDays(viewStart, dayIndex - dragOffsetDays);
+    const skip       = skipWeekendsRef.current;
+    let   newStart   = addDays(viewStart, dayIndex - dragOffsetDays);
+    if (skip) newStart = snapToWeekday(newStart);
 
     setDraggingId(null);
 
@@ -2088,7 +2179,7 @@ export default function Scheduler({
     const movingBlock = allBlocks.find(b => b.id === blockId);
     if (!movingBlock) return;
 
-    const conflicts = findOverlapConflicts(allBlocks, crewId, newStart, movingBlock.durationDays, blockId);
+    const conflicts = findOverlapConflicts(allBlocks, crewId, newStart, movingBlock.durationDays, skip, blockId);
     if (conflicts.length > 0) {
       const crew = crewsStateRef.current.find(c => c.id === crewId);
       setPendingMove({
@@ -2228,14 +2319,16 @@ export default function Scheduler({
       const xInContent = touch.clientX - containerRect.left + container.scrollLeft;
       const xInGrid    = xInContent - CREW_COL_W;
       const dayIndex   = dw > 0 ? Math.floor(xInGrid / dw) : 0;
-      const newStart   = addDays(viewStartRef.current, dayIndex - drag.offsetDays);
+      const skip       = skipWeekendsRef.current;
+      let   newStart   = addDays(viewStartRef.current, dayIndex - drag.offsetDays);
+      if (skip) newStart = snapToWeekday(newStart);
 
       if (targetCrew) {
         const allBlocks   = blocksRef.current;
         const movingBlock = allBlocks.find(b => b.id === drag.blockId);
         if (movingBlock) {
           const conflicts = findOverlapConflicts(
-            allBlocks, targetCrew.id, newStart, movingBlock.durationDays, drag.blockId,
+            allBlocks, targetCrew.id, newStart, movingBlock.durationDays, skip, drag.blockId,
           );
           if (conflicts.length > 0) {
             setPendingMove({
@@ -2272,6 +2365,7 @@ export default function Scheduler({
       blockId:      block.id,
       startX:       e.clientX,
       origDuration: block.durationDays,
+      origStart:    block.startDate,
       crewId:       block.crewId,
     };
     setResizingId(block.id);
@@ -2286,6 +2380,7 @@ export default function Scheduler({
       blockId:      block.id,
       startX:       touch.clientX,
       origDuration: block.durationDays,
+      origStart:    block.startDate,
       crewId:       block.crewId,
     };
     setResizingId(block.id);
@@ -2295,23 +2390,33 @@ export default function Scheduler({
   useEffect(() => {
     if (!resizingId) return;
 
+    // Convert a pixel drag (in calendar columns) into a working-day duration
+    // delta so that dragging across a weekend doesn't add weekend days when
+    // weekend-skipping is on.
+    const toDurationDelta = (r: NonNullable<typeof resizeRef.current>, cols: number): number => {
+      if (cols <= 0) return 0;
+      if (!skipWeekendsRef.current) return cols;
+      const origLast    = nthWorkingDay(r.origStart, r.origDuration);
+      const targetEnd   = addDays(origLast, cols);
+      const newDuration = countWorkingDays(r.origStart, targetEnd);
+      return Math.max(0, newDuration - r.origDuration);
+    };
+
     const onMouseMove = (e: MouseEvent) => {
       const r = resizeRef.current;
       if (!r || dayWidthRef.current === 0) return;
-      const deltaX    = e.clientX - r.startX;
-      const deltaDays = Math.max(0, Math.round(deltaX / dayWidthRef.current));
-      setResizeDeltaDays(deltaDays);
+      const cols = Math.max(0, Math.round((e.clientX - r.startX) / dayWidthRef.current));
+      setResizeDeltaDays(toDurationDelta(r, cols));
     };
 
     const onMouseUp = (e: MouseEvent) => {
       const r = resizeRef.current;
       if (!r) return;
       const dw = dayWidthRef.current;
-      const deltaDays = dw > 0
-        ? Math.max(0, Math.round((e.clientX - r.startX) / dw))
-        : 0;
-      if (deltaDays > 0) {
-        dispatch({ type: 'EXTEND_JOB', blockId: r.blockId, days: deltaDays });
+      const cols = dw > 0 ? Math.max(0, Math.round((e.clientX - r.startX) / dw)) : 0;
+      const days = toDurationDelta(r, cols);
+      if (days > 0) {
+        dispatch({ type: 'EXTEND_JOB', blockId: r.blockId, days, skipWeekends: skipWeekendsRef.current });
       }
       resizeRef.current = null;
       setResizingId(null);
@@ -2323,9 +2428,8 @@ export default function Scheduler({
       if (!r || dayWidthRef.current === 0) return;
       e.preventDefault();
       const touch = e.touches[0];
-      const deltaX    = touch.clientX - r.startX;
-      const deltaDays = Math.max(0, Math.round(deltaX / dayWidthRef.current));
-      setResizeDeltaDays(deltaDays);
+      const cols = Math.max(0, Math.round((touch.clientX - r.startX) / dayWidthRef.current));
+      setResizeDeltaDays(toDurationDelta(r, cols));
     };
 
     const onTouchEnd = (e: TouchEvent) => {
@@ -2333,11 +2437,10 @@ export default function Scheduler({
       if (!r) return;
       const dw = dayWidthRef.current;
       const touch = e.changedTouches[0];
-      const deltaDays = dw > 0
-        ? Math.max(0, Math.round((touch.clientX - r.startX) / dw))
-        : 0;
-      if (deltaDays > 0) {
-        dispatch({ type: 'EXTEND_JOB', blockId: r.blockId, days: deltaDays });
+      const cols = dw > 0 ? Math.max(0, Math.round((touch.clientX - r.startX) / dw)) : 0;
+      const days = toDurationDelta(r, cols);
+      if (days > 0) {
+        dispatch({ type: 'EXTEND_JOB', blockId: r.blockId, days, skipWeekends: skipWeekendsRef.current });
       }
       resizeRef.current = null;
       setResizingId(null);
@@ -2463,6 +2566,23 @@ export default function Scheduler({
         </span>
 
         <div className="ml-auto flex items-center gap-2">
+          {/* Skip-weekends toggle — when on, jobs span Mon–Fri and auto-skip Sat/Sun */}
+          <button
+            onClick={() => setSkipWeekends(s => !s)}
+            aria-pressed={skipWeekends}
+            aria-label={skipWeekends ? 'Weekends skipped — click to include weekends' : 'Weekends included — click to skip weekends'}
+            title={skipWeekends
+              ? 'Weekends skipped — jobs are scheduled Monday–Friday. Click to allow weekend work.'
+              : 'Weekends included — jobs can run any day. Click to skip weekends.'}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-all border ${
+              skipWeekends
+                ? 'bg-white/10 hover:bg-white/20 text-slate-200 border-white/10'
+                : 'bg-amber-400 text-slate-900 border-amber-300 shadow-sm'
+            }`}
+          >
+            <Calendar className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">{skipWeekends ? 'Mon–Fri' : '7-Day'}</span>
+          </button>
           {/* Edit mode toggle */}
           <button
             onClick={() => setEditMode(m => !m)}
@@ -2804,7 +2924,8 @@ export default function Scheduler({
                   {crewBlocks.map(block => {
                     const left  = diffDays(block.startDate, viewStart) * dayWidth;
                     const isResizing = resizingId === block.id;
-                    const width = (block.durationDays + (isResizing ? resizeDeltaDays : 0)) * dayWidth;
+                    const previewDuration = block.durationDays + (isResizing ? resizeDeltaDays : 0);
+                    const width = blockSpanDays(block.startDate, previewDuration, skipWeekends) * dayWidth;
                     if (left + width < 0 || left > totalGridWidth) return null;
                     const job = jobsState.find(j => j.jobNumber === block.jobNumber);
                     const eqCount = (block.equipmentIds ?? []).length;
@@ -2858,7 +2979,7 @@ export default function Scheduler({
       </div>
 
       {/* ─── Overlays ─── */}
-      {tooltip && <BlockTooltip tip={tooltip} />}
+      {tooltip && <BlockTooltip tip={tooltip} skipWeekends={skipWeekends} />}
 
       {/* Touch drag ghost */}
       {touchGhostPos && touchDragRef.current && (
@@ -2988,9 +3109,12 @@ export default function Scheduler({
         <AddBlockModal
           crews={crewsState}
           jobs={jobsState}
-          onAdd={block => {
+          onAdd={rawBlock => {
+            const block = skipWeekends
+              ? { ...rawBlock, startDate: snapToWeekday(rawBlock.startDate) }
+              : rawBlock;
             const conflicts = findOverlapConflicts(
-              blocks, block.crewId, block.startDate, block.durationDays,
+              blocks, block.crewId, block.startDate, block.durationDays, skipWeekends,
             );
             if (conflicts.length > 0) {
               const crew = crewsState.find(c => c.id === block.crewId);

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -1625,7 +1625,6 @@ const JobBlock = ({
   const segs = segments && segments.length > 0
     ? segments
     : [{ left: BLOCK_MARGIN, width: Math.max(width - BLOCK_MARGIN * 2, 24) }];
-  const firstW  = segs[0].width;          // governs which labels fit
   const lastIdx = segs.length - 1;
 
   const fillImage = isDelay
@@ -1846,23 +1845,20 @@ const JobBlock = ({
               </button>
             )}
 
-            {/* Labels — first segment only */}
-            {isFirst && (
-              <>
-                <div style={{ color: '#fff', fontSize: 11.5, fontWeight: 700, lineHeight: 1.2, letterSpacing: '0.01em', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 2px rgba(0,0,0,0.28)' }}>
-                  {block.jobNumber}
-                </div>
-                {!isDelay && job && firstW > 64 && (
-                  <div style={{ color: 'rgba(255,255,255,0.82)', fontSize: 9.5, marginTop: 2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 1px rgba(0,0,0,0.2)' }}>
-                    {job.location}
-                  </div>
-                )}
-                {firstW > 40 && (
-                  <div style={{ display: 'inline-flex', alignItems: 'center', alignSelf: 'flex-start', marginTop: 4, padding: '1px 6px', borderRadius: 999, background: 'rgba(255,255,255,0.20)', color: 'rgba(255,255,255,0.95)', fontSize: 9, fontWeight: 600, lineHeight: 1.3, backdropFilter: 'blur(2px)' }}>
-                    {block.durationDays}d
-                  </div>
-                )}
-              </>
+            {/* Labels — shown on every segment so each piece of a block that
+                carries through a weekend still identifies its job. */}
+            <div style={{ color: '#fff', fontSize: 11.5, fontWeight: 700, lineHeight: 1.2, letterSpacing: '0.01em', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 2px rgba(0,0,0,0.28)' }}>
+              {block.jobNumber}
+            </div>
+            {!isDelay && job && seg.width > 64 && (
+              <div style={{ color: 'rgba(255,255,255,0.82)', fontSize: 9.5, marginTop: 2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 1px rgba(0,0,0,0.2)' }}>
+                {job.location}
+              </div>
+            )}
+            {seg.width > 40 && (
+              <div style={{ display: 'inline-flex', alignItems: 'center', alignSelf: 'flex-start', marginTop: 4, padding: '1px 6px', borderRadius: 999, background: 'rgba(255,255,255,0.20)', color: 'rgba(255,255,255,0.95)', fontSize: 9, fontWeight: 600, lineHeight: 1.3, backdropFilter: 'blur(2px)' }}>
+                {block.durationDays}d
+              </div>
             )}
           </div>
         );

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -173,6 +173,33 @@ const countWorkingDays = (start: string, end: string): number => {
 const blockSpanDays = (start: string, durationDays: number, skip: boolean): number =>
   skip ? diffDays(nthWorkingDay(start, durationDays), start) + 1 : durationDays;
 
+/**
+ * Break a block into the contiguous runs of working days it covers, expressed as
+ * calendar-column offsets from `start`. When weekend-skipping is off (or a block
+ * never touches a weekend) this is a single run spanning the whole block. When a
+ * block carries through a weekend it yields one run per work stretch so the bar
+ * can be drawn with the weekend columns left empty.
+ */
+const workingDayRuns = (
+  start: string, durationDays: number, skip: boolean,
+): { offsetDays: number; lengthDays: number }[] => {
+  if (!skip) return [{ offsetDays: 0, lengthDays: durationDays }];
+  const totalCols = diffDays(nthWorkingDay(start, durationDays), start) + 1;
+  const runs: { offsetDays: number; lengthDays: number }[] = [];
+  let runStart = -1;
+  for (let i = 0; i < totalCols; i++) {
+    const weekend = isWeekendDate(parseDate(addDays(start, i)));
+    if (!weekend && runStart === -1) {
+      runStart = i;
+    } else if (weekend && runStart !== -1) {
+      runs.push({ offsetDays: runStart, lengthDays: i - runStart });
+      runStart = -1;
+    }
+  }
+  if (runStart !== -1) runs.push({ offsetDays: runStart, lengthDays: totalCols - runStart });
+  return runs.length > 0 ? runs : [{ offsetDays: 0, lengthDays: Math.max(1, totalCols) }];
+};
+
 /** First calendar day after a block ends (its next available start), weekday-snapped when skipping. */
 const blockEndExclusive = (start: string, durationDays: number, skip: boolean): string =>
   skip ? snapToWeekday(addDays(nthWorkingDay(start, durationDays), 1)) : addDays(start, durationDays);
@@ -1541,6 +1568,8 @@ interface JobBlockProps {
   onTouchStart?: (e: React.TouchEvent) => void;
   onResizeStart?: (e: React.MouseEvent) => void;
   onResizeTouchStart?: (e: React.TouchEvent) => void;
+  /** Visual segments (px offsets relative to the block's left). Multiple when a job carries through a weekend. */
+  segments?: { left: number; width: number }[];
 }
 
 const JobBlock = ({
@@ -1550,11 +1579,24 @@ const JobBlock = ({
   onDragStart, onDragEnd, onContextMenu,
   onMouseEnter, onMouseMove, onMouseLeave, onTouchStart,
   onResizeStart, onResizeTouchStart,
+  segments,
 }: JobBlockProps) => {
   const isDelay   = block.type === 'delay';
   const bgColor   = isDelay ? '#64748b' : color;
-  const blockW    = Math.max(width - BLOCK_MARGIN * 2, 24);
   const blockH    = ROW_HEIGHT - BLOCK_MARGIN * 2;
+
+  // Each segment is a contiguous run of working days. A block that carries
+  // through a weekend has more than one, drawn with the weekend columns left
+  // empty so the bar visually skips the weekend. Falls back to a single bar.
+  const segs = segments && segments.length > 0
+    ? segments
+    : [{ left: BLOCK_MARGIN, width: Math.max(width - BLOCK_MARGIN * 2, 24) }];
+  const firstW  = segs[0].width;          // governs which labels fit
+  const lastIdx = segs.length - 1;
+
+  const fillImage = isDelay
+    ? 'repeating-linear-gradient(45deg, transparent, transparent 7px, rgba(255,255,255,0.10) 7px, rgba(255,255,255,0.10) 14px)'
+    : 'linear-gradient(160deg, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.05) 42%, rgba(0,0,0,0.14) 100%)';
 
   return (
     <div
@@ -1591,187 +1633,206 @@ const JobBlock = ({
       }}
       style={{
         position: 'absolute',
-        left: left + BLOCK_MARGIN,
-        top: BLOCK_MARGIN,
-        width: blockW,
-        height: blockH,
-        backgroundColor: bgColor,
-        backgroundImage: isDelay
-          ? 'repeating-linear-gradient(45deg, transparent, transparent 7px, rgba(255,255,255,0.10) 7px, rgba(255,255,255,0.10) 14px)'
-          : 'linear-gradient(160deg, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.05) 42%, rgba(0,0,0,0.14) 100%)',
+        left,
+        top: 0,
+        width,
+        height: ROW_HEIGHT,
         opacity: isDragging ? 0.4 : 1,
-        borderRadius: 10,
         cursor: editMode ? 'grab' : 'default',
         userSelect: 'none',
         touchAction: editMode ? 'none' : 'auto',
-        overflow: 'hidden',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        padding: '0 10px 0 13px',
-        boxSizing: 'border-box',
-        boxShadow: isEquipDragOver
-          ? '0 0 0 2px #fff, 0 0 0 4px var(--brand-primary, #3b82f6)'
-          : isDragging
-            ? 'none'
-            : 'inset 0 1px 0 rgba(255,255,255,0.22), 0 1px 2px rgba(15,23,42,0.20), 0 4px 10px rgba(15,23,42,0.12)',
         transform: isDragging ? 'scale(0.98)' : undefined,
-        transition: 'opacity 0.12s, box-shadow 0.12s, transform 0.12s',
+        transition: 'opacity 0.12s, transform 0.12s',
         zIndex: 5,
       }}
     >
-      {/* Left accent strip — adds visual structure / a "tab" feel */}
-      <div
-        style={{
-          position: 'absolute', left: 0, top: 0, bottom: 0, width: 4,
-          background: isDelay
-            ? 'rgba(255,255,255,0.35)'
-            : 'linear-gradient(180deg, rgba(255,255,255,0.65), rgba(255,255,255,0.25))',
-          pointerEvents: 'none',
-        }}
-      />
-      {/* Extended dashed border */}
-      {block.extended && !isDelay && (
-        <div
-          style={{
-            position: 'absolute', inset: 0, borderRadius: 10,
-            border: '2px dashed rgba(251,191,36,0.85)',
-            pointerEvents: 'none',
-          }}
-        />
-      )}
+      {segs.map((seg, i) => {
+        const isFirst = i === 0;
+        const isLast  = i === lastIdx;
+        return (
+          <div
+            key={i}
+            style={{
+              position: 'absolute',
+              left: seg.left,
+              top: BLOCK_MARGIN,
+              width: seg.width,
+              height: blockH,
+              backgroundColor: bgColor,
+              backgroundImage: fillImage,
+              borderRadius: 10,
+              overflow: 'hidden',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              padding: '0 10px 0 13px',
+              boxSizing: 'border-box',
+              boxShadow: isEquipDragOver
+                ? '0 0 0 2px #fff, 0 0 0 4px var(--brand-primary, #3b82f6)'
+                : isDragging
+                  ? 'none'
+                  : 'inset 0 1px 0 rgba(255,255,255,0.22), 0 1px 2px rgba(15,23,42,0.20), 0 4px 10px rgba(15,23,42,0.12)',
+            }}
+          >
+            {/* Left accent strip — adds visual structure / a "tab" feel */}
+            <div
+              style={{
+                position: 'absolute', left: 0, top: 0, bottom: 0, width: 4,
+                background: isDelay
+                  ? 'rgba(255,255,255,0.35)'
+                  : 'linear-gradient(180deg, rgba(255,255,255,0.65), rgba(255,255,255,0.25))',
+                pointerEvents: 'none',
+              }}
+            />
+            {/* Extended dashed border (every segment, so the whole job reads as extended) */}
+            {block.extended && !isDelay && (
+              <div
+                style={{
+                  position: 'absolute', inset: 0, borderRadius: 10,
+                  border: '2px dashed rgba(251,191,36,0.85)',
+                  pointerEvents: 'none',
+                }}
+              />
+            )}
 
-      {/* Extended corner badge */}
-      {block.extended && !isDelay && (
-        <div
-          title="Extended"
-          style={{
-            position: 'absolute', top: 0, right: 0,
-            width: 0, height: 0,
-            borderStyle: 'solid',
-            borderWidth: '0 16px 16px 0',
-            borderColor: `transparent #fbbf24 transparent transparent`,
-          }}
-        />
-      )}
+            {/* Extended corner badge — on the final segment (the job's end) */}
+            {block.extended && !isDelay && isLast && (
+              <div
+                title="Extended"
+                style={{
+                  position: 'absolute', top: 0, right: 0,
+                  width: 0, height: 0,
+                  borderStyle: 'solid',
+                  borderWidth: '0 16px 16px 0',
+                  borderColor: `transparent #fbbf24 transparent transparent`,
+                }}
+              />
+            )}
 
-      {/* Edit mode drag handle — visible on top-left of block in edit mode */}
-      {editMode && (
-        <div
-          style={{
-            position: 'absolute', top: 3, left: 3,
-            color: 'rgba(255,255,255,0.65)',
-            pointerEvents: 'none',
-            lineHeight: 1,
-          }}
-        >
-          <GripHorizontal style={{ width: 10, height: 10 }} />
-        </div>
-      )}
+            {/* Edit mode drag handle — top-left of the first segment */}
+            {editMode && isFirst && (
+              <div
+                style={{
+                  position: 'absolute', top: 3, left: 3,
+                  color: 'rgba(255,255,255,0.65)',
+                  pointerEvents: 'none',
+                  lineHeight: 1,
+                }}
+              >
+                <GripHorizontal style={{ width: 10, height: 10 }} />
+              </div>
+            )}
 
-      {/* Resize handle — visible on right edge in edit mode for job blocks */}
-      {editMode && !isDelay && (
-        <div
-          onMouseDown={e => { e.stopPropagation(); e.preventDefault(); onResizeStart?.(e); }}
-          onTouchStart={e => { e.stopPropagation(); e.preventDefault(); onResizeTouchStart?.(e); }}
-          title="Drag to extend job duration"
-          style={{
-            position: 'absolute',
-            right: 0, top: 0,
-            width: 10, height: '100%',
-            cursor: 'col-resize',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 3,
-            zIndex: 15,
-          }}
-        >
-          <div style={{ width: 2, height: 6, background: 'rgba(255,255,255,0.55)', borderRadius: 1 }} />
-          <div style={{ width: 2, height: 6, background: 'rgba(255,255,255,0.55)', borderRadius: 1 }} />
-          <div style={{ width: 2, height: 6, background: 'rgba(255,255,255,0.55)', borderRadius: 1 }} />
-        </div>
-      )}
+            {/* Resize handle — right edge of the final segment for job blocks */}
+            {editMode && !isDelay && isLast && (
+              <div
+                onMouseDown={e => { e.stopPropagation(); e.preventDefault(); onResizeStart?.(e); }}
+                onTouchStart={e => { e.stopPropagation(); e.preventDefault(); onResizeTouchStart?.(e); }}
+                title="Drag to extend job duration"
+                style={{
+                  position: 'absolute',
+                  right: 0, top: 0,
+                  width: 10, height: '100%',
+                  cursor: 'col-resize',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 3,
+                  zIndex: 15,
+                }}
+              >
+                <div style={{ width: 2, height: 6, background: 'rgba(255,255,255,0.55)', borderRadius: 1 }} />
+                <div style={{ width: 2, height: 6, background: 'rgba(255,255,255,0.55)', borderRadius: 1 }} />
+                <div style={{ width: 2, height: 6, background: 'rgba(255,255,255,0.55)', borderRadius: 1 }} />
+              </div>
+            )}
 
-      {/* Admin delete button — visible on block for mobile/touch accessibility */}
-      {isAdmin && onDelete && (
-        <button
-          onClick={e => { e.stopPropagation(); e.preventDefault(); onDelete(); }}
-          onMouseDown={e => e.stopPropagation()}
-          onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); e.preventDefault(); onDelete(); } }}
-          title="Delete block"
-          aria-label="Delete block"
-          style={{
-            position: 'absolute',
-            top: 3,
-            right: 3,
-            width: 16,
-            height: 16,
-            borderRadius: '50%',
-            backgroundColor: 'rgba(0,0,0,0.35)',
-            border: 'none',
-            cursor: 'pointer',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: 0,
-            zIndex: 10,
-            lineHeight: 1,
-            color: '#fff',
-            fontSize: 10,
-            fontWeight: 700,
-          }}
-        >
-          ×
-        </button>
-      )}
+            {/* Admin delete button — top-right of the first segment */}
+            {isAdmin && onDelete && isFirst && (
+              <button
+                onClick={e => { e.stopPropagation(); e.preventDefault(); onDelete(); }}
+                onMouseDown={e => e.stopPropagation()}
+                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); e.preventDefault(); onDelete(); } }}
+                title="Delete block"
+                aria-label="Delete block"
+                style={{
+                  position: 'absolute',
+                  top: 3,
+                  right: 3,
+                  width: 16,
+                  height: 16,
+                  borderRadius: '50%',
+                  backgroundColor: 'rgba(0,0,0,0.35)',
+                  border: 'none',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 0,
+                  zIndex: 10,
+                  lineHeight: 1,
+                  color: '#fff',
+                  fontSize: 10,
+                  fontWeight: 700,
+                }}
+              >
+                ×
+              </button>
+            )}
 
-      {/* Equipment badge — bottom-left; clickable to open equipment modal */}
-      {!isDelay && (equipmentCount ?? 0) > 0 && onEquipmentClick && (
-        <button
-          onClick={e => { e.stopPropagation(); e.preventDefault(); onEquipmentClick(); }}
-          onMouseDown={e => e.stopPropagation()}
-          title={`${equipmentCount} piece${equipmentCount !== 1 ? 's' : ''} of equipment on site — click to manage`}
-          aria-label={`${equipmentCount} equipment assigned — click to manage`}
-          style={{
-            position: 'absolute',
-            bottom: 3,
-            left: 4,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2,
-            background: 'rgba(0,0,0,0.35)',
-            border: 'none',
-            borderRadius: 4,
-            padding: '1px 4px',
-            cursor: 'pointer',
-            zIndex: 10,
-            color: '#fff',
-            fontSize: 9,
-            fontWeight: 700,
-            lineHeight: 1.4,
-          }}
-        >
-          <Wrench style={{ width: 8, height: 8, flexShrink: 0 }} aria-hidden="true" />
-          {equipmentCount}
-        </button>
-      )}
+            {/* Equipment badge — bottom-left of the first segment; opens equipment modal */}
+            {!isDelay && (equipmentCount ?? 0) > 0 && onEquipmentClick && isFirst && (
+              <button
+                onClick={e => { e.stopPropagation(); e.preventDefault(); onEquipmentClick(); }}
+                onMouseDown={e => e.stopPropagation()}
+                title={`${equipmentCount} piece${equipmentCount !== 1 ? 's' : ''} of equipment on site — click to manage`}
+                aria-label={`${equipmentCount} equipment assigned — click to manage`}
+                style={{
+                  position: 'absolute',
+                  bottom: 3,
+                  left: 4,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  background: 'rgba(0,0,0,0.35)',
+                  border: 'none',
+                  borderRadius: 4,
+                  padding: '1px 4px',
+                  cursor: 'pointer',
+                  zIndex: 10,
+                  color: '#fff',
+                  fontSize: 9,
+                  fontWeight: 700,
+                  lineHeight: 1.4,
+                }}
+              >
+                <Wrench style={{ width: 8, height: 8, flexShrink: 0 }} aria-hidden="true" />
+                {equipmentCount}
+              </button>
+            )}
 
-      {/* Label */}
-      <div style={{ color: '#fff', fontSize: 11.5, fontWeight: 700, lineHeight: 1.2, letterSpacing: '0.01em', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 2px rgba(0,0,0,0.28)' }}>
-        {block.jobNumber}
-      </div>
-      {!isDelay && job && blockW > 64 && (
-        <div style={{ color: 'rgba(255,255,255,0.82)', fontSize: 9.5, marginTop: 2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 1px rgba(0,0,0,0.2)' }}>
-          {job.location}
-        </div>
-      )}
-      {blockW > 40 && (
-        <div style={{ display: 'inline-flex', alignItems: 'center', alignSelf: 'flex-start', marginTop: 4, padding: '1px 6px', borderRadius: 999, background: 'rgba(255,255,255,0.20)', color: 'rgba(255,255,255,0.95)', fontSize: 9, fontWeight: 600, lineHeight: 1.3, backdropFilter: 'blur(2px)' }}>
-          {block.durationDays}d
-        </div>
-      )}
+            {/* Labels — first segment only */}
+            {isFirst && (
+              <>
+                <div style={{ color: '#fff', fontSize: 11.5, fontWeight: 700, lineHeight: 1.2, letterSpacing: '0.01em', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 2px rgba(0,0,0,0.28)' }}>
+                  {block.jobNumber}
+                </div>
+                {!isDelay && job && firstW > 64 && (
+                  <div style={{ color: 'rgba(255,255,255,0.82)', fontSize: 9.5, marginTop: 2, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', textShadow: '0 1px 1px rgba(0,0,0,0.2)' }}>
+                    {job.location}
+                  </div>
+                )}
+                {firstW > 40 && (
+                  <div style={{ display: 'inline-flex', alignItems: 'center', alignSelf: 'flex-start', marginTop: 4, padding: '1px 6px', borderRadius: 999, background: 'rgba(255,255,255,0.20)', color: 'rgba(255,255,255,0.95)', fontSize: 9, fontWeight: 600, lineHeight: 1.3, backdropFilter: 'blur(2px)' }}>
+                    {block.durationDays}d
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 };
@@ -3010,6 +3071,12 @@ export default function Scheduler({
                     const isResizing = resizingId === block.id;
                     const previewDuration = block.durationDays + (isResizing ? resizeDeltaDays : 0);
                     const width = blockSpanDays(block.startDate, previewDuration, skipWeekends) * dayWidth;
+                    // Split the bar into per-work-stretch segments so a job that
+                    // carries through a weekend renders with the weekend skipped.
+                    const segments = workingDayRuns(block.startDate, previewDuration, skipWeekends).map(run => ({
+                      left:  run.offsetDays * dayWidth + BLOCK_MARGIN,
+                      width: Math.max(run.lengthDays * dayWidth - BLOCK_MARGIN * 2, 16),
+                    }));
                     if (left + width < 0 || left > totalGridWidth) return null;
                     const job = jobsState.find(j => j.jobNumber === block.jobNumber);
                     const eqCount = (block.equipmentIds ?? []).length;
@@ -3021,6 +3088,7 @@ export default function Scheduler({
                         job={job}
                         left={left}
                         width={width}
+                        segments={segments}
                         color={color}
                         isDragging={draggingId === block.id}
                         isAdmin={isAdmin}

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -2286,8 +2286,28 @@ export default function Scheduler({
   // Global touch-move / touch-end listeners while a touch drag is in progress
   const dayWidthRef    = useRef(dayWidth);
   const viewStartRef   = useRef(viewStart);
+  const todayOffsetRef = useRef(todayOffset);
   dayWidthRef.current    = dayWidth;
   viewStartRef.current   = viewStart;
+  todayOffsetRef.current = todayOffset;
+
+  // ── Focus today ───────────────────────────────────────────────────────────
+  // Horizontally scroll so today's column sits just inside the left edge (with a
+  // day of lead-in for context). Past days remain reachable by scrolling left and
+  // future days by scrolling right. Bumping `focusTodayNonce` re-triggers it.
+  const [focusTodayNonce, setFocusTodayNonce] = useState(0);
+  const scrollToToday = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollLeft = Math.max(0, todayOffsetRef.current - dayWidthRef.current);
+  }, []);
+
+  // Run on first paint and whenever the view granularity changes or the user
+  // explicitly asks to jump back to today.
+  useEffect(() => {
+    const id = requestAnimationFrame(scrollToToday);
+    return () => cancelAnimationFrame(id);
+  }, [view, focusTodayNonce, scrollToToday]);
 
   useEffect(() => {
     if (!touchGhostPos) return; // nothing being dragged
@@ -2602,7 +2622,7 @@ export default function Scheduler({
             <ChevronLeft className="w-4 h-4" />
           </button>
           <button
-            onClick={() => setViewOffset(0)}
+            onClick={() => { setViewOffset(0); setFocusTodayNonce(n => n + 1); }}
             className="px-3 py-1 text-xs font-semibold text-slate-200 hover:bg-white/10 hover:text-white rounded-md transition-colors"
           >
             Today


### PR DESCRIPTION
Treat job durations as working days (Mon–Fri) and auto-skip Saturdays
and Sundays across the dispatch board:

- New, dragged, and dropped blocks snap their start off weekends onto
  the next weekday.
- Block bars span weekends visually but only count working days, so a
  5-day job starting Monday ends Friday.
- Delays, extends, crew pushes, overlap detection, and conflict
  cascades all advance by working days.
- Added a "Mon–Fri / 7-Day" toolbar toggle (default Mon–Fri, persisted)
  so a weekend crew can still be scheduled when needed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TYKpR5Yf7U9ksF51JrKRA2