### PR TITLE
Fix PDF viewer rendering behind Leaflet map layers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1348,7 +1348,7 @@ const App: React.FC = () => {
         </div>
       )}
       {viewingDocUrl && (
-        <div className="fixed inset-0 bg-black/95 z-[300] flex flex-col items-center justify-center p-4">
+        <div className="fixed inset-0 bg-black/95 z-[1000] flex flex-col items-center justify-center p-4">
           <div className="w-full max-w-5xl flex flex-col h-[90vh]">
             <div className="flex justify-end pb-2 shrink-0">
               <button onClick={() => setViewingDocUrl(null)} className="p-2.5 bg-rose-600 text-white rounded-xl hover:bg-rose-500 hover:scale-105 transition-all active:scale-95 min-w-[44px] min-h-[44px] flex items-center justify-center" title="Close">

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -498,7 +498,7 @@ export const MapView: React.FC<MapViewProps> = ({ tickets, isDarkMode, onEditTic
       )}
 
       <div className={`rounded-[2.5rem] overflow-hidden border shadow-2xl ${isDarkMode ? 'border-white/5 shadow-black/40' : 'border-slate-200 shadow-slate-200/50'}`}
-           style={{ height: 'calc(100vh - 20rem)' }}>
+           style={{ height: 'calc(100vh - 20rem)', isolation: 'isolate' }}>
         <div ref={mapDivRef} style={{ width: '100%', height: '100%' }} />
       </div>
 


### PR DESCRIPTION
Leaflet's internal panes use z-indexes up to 700 (popup pane). The PDF
overlay was at z-[300], so map layers rendered on top of it. Bumped the
overlay to z-[1000] so it always sits above all Leaflet panes.