### PR TITLE
Add Job Hub invoicing; remove equipment/job-options from scheduler

### DIFF
--- a/components/JobHub.tsx
+++ b/components/JobHub.tsx
@@ -744,6 +744,8 @@ export const JobHub: React.FC<JobHubProps> = ({
             materials: detail.materials.map(i => ({ name: i.name, quantity: i.quantity, unitPrice: 0 })),
             customerName: selectedJob.customer ?? '',
             address: [selectedJob.address, selectedJob.city, selectedJob.state].filter(Boolean).join(', '),
+            // Raw entries so the modal can re-pull crew hours by work-date range.
+            timeEntries: detail.jobEntries,
           }}
           onClose={() => setShowInvoice(false)}
           onSaved={() => loadInvoiceCount(selectedJob.id)}

--- a/components/JobHub.tsx
+++ b/components/JobHub.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Search, Plus, FileText, Upload, Clock, Package, Users, Truck,
-  CalendarDays, Activity, Trash2, Pencil, CheckCircle2, RotateCcw, X,
+  CalendarDays, Activity, Trash2, Pencil, CheckCircle2, RotateCcw, X, Receipt,
 } from 'lucide-react';
 import { Job, DigTicket, TicketStatus, InventoryItem, InventoryItemType, InventoryMovement, JobPrint } from '../types.ts';
 import { getTicketStatus, getStatusColor, formatDateStr } from '../utils/dateUtils.ts';
@@ -10,6 +10,8 @@ import { scheduleService } from '../services/scheduleService.ts';
 import { timeTrackingService } from '../services/timeTrackingService.ts';
 import { CostCode, JobCostCodeAssignment, TimeEntry, entryRoundedHours } from '../services/timeTrackingTypes.ts';
 import { Employee } from '../services/schedulingTypes.ts';
+import { jobInvoiceService } from '../services/jobInvoiceService.ts';
+import { JobInvoiceModal } from './JobInvoiceModal.tsx';
 import { supabase } from '../lib/supabaseClient.ts';
 
 interface JobHubProps {
@@ -90,6 +92,10 @@ export const JobHub: React.FC<JobHubProps> = ({
   const [printsLoading, setPrintsLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  // ── invoicing ───────────────────────────────────────────────────────────────
+  const [showInvoice, setShowInvoice] = useState(false);
+  const [invoiceCount, setInvoiceCount] = useState(0);
 
   const card = isDarkMode ? 'bg-[#1e293b] border-white/5' : 'bg-white border-slate-200 shadow-sm';
   const subtle = isDarkMode ? 'text-slate-400' : 'text-slate-500';
@@ -197,6 +203,15 @@ export const JobHub: React.FC<JobHubProps> = ({
       .finally(() => { if (alive) setPrintsLoading(false); });
     return () => { alive = false; };
   }, [selectedJob?.jobNumber]);
+
+  // Load saved-invoice count for the selected job (drives the header badge).
+  const loadInvoiceCount = (jobId: string) => {
+    jobInvoiceService.listByJob(jobId).then(list => setInvoiceCount(list.length)).catch(() => setInvoiceCount(0));
+  };
+  useEffect(() => {
+    if (!selectedJob) { setInvoiceCount(0); return; }
+    loadInvoiceCount(selectedJob.id);
+  }, [selectedJob?.id]);
 
   const selectJob = (id: string) => { setSelectedId(id); setMobileDetailOpen(true); };
 
@@ -436,6 +451,9 @@ export const JobHub: React.FC<JobHubProps> = ({
                   </div>
                   {isAdmin && (
                     <div className="flex flex-wrap items-center gap-2">
+                      <button onClick={() => setShowInvoice(true)} className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-brand/10 text-brand text-[10px] font-black uppercase tracking-widest hover:bg-brand/20 transition-all">
+                        <Receipt size={13} /> Invoice{invoiceCount > 0 ? ` (${invoiceCount})` : ''}
+                      </button>
                       <button onClick={() => onEditJob(selectedJob)} className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-[10px] font-black uppercase tracking-widest transition-all ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>
                         <Pencil size={13} /> Edit
                       </button>
@@ -704,6 +722,33 @@ export const JobHub: React.FC<JobHubProps> = ({
           )}
         </div>
       </div>
+
+      {showInvoice && selectedJob && detail && (
+        <JobInvoiceModal
+          job={selectedJob}
+          companyId={companyId}
+          isDarkMode={isDarkMode}
+          prefill={{
+            // Crew: aggregate logged hours per employee, rate from the employee record.
+            crew: Array.from(
+              detail.jobEntries.reduce((map, e) => {
+                const prev = map.get(e.employeeId) ?? { employeeId: e.employeeId, hours: 0, rate: empById.get(e.employeeId)?.hourlyRate ?? 0 };
+                prev.hours += entryRoundedHours(e);
+                map.set(e.employeeId, prev);
+                return map;
+              }, new Map<number, { employeeId: number; hours: number; rate: number }>()).values(),
+            ),
+            // Equipment on site: one line each, hours blank for the user to fill.
+            equipment: detail.equipment.map(i => ({ equipmentId: i.id, hours: 0, rate: i.hourlyRate ?? 0 })),
+            // Materials linked to the job: qty from inventory, price for the user to fill.
+            materials: detail.materials.map(i => ({ name: i.name, quantity: i.quantity, unitPrice: 0 })),
+            customerName: selectedJob.customer ?? '',
+            address: [selectedJob.address, selectedJob.city, selectedJob.state].filter(Boolean).join(', '),
+          }}
+          onClose={() => setShowInvoice(false)}
+          onSaved={() => loadInvoiceCount(selectedJob.id)}
+        />
+      )}
     </div>
   );
 };

--- a/components/JobInvoiceModal.tsx
+++ b/components/JobInvoiceModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText } from 'lucide-react';
+import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText, Clock } from 'lucide-react';
 import { Job, InventoryItem, InventoryItemType } from '../types.ts';
 import {
   Employee, Equipment, ServiceJob, WorkLog, WorkLogEntry, InvoiceSettings, JobInvoice, JobInvoiceData,
@@ -9,6 +9,7 @@ import { computeTotals } from './scheduling/costUtils.ts';
 import { jobInvoiceService } from '../services/jobInvoiceService.ts';
 import { scheduleService } from '../services/scheduleService.ts';
 import { apiService } from '../services/apiService.ts';
+import { TimeEntry, entryRoundedHours } from '../services/timeTrackingTypes.ts';
 
 type CrewLine = WorkLogEntry['employees'][number];
 type EquipLine = WorkLogEntry['equipment'][number];
@@ -20,6 +21,8 @@ interface PrefillData {
   materials: MatLine[];
   customerName: string;
   address: string;
+  // Raw time entries for this job, so the modal can re-pull crew hours by work date.
+  timeEntries: TimeEntry[];
 }
 
 interface JobInvoiceModalProps {
@@ -56,7 +59,15 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   const [customerName, setCustomerName] = useState(prefill.customerName);
   const [address, setAddress] = useState(prefill.address);
   const [invoiceDate, setInvoiceDate] = useState(toISODate(new Date()));
-  const [dueDate, setDueDate] = useState(toISODate(new Date(Date.now() + 30 * 86400000)));
+
+  // Work-date range over which crew hours are pulled (a time entry's clock-in day).
+  // Defaults to the full span of the job's logged entries.
+  const workDays = useMemo(
+    () => prefill.timeEntries.map(e => e.clockedInAt.slice(0, 10)).sort(),
+    [prefill.timeEntries],
+  );
+  const [workFrom, setWorkFrom] = useState(workDays[0] ?? '');
+  const [workTo, setWorkTo] = useState(workDays[workDays.length - 1] ?? '');
 
   // ── catalogs + branding + history (loaded on mount) ─────────────────────────
   const [employees, setEmployees] = useState<Employee[]>([]);
@@ -94,6 +105,24 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   const empName = (id: number) => employees.find(e => e.id === id)?.name ?? `Employee #${id}`;
   const equipName = (id: string) => equipCatalog.find(e => e.id === id)?.name ?? `Equipment #${id}`;
 
+  // Re-pull crew lines from the time entries whose work day falls in [workFrom, workTo],
+  // grouped by employee with hours summed and rate from the employee record.
+  const pullCrewFromWorkDates = () => {
+    const inRange = prefill.timeEntries.filter(e => {
+      const d = e.clockedInAt.slice(0, 10);
+      return (!workFrom || d >= workFrom) && (!workTo || d <= workTo);
+    });
+    const byEmp = new Map<number, CrewLine>();
+    for (const e of inRange) {
+      const rate = employees.find(em => em.id === e.employeeId)?.hourlyRate
+        ?? crew.find(c => c.employeeId === e.employeeId)?.rate ?? 0;
+      const prev = byEmp.get(e.employeeId) ?? { employeeId: e.employeeId, hours: 0, rate };
+      prev.hours += entryRoundedHours(e);
+      byEmp.set(e.employeeId, prev);
+    }
+    setCrew(Array.from(byEmp.values()));
+  };
+
   // ── totals ──────────────────────────────────────────────────────────────────
   const entry: WorkLogEntry = useMemo(() => ({ employees: crew, equipment, materials }), [crew, equipment, materials]);
   const totals = useMemo(() => computeTotals([{ id: 0, jobId: 0, date: invoiceDate, notes: '', data: entry }], []), [entry, invoiceDate]);
@@ -106,12 +135,12 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   });
 
   const download = (
-    log: WorkLog, t: ReturnType<typeof computeTotals>, num: string, cn: string, addr: string, dt: Date, due: Date,
+    log: WorkLog, t: ReturnType<typeof computeTotals>, num: string, cn: string, addr: string, dt: Date,
   ) => {
     generateInvoicePdf({
       job: buildServiceJob(cn, addr),
       logs: [log], totals: t, invoiceNumber: num,
-      invoiceDate: dt, dueDate: due, branding,
+      invoiceDate: dt, branding,
       employees, equipment: equipCatalog, materials: [],
     });
   };
@@ -119,7 +148,7 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   const handleDownload = () => {
     download(
       { id: 0, jobId: 0, date: invoiceDate, notes: '', data: entry },
-      totals, invoiceNumber, customerName, address, new Date(invoiceDate), new Date(dueDate),
+      totals, invoiceNumber, customerName, address, new Date(invoiceDate),
     );
   };
 
@@ -128,7 +157,7 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
     try {
       const data: JobInvoiceData = { customerName, address, employees: crew, equipment, materials };
       const saved = await jobInvoiceService.create(companyId, {
-        jobId: job.id, invoiceNumber, date: invoiceDate, dueDate,
+        jobId: job.id, invoiceNumber, date: invoiceDate, dueDate: null,
         laborTotal: totals.labor, equipmentTotal: totals.equipment,
         materialTotal: totals.material, grandTotal: totals.grand, data,
       });
@@ -148,7 +177,7 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
       log,
       { labor: inv.laborTotal, equipment: inv.equipmentTotal, material: inv.materialTotal, grand: inv.grandTotal },
       inv.invoiceNumber, data.customerName, data.address,
-      inv.date ? new Date(inv.date) : new Date(), inv.dueDate ? new Date(inv.dueDate) : new Date(),
+      inv.date ? new Date(inv.date) : new Date(),
     );
   };
 
@@ -208,16 +237,30 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
               <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Invoice Date</label>
               <input type="date" value={invoiceDate} onChange={e => setInvoiceDate(e.target.value)} className={`${inputCls} w-full`} />
             </div>
-            <div className="space-y-1">
-              <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Due Date</label>
-              <input type="date" value={dueDate} onChange={e => setDueDate(e.target.value)} className={`${inputCls} w-full`} />
-            </div>
           </div>
 
           {/* Crew labor */}
           <div>
             <SectionHead icon={<Users size={14} />} title="Crew Labor" addLabel="Add crew"
               onAdd={() => setCrew(prev => [...prev, { employeeId: employees[0]?.id ?? 0, hours: 0, rate: employees[0]?.hourlyRate ?? 0 }])} />
+            {/* Work-date range: pull employees + hours logged within the window. */}
+            <div className={`flex flex-wrap items-end gap-2 mb-3 p-3 rounded-xl border ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
+              <div className="space-y-1">
+                <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Work From</label>
+                <input type="date" value={workFrom} onChange={e => setWorkFrom(e.target.value)} className={`${inputCls} w-full`} />
+              </div>
+              <div className="space-y-1">
+                <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Work To</label>
+                <input type="date" value={workTo} onChange={e => setWorkTo(e.target.value)} className={`${inputCls} w-full`} />
+              </div>
+              <button onClick={pullCrewFromWorkDates} disabled={prefill.timeEntries.length === 0}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand text-[#0f172a] text-[9px] font-black uppercase tracking-widest disabled:opacity-40">
+                <Clock size={12} /> Pull Hours
+              </button>
+              <span className={`text-[9px] font-bold ${subtle}`}>
+                {prefill.timeEntries.length === 0 ? 'No time logged on this job' : `${prefill.timeEntries.length} entr${prefill.timeEntries.length === 1 ? 'y' : 'ies'} logged`}
+              </span>
+            </div>
             {crew.length === 0 ? <p className={`text-[11px] italic ${subtle}`}>No crew lines.</p> : (
               <div className="space-y-1.5">
                 {crew.map((c, i) => (

--- a/components/JobInvoiceModal.tsx
+++ b/components/JobInvoiceModal.tsx
@@ -9,7 +9,22 @@ import { computeTotals } from './scheduling/costUtils.ts';
 import { jobInvoiceService } from '../services/jobInvoiceService.ts';
 import { scheduleService } from '../services/scheduleService.ts';
 import { apiService } from '../services/apiService.ts';
+import { timeTrackingService } from '../services/timeTrackingService.ts';
 import { TimeEntry, entryRoundedHours } from '../services/timeTrackingTypes.ts';
+
+// Group a set of time entries into crew line items: one row per employee with
+// hours summed and rate resolved from the employee catalog.
+const aggregateCrew = (entries: TimeEntry[], employees: Employee[], fallback: CrewLine[] = []): CrewLine[] => {
+  const byEmp = new Map<number, CrewLine>();
+  for (const e of entries) {
+    const rate = employees.find(em => em.id === e.employeeId)?.hourlyRate
+      ?? fallback.find(c => c.employeeId === e.employeeId)?.rate ?? 0;
+    const prev = byEmp.get(e.employeeId) ?? { employeeId: e.employeeId, hours: 0, rate };
+    prev.hours += entryRoundedHours(e);
+    byEmp.set(e.employeeId, prev);
+  }
+  return Array.from(byEmp.values());
+};
 
 type CrewLine = WorkLogEntry['employees'][number];
 type EquipLine = WorkLogEntry['equipment'][number];
@@ -60,14 +75,16 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   const [address, setAddress] = useState(prefill.address);
   const [invoiceDate, setInvoiceDate] = useState(toISODate(new Date()));
 
+  // This job's dig-job time entries. Seeded from what JobHub passed in, but the
+  // modal re-fetches them directly on mount so it never depends on JobHub having
+  // finished (or succeeded at) loading time entries before the invoice opened.
+  const [jobEntries, setJobEntries] = useState<TimeEntry[]>(prefill.timeEntries);
+
   // Work-date range over which crew hours are pulled (a time entry's clock-in day).
   // Defaults to the full span of the job's logged entries.
-  const workDays = useMemo(
-    () => prefill.timeEntries.map(e => e.clockedInAt.slice(0, 10)).sort(),
-    [prefill.timeEntries],
-  );
-  const [workFrom, setWorkFrom] = useState(workDays[0] ?? '');
-  const [workTo, setWorkTo] = useState(workDays[workDays.length - 1] ?? '');
+  const seedDays = prefill.timeEntries.map(e => e.clockedInAt.slice(0, 10)).sort();
+  const [workFrom, setWorkFrom] = useState(seedDays[0] ?? '');
+  const [workTo, setWorkTo] = useState(seedDays[seedDays.length - 1] ?? '');
 
   // ── catalogs + branding + history (loaded on mount) ─────────────────────────
   const [employees, setEmployees] = useState<Employee[]>([]);
@@ -84,11 +101,12 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   useEffect(() => {
     let alive = true;
     (async () => {
-      const [emps, items, settings, invs] = await Promise.all([
+      const [emps, items, settings, invs, entries] = await Promise.all([
         scheduleService.getEmployees().catch(() => [] as Employee[]),
         apiService.getInventoryItems().catch(() => [] as InventoryItem[]),
         scheduleService.getInvoiceSettings().catch(() => null),
         jobInvoiceService.listByJob(job.id).catch(() => [] as JobInvoice[]),
+        timeTrackingService.listEntries().catch(() => [] as TimeEntry[]),
       ]);
       if (!alive) return;
       setEmployees(emps);
@@ -98,6 +116,18 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
       setMatCatalog(items.filter(i => i.itemType === InventoryItemType.MATERIAL));
       if (settings) setBranding(settings);
       setHistory(invs);
+
+      // Authoritative time entries for this dig job, fetched directly.
+      const digEntries = entries.filter(e => e.jobKind === 'dig' && e.jobRef === job.id);
+      setJobEntries(digEntries);
+      if (digEntries.length > 0) {
+        const days = digEntries.map(e => e.clockedInAt.slice(0, 10)).sort();
+        setWorkFrom(days[0]);
+        setWorkTo(days[days.length - 1]);
+        // Seed crew from the full span only when nothing has been entered yet, so
+        // a slow/empty JobHub prefill no longer leaves the invoice blank.
+        setCrew(prev => (prev.length === 0 ? aggregateCrew(digEntries, emps) : prev));
+      }
     })();
     return () => { alive = false; };
   }, [job.id, companyId]);
@@ -108,19 +138,11 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   // Re-pull crew lines from the time entries whose work day falls in [workFrom, workTo],
   // grouped by employee with hours summed and rate from the employee record.
   const pullCrewFromWorkDates = () => {
-    const inRange = prefill.timeEntries.filter(e => {
+    const inRange = jobEntries.filter(e => {
       const d = e.clockedInAt.slice(0, 10);
       return (!workFrom || d >= workFrom) && (!workTo || d <= workTo);
     });
-    const byEmp = new Map<number, CrewLine>();
-    for (const e of inRange) {
-      const rate = employees.find(em => em.id === e.employeeId)?.hourlyRate
-        ?? crew.find(c => c.employeeId === e.employeeId)?.rate ?? 0;
-      const prev = byEmp.get(e.employeeId) ?? { employeeId: e.employeeId, hours: 0, rate };
-      prev.hours += entryRoundedHours(e);
-      byEmp.set(e.employeeId, prev);
-    }
-    setCrew(Array.from(byEmp.values()));
+    setCrew(aggregateCrew(inRange, employees, crew));
   };
 
   // ── totals ──────────────────────────────────────────────────────────────────
@@ -253,12 +275,12 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
                 <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Work To</label>
                 <input type="date" value={workTo} onChange={e => setWorkTo(e.target.value)} className={`${inputCls} w-full`} />
               </div>
-              <button onClick={pullCrewFromWorkDates} disabled={prefill.timeEntries.length === 0}
+              <button onClick={pullCrewFromWorkDates} disabled={jobEntries.length === 0}
                 className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand text-[#0f172a] text-[9px] font-black uppercase tracking-widest disabled:opacity-40">
                 <Clock size={12} /> Pull Hours
               </button>
               <span className={`text-[9px] font-bold ${subtle}`}>
-                {prefill.timeEntries.length === 0 ? 'No time logged on this job' : `${prefill.timeEntries.length} entr${prefill.timeEntries.length === 1 ? 'y' : 'ies'} logged`}
+                {jobEntries.length === 0 ? 'No time logged on this job' : `${jobEntries.length} entr${jobEntries.length === 1 ? 'y' : 'ies'} logged`}
               </span>
             </div>
             {crew.length === 0 ? <p className={`text-[11px] italic ${subtle}`}>No crew lines.</p> : (

--- a/components/JobInvoiceModal.tsx
+++ b/components/JobInvoiceModal.tsx
@@ -1,0 +1,338 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText } from 'lucide-react';
+import { Job, InventoryItem, InventoryItemType } from '../types.ts';
+import {
+  Employee, Equipment, ServiceJob, WorkLog, WorkLogEntry, InvoiceSettings, JobInvoice, JobInvoiceData,
+} from '../services/schedulingTypes.ts';
+import { generateInvoicePdf } from './scheduling/invoicePdf.ts';
+import { computeTotals } from './scheduling/costUtils.ts';
+import { jobInvoiceService } from '../services/jobInvoiceService.ts';
+import { scheduleService } from '../services/scheduleService.ts';
+import { apiService } from '../services/apiService.ts';
+
+type CrewLine = WorkLogEntry['employees'][number];
+type EquipLine = WorkLogEntry['equipment'][number];
+type MatLine = WorkLogEntry['materials'][number];
+
+interface PrefillData {
+  crew: CrewLine[];
+  equipment: EquipLine[];
+  materials: MatLine[];
+  customerName: string;
+  address: string;
+}
+
+interface JobInvoiceModalProps {
+  job: Job;
+  companyId: string;
+  isDarkMode?: boolean;
+  prefill: PrefillData;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+const DEFAULT_BRANDING = (companyId: string): InvoiceSettings => ({
+  companyId,
+  companyName: '',
+  companyAddress: '',
+  companyPhone: '',
+  companyEmail: '',
+  logoInitials: '',
+  paymentTerms: 'Payment due within 30 days.',
+  headerColor: '#0a142d',
+  accentColor: '#c49614',
+});
+
+const toISODate = (d: Date) => d.toISOString().slice(0, 10);
+
+export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
+  job, companyId, isDarkMode, prefill, onClose, onSaved,
+}) => {
+  // ── editable line items (seeded from the job's tracked data) ────────────────
+  const [crew, setCrew] = useState<CrewLine[]>(prefill.crew);
+  const [equipment, setEquipment] = useState<EquipLine[]>(prefill.equipment);
+  const [materials, setMaterials] = useState<MatLine[]>(prefill.materials);
+
+  const [customerName, setCustomerName] = useState(prefill.customerName);
+  const [address, setAddress] = useState(prefill.address);
+  const [invoiceDate, setInvoiceDate] = useState(toISODate(new Date()));
+  const [dueDate, setDueDate] = useState(toISODate(new Date(Date.now() + 30 * 86400000)));
+
+  // ── catalogs + branding + history (loaded on mount) ─────────────────────────
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [equipCatalog, setEquipCatalog] = useState<Equipment[]>([]);
+  const [matCatalog, setMatCatalog] = useState<InventoryItem[]>([]);
+  const [branding, setBranding] = useState<InvoiceSettings>(DEFAULT_BRANDING(companyId));
+  const [history, setHistory] = useState<JobInvoice[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const card = isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200';
+  const subtle = isDarkMode ? 'text-slate-400' : 'text-slate-500';
+  const inputCls = `px-2 py-1.5 rounded-lg border text-[11px] font-bold outline-none focus:ring-4 focus:ring-brand/10 ${isDarkMode ? 'bg-white/5 border-white/10 text-white' : 'bg-slate-50 border-slate-200 text-slate-900'}`;
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const [emps, items, settings, invs] = await Promise.all([
+        scheduleService.getEmployees().catch(() => [] as Employee[]),
+        apiService.getInventoryItems().catch(() => [] as InventoryItem[]),
+        scheduleService.getInvoiceSettings().catch(() => null),
+        jobInvoiceService.listByJob(job.id).catch(() => [] as JobInvoice[]),
+      ]);
+      if (!alive) return;
+      setEmployees(emps);
+      setEquipCatalog(items
+        .filter(i => i.itemType === InventoryItemType.EQUIPMENT)
+        .map(i => ({ id: i.id, companyId: i.companyId, name: i.unitNumber ? `#${i.unitNumber} ${i.name}` : i.name, hourlyRate: i.hourlyRate ?? 0 })));
+      setMatCatalog(items.filter(i => i.itemType === InventoryItemType.MATERIAL));
+      if (settings) setBranding(settings);
+      setHistory(invs);
+    })();
+    return () => { alive = false; };
+  }, [job.id, companyId]);
+
+  const empName = (id: number) => employees.find(e => e.id === id)?.name ?? `Employee #${id}`;
+  const equipName = (id: string) => equipCatalog.find(e => e.id === id)?.name ?? `Equipment #${id}`;
+
+  // ── totals ──────────────────────────────────────────────────────────────────
+  const entry: WorkLogEntry = useMemo(() => ({ employees: crew, equipment, materials }), [crew, equipment, materials]);
+  const totals = useMemo(() => computeTotals([{ id: 0, jobId: 0, date: invoiceDate, notes: '', data: entry }], []), [entry, invoiceDate]);
+
+  const invoiceNumber = useMemo(() => `INV-${job.jobNumber}-${history.length + 1}`, [job.jobNumber, history.length]);
+
+  const buildServiceJob = (cn: string, addr: string): ServiceJob => ({
+    id: 0, companyId, customerName: cn, jobName: job.jobName || '', jobNumber: job.jobNumber,
+    address: addr, startDate: null, endDate: null, notes: '', status: 'active', foremanId: null,
+  });
+
+  const download = (
+    log: WorkLog, t: ReturnType<typeof computeTotals>, num: string, cn: string, addr: string, dt: Date, due: Date,
+  ) => {
+    generateInvoicePdf({
+      job: buildServiceJob(cn, addr),
+      logs: [log], totals: t, invoiceNumber: num,
+      invoiceDate: dt, dueDate: due, branding,
+      employees, equipment: equipCatalog, materials: [],
+    });
+  };
+
+  const handleDownload = () => {
+    download(
+      { id: 0, jobId: 0, date: invoiceDate, notes: '', data: entry },
+      totals, invoiceNumber, customerName, address, new Date(invoiceDate), new Date(dueDate),
+    );
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const data: JobInvoiceData = { customerName, address, employees: crew, equipment, materials };
+      const saved = await jobInvoiceService.create(companyId, {
+        jobId: job.id, invoiceNumber, date: invoiceDate, dueDate,
+        laborTotal: totals.labor, equipmentTotal: totals.equipment,
+        materialTotal: totals.material, grandTotal: totals.grand, data,
+      });
+      setHistory(prev => [saved, ...prev]);
+      onSaved?.();
+    } catch (err: any) {
+      alert('Failed to save invoice: ' + (err?.message ?? err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const downloadSaved = (inv: JobInvoice) => {
+    const data = inv.data;
+    const log: WorkLog = { id: 0, jobId: 0, date: inv.date ?? toISODate(new Date()), notes: '', data: { employees: data.employees, equipment: data.equipment, materials: data.materials } };
+    download(
+      log,
+      { labor: inv.laborTotal, equipment: inv.equipmentTotal, material: inv.materialTotal, grand: inv.grandTotal },
+      inv.invoiceNumber, data.customerName, data.address,
+      inv.date ? new Date(inv.date) : new Date(), inv.dueDate ? new Date(inv.dueDate) : new Date(),
+    );
+  };
+
+  const deleteSaved = async (inv: JobInvoice) => {
+    if (!confirm(`Delete invoice ${inv.invoiceNumber}?`)) return;
+    try {
+      await jobInvoiceService.delete(inv.id);
+      setHistory(prev => prev.filter(i => i.id !== inv.id));
+      onSaved?.();
+    } catch (err: any) {
+      alert('Failed to delete: ' + (err?.message ?? err));
+    }
+  };
+
+  // ── line-item editors ─────────────────────────────────────────────────────
+  const SectionHead: React.FC<{ icon: React.ReactNode; title: string; onAdd: () => void; addLabel: string }> = ({ icon, title, onAdd, addLabel }) => (
+    <div className="flex items-center justify-between mb-2">
+      <div className="flex items-center gap-2">
+        <span className="text-brand">{icon}</span>
+        <h4 className={`text-[10px] font-black uppercase tracking-[0.18em] ${subtle}`}>{title}</h4>
+      </div>
+      <button onClick={onAdd} className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-brand/10 text-brand text-[9px] font-black uppercase tracking-widest hover:bg-brand/20">
+        <Plus size={11} /> {addLabel}
+      </button>
+    </div>
+  );
+
+  const numInput = (val: number, onChange: (n: number) => void, w = 'w-20') => (
+    <input type="number" min={0} step="0.01" value={Number.isFinite(val) ? val : 0}
+      onChange={e => onChange(parseFloat(e.target.value) || 0)} className={`${inputCls} ${w} text-right`} />
+  );
+
+  return (
+    <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-md z-[170] overflow-y-auto pt-8 pb-20 px-4">
+      <div className={`w-full max-w-2xl mx-auto rounded-3xl shadow-2xl overflow-hidden border ${card}`}>
+        {/* Header */}
+        <div className="px-6 py-5 border-b border-black/5 flex justify-between items-center bg-black/5">
+          <div>
+            <h2 className="text-sm font-black uppercase tracking-[0.2em] text-brand">Create Invoice</h2>
+            <p className={`text-[10px] font-bold uppercase tracking-widest mt-0.5 ${subtle}`}>Job #{job.jobNumber} · {invoiceNumber}</p>
+          </div>
+          <button onClick={onClose} className="p-2 opacity-50 hover:opacity-100 transition-opacity"><X size={18} /></button>
+        </div>
+
+        <div className="p-6 space-y-6 max-h-[70vh] overflow-y-auto">
+          {/* Bill-to + dates */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Bill To</label>
+              <input value={customerName} onChange={e => setCustomerName(e.target.value)} placeholder="Customer name" className={`${inputCls} w-full`} />
+            </div>
+            <div className="space-y-1">
+              <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Address</label>
+              <input value={address} onChange={e => setAddress(e.target.value)} placeholder="Billing address" className={`${inputCls} w-full`} />
+            </div>
+            <div className="space-y-1">
+              <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Invoice Date</label>
+              <input type="date" value={invoiceDate} onChange={e => setInvoiceDate(e.target.value)} className={`${inputCls} w-full`} />
+            </div>
+            <div className="space-y-1">
+              <label className={`text-[9px] font-black uppercase tracking-widest ${subtle}`}>Due Date</label>
+              <input type="date" value={dueDate} onChange={e => setDueDate(e.target.value)} className={`${inputCls} w-full`} />
+            </div>
+          </div>
+
+          {/* Crew labor */}
+          <div>
+            <SectionHead icon={<Users size={14} />} title="Crew Labor" addLabel="Add crew"
+              onAdd={() => setCrew(prev => [...prev, { employeeId: employees[0]?.id ?? 0, hours: 0, rate: employees[0]?.hourlyRate ?? 0 }])} />
+            {crew.length === 0 ? <p className={`text-[11px] italic ${subtle}`}>No crew lines.</p> : (
+              <div className="space-y-1.5">
+                {crew.map((c, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <select value={c.employeeId} onChange={e => setCrew(prev => prev.map((x, j) => j === i ? { ...x, employeeId: Number(e.target.value), rate: x.rate || (employees.find(em => em.id === Number(e.target.value))?.hourlyRate ?? 0) } : x))} className={`${inputCls} flex-1`}>
+                      {employees.length === 0 && <option value={c.employeeId}>{empName(c.employeeId)}</option>}
+                      {employees.map(e => <option key={e.id} value={e.id}>{e.name}</option>)}
+                    </select>
+                    {numInput(c.hours, n => setCrew(prev => prev.map((x, j) => j === i ? { ...x, hours: n } : x)))}
+                    <span className={`text-[9px] ${subtle}`}>hrs ×</span>
+                    {numInput(c.rate, n => setCrew(prev => prev.map((x, j) => j === i ? { ...x, rate: n } : x)))}
+                    <span className="w-20 text-right text-[11px] font-black">${(c.hours * c.rate).toFixed(2)}</span>
+                    <button onClick={() => setCrew(prev => prev.filter((_, j) => j !== i))} className="text-rose-500 hover:text-rose-600"><Trash2 size={13} /></button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Equipment */}
+          <div>
+            <SectionHead icon={<Truck size={14} />} title="Equipment" addLabel="Add equipment"
+              onAdd={() => setEquipment(prev => [...prev, { equipmentId: equipCatalog[0]?.id ?? '', hours: 0, rate: equipCatalog[0]?.hourlyRate ?? 0 }])} />
+            {equipment.length === 0 ? <p className={`text-[11px] italic ${subtle}`}>No equipment lines.</p> : (
+              <div className="space-y-1.5">
+                {equipment.map((eq, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <select value={eq.equipmentId} onChange={e => setEquipment(prev => prev.map((x, j) => j === i ? { ...x, equipmentId: e.target.value, rate: x.rate || (equipCatalog.find(c => c.id === e.target.value)?.hourlyRate ?? 0) } : x))} className={`${inputCls} flex-1`}>
+                      {equipCatalog.length === 0 && <option value={eq.equipmentId}>{equipName(eq.equipmentId)}</option>}
+                      {equipCatalog.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                    </select>
+                    {numInput(eq.hours, n => setEquipment(prev => prev.map((x, j) => j === i ? { ...x, hours: n } : x)))}
+                    <span className={`text-[9px] ${subtle}`}>hrs ×</span>
+                    {numInput(eq.rate, n => setEquipment(prev => prev.map((x, j) => j === i ? { ...x, rate: n } : x)))}
+                    <span className="w-20 text-right text-[11px] font-black">${(eq.hours * eq.rate).toFixed(2)}</span>
+                    <button onClick={() => setEquipment(prev => prev.filter((_, j) => j !== i))} className="text-rose-500 hover:text-rose-600"><Trash2 size={13} /></button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Materials */}
+          <div>
+            <SectionHead icon={<Package size={14} />} title="Materials" addLabel="Add material"
+              onAdd={() => setMaterials(prev => [...prev, { name: '', quantity: 1, unitPrice: 0 }])} />
+            {materials.length === 0 ? <p className={`text-[11px] italic ${subtle}`}>No material lines.</p> : (
+              <div className="space-y-1.5">
+                {materials.map((m, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <input list="job-invoice-materials" value={m.name} placeholder="Material"
+                      onChange={e => setMaterials(prev => prev.map((x, j) => j === i ? { ...x, name: e.target.value } : x))}
+                      className={`${inputCls} flex-1`} />
+                    {numInput(m.quantity, n => setMaterials(prev => prev.map((x, j) => j === i ? { ...x, quantity: n } : x)))}
+                    <span className={`text-[9px] ${subtle}`}>×</span>
+                    {numInput(m.unitPrice, n => setMaterials(prev => prev.map((x, j) => j === i ? { ...x, unitPrice: n } : x)))}
+                    <span className="w-20 text-right text-[11px] font-black">${(m.quantity * m.unitPrice).toFixed(2)}</span>
+                    <button onClick={() => setMaterials(prev => prev.filter((_, j) => j !== i))} className="text-rose-500 hover:text-rose-600"><Trash2 size={13} /></button>
+                  </div>
+                ))}
+                <datalist id="job-invoice-materials">
+                  {matCatalog.map(c => <option key={c.id} value={c.name} />)}
+                </datalist>
+              </div>
+            )}
+          </div>
+
+          {/* Totals */}
+          <div className={`rounded-2xl border p-4 ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
+            <div className="space-y-1 text-[11px]">
+              <div className="flex justify-between"><span className={subtle}>Labor</span><span className="font-bold">${totals.labor.toFixed(2)}</span></div>
+              <div className="flex justify-between"><span className={subtle}>Equipment</span><span className="font-bold">${totals.equipment.toFixed(2)}</span></div>
+              <div className="flex justify-between"><span className={subtle}>Materials</span><span className="font-bold">${totals.material.toFixed(2)}</span></div>
+              <div className="flex justify-between pt-2 mt-1 border-t border-black/10 text-sm"><span className="font-black uppercase tracking-widest">Total</span><span className="font-black text-brand">${totals.grand.toFixed(2)}</span></div>
+            </div>
+          </div>
+
+          {/* History */}
+          {history.length > 0 && (
+            <div>
+              <h4 className={`text-[10px] font-black uppercase tracking-[0.18em] mb-2 ${subtle}`}>Saved Invoices</h4>
+              <div className="space-y-1.5">
+                {history.map(inv => (
+                  <div key={inv.id} className={`flex items-center justify-between gap-2 p-2.5 rounded-xl border ${isDarkMode ? 'border-white/10' : 'border-slate-200'}`}>
+                    <div className="flex items-center gap-2 min-w-0">
+                      <FileText size={14} className="text-brand shrink-0" />
+                      <div className="min-w-0">
+                        <p className="text-[11px] font-bold truncate">{inv.invoiceNumber}</p>
+                        <p className={`text-[9px] font-semibold ${subtle}`}>{inv.date ?? ''} · ${inv.grandTotal.toFixed(2)}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <button onClick={() => downloadSaved(inv)} className="p-1.5 rounded-lg bg-brand/10 text-brand hover:bg-brand/20" aria-label="Download"><Download size={13} /></button>
+                      <button onClick={() => deleteSaved(inv)} className="p-1.5 rounded-lg text-rose-500 hover:bg-rose-500/10" aria-label="Delete"><Trash2 size={13} /></button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        <div className="px-6 py-4 border-t border-black/5 flex items-center justify-end gap-2 bg-black/5">
+          <button onClick={onClose} className={`px-4 py-2.5 rounded-xl border text-[10px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>Close</button>
+          <button onClick={handleDownload} className={`flex items-center gap-1.5 px-4 py-2.5 rounded-xl border text-[10px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>
+            <Download size={13} /> Download PDF
+          </button>
+          <button onClick={handleSave} disabled={saving} className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl bg-brand text-[#0f172a] text-[10px] font-black uppercase tracking-widest disabled:opacity-50">
+            <Save size={13} /> {saving ? 'Saving…' : 'Save Invoice'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default JobInvoiceModal;

--- a/components/scheduling/Scheduler.tsx
+++ b/components/scheduling/Scheduler.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useReducer, useRef, useCallback, useEffect } from 'react';
-import { Plus, X, ChevronLeft, ChevronRight, Clock, Calendar, Pencil, Trash2, Briefcase, Users, Wrench, GripHorizontal, RotateCcw, Search, Upload, MoreHorizontal, MapPin } from 'lucide-react';
+import { Plus, X, ChevronLeft, ChevronRight, Clock, Calendar, Pencil, Trash2, Users, GripHorizontal, RotateCcw, Search, Upload, MoreHorizontal, MapPin } from 'lucide-react';
 import { supabase } from '../../lib/supabaseClient.ts';
-import { scheduleService } from '../../services/scheduleService.ts';
 import ScheduleImportModal, { type ScheduleImportRow } from './ScheduleImportModal.tsx';
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -12,12 +11,6 @@ export interface SchedulerEmployee {
   id: number;
   name: string;
   role?: string;
-}
-
-export interface SchedulerEquipment {
-  id: string;
-  name: string;
-  hourly_rate?: number;
 }
 
 export interface Crew {
@@ -41,7 +34,6 @@ export interface ScheduleBlock {
   durationDays: number;
   type: 'job' | 'delay';
   extended: boolean;
-  equipmentIds?: string[];  // IDs of equipment assigned to be on site
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -82,14 +74,6 @@ export const MOCK_JOBS: JobOption[] = [
   { jobNumber: 'J-1003', location: '789 Pine Rd, Capital City', estimatedDays: 7 },
   { jobNumber: 'J-1004', location: '321 Elm St, Shelbyville',   estimatedDays: 4 },
   { jobNumber: 'J-1005', location: '654 Maple Dr, Springfield', estimatedDays: 6 },
-];
-
-export const MOCK_EQUIPMENT: SchedulerEquipment[] = [
-  { id: 'mock-1', name: 'Excavator',      hourly_rate: 150 },
-  { id: 'mock-2', name: 'Dump Truck',     hourly_rate: 80  },
-  { id: 'mock-3', name: 'Skid Steer',     hourly_rate: 70  },
-  { id: 'mock-4', name: 'Concrete Mixer', hourly_rate: 45  },
-  { id: 'mock-5', name: 'Compactor',      hourly_rate: 35  },
 ];
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -274,8 +258,6 @@ type BaseAction =
   | { type: 'ADD_BLOCK_PUSH';     block: ScheduleBlock; shiftDays: number }
   | { type: 'DELETE_BLOCK';       id: string }
   | { type: 'REPLACE_ALL';        blocks: ScheduleBlock[] }
-  | { type: 'ASSIGN_EQUIPMENT';   blockId: string; equipmentId: string }
-  | { type: 'UNASSIGN_EQUIPMENT'; blockId: string; equipmentId: string }
   | { type: 'SHIFT_CREW';         crewId: string; fromDate: string; days: number };
 
 // `skipWeekends` is injected at dispatch time so the pure reducer can do
@@ -408,20 +390,6 @@ function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
     case 'REPLACE_ALL':
       return action.blocks;
 
-    case 'ASSIGN_EQUIPMENT':
-      return state.map(b =>
-        b.id === action.blockId
-          ? { ...b, equipmentIds: [...new Set([...(b.equipmentIds ?? []), action.equipmentId])] }
-          : b,
-      );
-
-    case 'UNASSIGN_EQUIPMENT':
-      return state.map(b =>
-        b.id === action.blockId
-          ? { ...b, equipmentIds: (b.equipmentIds ?? []).filter(id => id !== action.equipmentId) }
-          : b,
-      );
-
     case 'SHIFT_CREW':
       return state.map(b =>
         b.crewId === action.crewId && b.startDate >= action.fromDate
@@ -433,130 +401,6 @@ function reducer(state: ScheduleBlock[], action: Action): ScheduleBlock[] {
       return state;
   }
 }
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK EQUIPMENT MODAL  (view & manage equipment assigned to a specific block)
-// ═══════════════════════════════════════════════════════════════════════════════
-
-const BlockEquipmentModal = ({
-  block,
-  job,
-  crew,
-  equipmentList,
-  onAssign,
-  onUnassign,
-  onClose,
-}: {
-  block: ScheduleBlock;
-  job: JobOption | undefined;
-  crew: Crew | undefined;
-  equipmentList: SchedulerEquipment[];
-  onAssign: (equipmentId: string) => void;
-  onUnassign: (equipmentId: string) => void;
-  onClose: () => void;
-}) => {
-  const assigned  = block.equipmentIds ?? [];
-  const available = equipmentList.filter(eq => !assigned.includes(eq.id));
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="equip-modal-title"
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
-    >
-      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden flex flex-col" style={{ maxHeight: '80vh' }}>
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100">
-          <div>
-            <h3 id="equip-modal-title" className="text-base font-bold text-slate-900">Equipment on Site</h3>
-            <p className="text-xs text-slate-500 mt-0.5">
-              {block.jobNumber}{job ? ` · ${job.location}` : ''}{crew ? ` · ${crew.name}` : ''}
-            </p>
-          </div>
-          <button
-            onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        </div>
-
-        <div className="overflow-y-auto flex-1 p-4 space-y-4">
-          {/* Assigned equipment */}
-          <div>
-            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
-              Assigned ({assigned.length})
-            </p>
-            {assigned.length === 0 ? (
-              <p className="text-sm text-slate-400 italic">No equipment assigned yet — drag from the tray or add below.</p>
-            ) : (
-              <ul className="space-y-1.5">
-                {assigned.map(id => {
-                  const eq = equipmentList.find(e => e.id === id);
-                  return (
-                    <li key={id} className="flex items-center justify-between rounded-lg bg-brand/10 px-3 py-2">
-                      <div className="flex items-center gap-2">
-                        <Wrench className="w-3.5 h-3.5 text-brand shrink-0" />
-                        <span className="text-sm font-medium text-slate-800">{eq?.name ?? `Equipment #${id}`}</span>
-                        {eq?.hourly_rate !== undefined && (
-                          <span className="text-xs text-slate-400">${eq.hourly_rate}/hr</span>
-                        )}
-                      </div>
-                      <button
-                        onClick={() => onUnassign(id)}
-                        className="w-6 h-6 flex items-center justify-center rounded-full text-red-400 hover:bg-red-50 hover:text-red-600 transition-colors"
-                        title="Remove"
-                        aria-label={`Remove ${eq?.name ?? `equipment ${id}`}`}
-                      >
-                        <X className="w-3.5 h-3.5" />
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </div>
-
-          {/* Add more equipment */}
-          {available.length > 0 && (
-            <div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Add Equipment</p>
-              <ul className="space-y-1.5">
-                {available.map(eq => (
-                  <li key={eq.id}>
-                    <button
-                      onClick={() => onAssign(eq.id)}
-                      className="w-full flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2 hover:border-brand/25 hover:bg-brand/10 transition-colors"
-                    >
-                      <div className="flex items-center gap-2">
-                        <Wrench className="w-3.5 h-3.5 text-slate-400 shrink-0" />
-                        <span className="text-sm text-slate-700">{eq.name}</span>
-                        {eq.hourly_rate !== undefined && (
-                          <span className="text-xs text-slate-400">${eq.hourly_rate}/hr</span>
-                        )}
-                      </div>
-                      <Plus className="w-4 h-4 text-brand" />
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-
-        <div className="px-5 py-4 border-t border-slate-100">
-          <button
-            onClick={onClose}
-            className="w-full py-2.5 rounded-xl bg-slate-900 text-white text-sm font-semibold hover:bg-slate-700 transition-colors"
-          >
-            Done
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // TOOLTIP
@@ -1058,142 +902,6 @@ const ManageCrewsModal = ({
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// MANAGE JOBS MODAL  (admin only)
-// ═══════════════════════════════════════════════════════════════════════════════
-
-const ManageJobsModal = ({
-  jobs,
-  onUpdate,
-  onClose,
-}: {
-  jobs: JobOption[];
-  onUpdate: (jobs: JobOption[]) => void;
-  onClose: () => void;
-}) => {
-  const blank: JobOption = { jobNumber: '', location: '', estimatedDays: 1 };
-  const [local, setLocal]           = useState<JobOption[]>(jobs);
-  const [editingNum, setEditNum]    = useState<string | null>(null);
-  const [editJob, setEditJob]       = useState<JobOption>(blank);
-  const [newJob, setNewJob]         = useState<JobOption>(blank);
-  const [dupError, setDupError]     = useState('');
-
-  const startEdit = (j: JobOption) => { setEditNum(j.jobNumber); setEditJob({ ...j }); };
-  const cancelEdit = () => setEditNum(null);
-  const saveEdit = () => {
-    if (!editingNum || !editJob.jobNumber.trim()) return;
-    const newNum = editJob.jobNumber.trim();
-    // Guard against renaming to a job number already used by a different entry
-    if (newNum !== editingNum && local.some(j => j.jobNumber === newNum)) {
-      setDupError('Job number already exists');
-      return;
-    }
-    setDupError('');
-    setLocal(prev => prev.map(j => j.jobNumber === editingNum ? { ...editJob, jobNumber: newNum, location: editJob.location.trim() } : j));
-    setEditNum(null);
-  };
-  const deleteJob = (num: string) => setLocal(prev => prev.filter(j => j.jobNumber !== num));
-  const addJob = () => {
-    if (!newJob.jobNumber.trim() || !newJob.location.trim()) return;
-    if (local.some(j => j.jobNumber === newJob.jobNumber.trim())) { setDupError('Job number already exists'); return; }
-    setDupError('');
-    setLocal(prev => [...prev, { jobNumber: newJob.jobNumber.trim(), location: newJob.location.trim(), estimatedDays: 1 }]);
-    setNewJob(blank);
-  };
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col" style={{ maxHeight: '85vh' }}>
-        <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-slate-100 shrink-0">
-          <h3 className="text-lg font-bold text-slate-900 flex items-center gap-2">
-            <Briefcase className="w-5 h-5 text-brand" />
-            Manage Jobs
-          </h3>
-          <button onClick={onClose} className="text-slate-400 hover:text-slate-600 transition-colors"><X className="w-5 h-5" /></button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-2">
-          {local.length === 0 && (
-            <p className="text-center text-slate-400 text-sm py-6 italic">No jobs yet. Add one below.</p>
-          )}
-          {local.map(j => {
-            if (editingNum === j.jobNumber) {
-              return (
-                <div key={j.jobNumber} className="p-3 bg-brand/10 rounded-xl border border-brand/20 space-y-2">
-                  <div className="flex gap-2">
-                    <input
-                      autoFocus
-                      value={editJob.jobNumber}
-                      onChange={e => setEditJob(p => ({ ...p, jobNumber: e.target.value }))}
-                      className="w-28 border border-slate-200 rounded-lg px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand/10"
-                      placeholder="Job #"
-                    />
-                    <input
-                      value={editJob.location}
-                      onChange={e => setEditJob(p => ({ ...p, location: e.target.value }))}
-                      className="flex-1 border border-slate-200 rounded-lg px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand/10 min-w-0"
-                      placeholder="Location"
-                    />
-                  </div>
-                  <div className="flex gap-2">
-                    <button onClick={saveEdit} className="flex-1 py-1.5 bg-brand text-white text-xs font-semibold rounded-lg hover:opacity-90 transition-colors">Save</button>
-                    <button onClick={cancelEdit} className="px-4 py-1.5 border border-slate-200 text-slate-600 text-xs rounded-lg hover:bg-slate-50 transition-colors">Cancel</button>
-                  </div>
-                </div>
-              );
-            }
-            return (
-              <div key={j.jobNumber} className="flex items-center gap-2 p-3 bg-slate-50 rounded-xl border border-slate-200">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-[10px] font-bold text-brand bg-brand/10 px-2 py-0.5 rounded border border-brand/20">{j.jobNumber}</span>
-                  </div>
-                  <div className="text-sm text-slate-700 truncate mt-0.5">{j.location}</div>
-                </div>
-                <button onClick={() => startEdit(j)} title="Edit" className="p-1.5 text-slate-400 hover:text-brand transition-colors"><Pencil className="w-3.5 h-3.5" /></button>
-                <button onClick={() => deleteJob(j.jobNumber)} title="Delete" className="p-1.5 text-slate-400 hover:text-red-500 transition-colors"><Trash2 className="w-3.5 h-3.5" /></button>
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="px-6 pb-5 pt-3 border-t border-slate-100 space-y-3 shrink-0">
-          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Add New Job</p>
-          {dupError && <p className="text-xs text-red-500">{dupError}</p>}
-          <div className="flex gap-2">
-            <input
-              value={newJob.jobNumber}
-              onChange={e => { setDupError(''); setNewJob(p => ({ ...p, jobNumber: e.target.value })); }}
-              className="w-28 border border-slate-200 rounded-lg px-2.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/10"
-              placeholder="Job #"
-            />
-            <input
-              value={newJob.location}
-              onChange={e => setNewJob(p => ({ ...p, location: e.target.value }))}
-              onKeyDown={e => e.key === 'Enter' && addJob()}
-              className="flex-1 border border-slate-200 rounded-lg px-2.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/10 min-w-0"
-              placeholder="Location"
-            />
-            <button
-              onClick={addJob}
-              disabled={!newJob.jobNumber.trim() || !newJob.location.trim()}
-              className="px-3 py-2 bg-brand hover:opacity-90 text-white rounded-lg transition-colors disabled:opacity-40"
-            >
-              <Plus className="w-4 h-4" />
-            </button>
-          </div>
-          <button
-            onClick={() => { onUpdate(local); onClose(); }}
-            className="w-full py-2.5 bg-slate-900 hover:bg-slate-800 text-white rounded-xl text-sm font-semibold transition-colors"
-          >
-            Save Changes
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ═══════════════════════════════════════════════════════════════════════════════
 // ADD BLOCK MODAL
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1530,12 +1238,6 @@ interface JobBlockProps {
   isAdmin?: boolean;
   editMode?: boolean;
   onDelete?: () => void;
-  equipmentCount?: number;
-  isEquipDragOver?: boolean;
-  onEquipmentDrop?: (equipmentId: string) => void;
-  onEquipmentDragOver?: () => void;
-  onEquipmentDragLeave?: () => void;
-  onEquipmentClick?: () => void;
   onDragStart: (e: React.DragEvent) => void;
   onDragEnd: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
@@ -1552,7 +1254,6 @@ interface JobBlockProps {
 const JobBlock = ({
   block, job, left, width, color, isDragging, isSettled,
   isAdmin, editMode, onDelete,
-  equipmentCount, isEquipDragOver, onEquipmentDrop, onEquipmentDragOver, onEquipmentDragLeave, onEquipmentClick,
   onDragStart, onDragEnd, onContextMenu,
   onMouseEnter, onMouseMove, onMouseLeave, onTouchStart,
   onResizeStart, onResizeTouchStart,
@@ -1597,28 +1298,6 @@ const JobBlock = ({
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}
       onTouchStart={editMode ? onTouchStart : undefined}
-      onDragOver={e => {
-        if (e.dataTransfer.types.includes('application/x-equip-id')) {
-          e.preventDefault();
-          e.stopPropagation();
-          e.dataTransfer.dropEffect = 'copy';
-          onEquipmentDragOver?.();
-        }
-      }}
-      onDragLeave={e => {
-        if (e.dataTransfer.types.includes('application/x-equip-id')) {
-          onEquipmentDragLeave?.();
-        }
-      }}
-      onDrop={e => {
-        const equipId = e.dataTransfer.getData('application/x-equip-id');
-        if (equipId) {
-          e.stopPropagation();
-          e.preventDefault();
-          onEquipmentDrop?.(equipId);
-          onEquipmentDragLeave?.();
-        }
-      }}
       style={{
         position: 'absolute',
         left,
@@ -1656,11 +1335,9 @@ const JobBlock = ({
               justifyContent: 'center',
               padding: '0 9px 0 16px',
               boxSizing: 'border-box',
-              boxShadow: isEquipDragOver
-                ? '0 0 0 2px #fff, 0 0 0 4px var(--brand-primary, #3b82f6)'
-                : isDragging
-                  ? '0 10px 24px rgba(15,23,42,0.30)'
-                  : `inset 0 1px 0 rgba(255,255,255,0.28), 0 1px 1px rgba(15,23,42,0.10), 0 4px 10px ${isDelay ? 'rgba(15,23,42,0.12)' : `color-mix(in srgb, ${color} 35%, transparent)`}`,
+              boxShadow: isDragging
+                ? '0 10px 24px rgba(15,23,42,0.30)'
+                : `inset 0 1px 0 rgba(255,255,255,0.28), 0 1px 1px rgba(15,23,42,0.10), 0 4px 10px ${isDelay ? 'rgba(15,23,42,0.12)' : `color-mix(in srgb, ${color} 35%, transparent)`}`,
             }}
           >
             {/* Left identity tab — a bold light rail anchoring the card to its crew */}
@@ -1809,35 +1486,9 @@ const JobBlock = ({
                 <span style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>{job.location}</span>
               </div>
             )}
-            {/* Meta row: equipment badge + duration pill share one line so they
-                never overlap, regardless of how narrow the bar gets. */}
+            {/* Duration pill. */}
             {seg.width > 36 && (
               <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4, minWidth: 0 }}>
-                {!isDelay && (equipmentCount ?? 0) > 0 && onEquipmentClick && isFirst && (
-                  <button
-                    onClick={e => { e.stopPropagation(); e.preventDefault(); onEquipmentClick(); }}
-                    onMouseDown={e => e.stopPropagation()}
-                    title={`${equipmentCount} piece${equipmentCount !== 1 ? 's' : ''} of equipment on site — click to manage`}
-                    aria-label={`${equipmentCount} equipment assigned — click to manage`}
-                    style={{
-                      display: 'inline-flex', alignItems: 'center', gap: 2.5,
-                      background: 'rgba(15,23,42,0.32)',
-                      border: '1px solid rgba(255,255,255,0.18)',
-                      borderRadius: 999,
-                      padding: '1px 6px 1px 5px',
-                      cursor: 'pointer',
-                      zIndex: 10,
-                      color: '#fff',
-                      fontSize: 9,
-                      fontWeight: 700,
-                      lineHeight: 1.4,
-                      flexShrink: 0,
-                    }}
-                  >
-                    <Wrench style={{ width: 8.5, height: 8.5, flexShrink: 0 }} aria-hidden="true" />
-                    {equipmentCount}
-                  </button>
-                )}
                 <span style={{ display: 'inline-flex', alignItems: 'center', padding: '1px 6px', borderRadius: 999, background: 'rgba(255,255,255,0.22)', color: 'rgba(255,255,255,0.97)', fontSize: 9, fontWeight: 700, lineHeight: 1.3, flexShrink: 0 }}>
                   {block.durationDays}d
                 </span>
@@ -1875,7 +1526,6 @@ export default function Scheduler({
   const [crewsState, setCrewsState] = useState<Crew[]>(initialCrews);
   const [jobsState,  setJobsState]  = useState<JobOption[]>(initialJobs);
   const [employeeList,  setEmployeeList]  = useState<SchedulerEmployee[]>([]);
-  const [equipmentList, setEquipmentList] = useState<SchedulerEquipment[]>([]);
   const [blocks, dispatch] = useReducer(reducer, initialBlocks);
   const [view, setView]    = useState<'day' | 'week' | 'month'>('week');
   const [viewOffset, setViewOffset] = useState(0); // days from default start
@@ -1903,11 +1553,9 @@ export default function Scheduler({
 
     Promise.all([
       supabase.from('schedule_crews').select('id, name, member_ids').eq('company_id', companyId).order('created_at'),
-      supabase.from('schedule_job_options').select('job_number, location, estimated_days').eq('company_id', companyId).order('created_at'),
-      supabase.from('schedule_blocks').select('id, crew_id, job_number, start_date, duration_days, type, extended, equipment_ids').eq('company_id', companyId),
-    ]).then(([crewsRes, jobsRes, blocksRes]) => {
+      supabase.from('schedule_blocks').select('id, crew_id, job_number, start_date, duration_days, type, extended').eq('company_id', companyId),
+    ]).then(([crewsRes, blocksRes]) => {
       if (crewsRes.error)  console.error('[Scheduler] Failed to load crews:',  crewsRes.error.message);
-      if (jobsRes.error)   console.error('[Scheduler] Failed to load jobs:',   jobsRes.error.message);
       if (blocksRes.error) console.error('[Scheduler] Failed to load blocks:', blocksRes.error.message);
 
       // Only replace mock data when Supabase returns actual rows
@@ -1919,20 +1567,6 @@ export default function Scheduler({
           memberIds: r.member_ids ?? [],
         })));
       }
-      {
-        // Hybrid job source: union the board's own saved job options (DB) with
-        // the jobs passed in from DigTrackPro (initialJobs), de-duped by
-        // jobNumber with the saved DB row winning. This lets the board default
-        // from existing DigTrackPro jobs while still allowing ad-hoc entries.
-        const dbJobs = (jobsRes.data ?? []).map(r => ({
-          jobNumber:     r.job_number,
-          location:      r.location,
-          estimatedDays: r.estimated_days,
-        }));
-        const seen = new Set(dbJobs.map(j => j.jobNumber));
-        const merged = [...dbJobs, ...initialJobs.filter(j => !seen.has(j.jobNumber))];
-        if (merged.length > 0) setJobsState(merged);
-      }
       if (blocksRes.data && blocksRes.data.length > 0) {
         const loaded: ScheduleBlock[] = blocksRes.data.map(r => ({
           id:            r.id,
@@ -1942,7 +1576,6 @@ export default function Scheduler({
           durationDays:  r.duration_days,
           type:          r.type as 'job' | 'delay',
           extended:      r.extended,
-          equipmentIds:  r.equipment_ids ?? [],
         }));
         dispatch({ type: 'REPLACE_ALL', blocks: loaded });
         dbBlockIdsRef.current = new Set(loaded.map(b => b.id));
@@ -1979,22 +1612,16 @@ export default function Scheduler({
     return () => clearTimeout(t);
   }, [crewsState, companyId]);
 
-  // ── Persist job options to Supabase whenever they change (debounced 600 ms)
+  // Jobs on the board come from DigTrackPro's dig-ticket jobs (passed in as
+  // initialJobs). Keep local state in sync as that list loads/changes, while
+  // preserving any ad-hoc jobs added via CSV import (unioned by jobNumber).
   useEffect(() => {
-    if (!companyId || !dbLoadedRef.current) return;
-    const rows = jobsState.map(j => ({
-      company_id:     companyId,
-      job_number:     j.jobNumber,
-      location:       j.location,
-      estimated_days: j.estimatedDays,
-    }));
-    if (rows.length === 0) return;
-    const t = setTimeout(() => {
-      supabase.from('schedule_job_options').upsert(rows, { onConflict: 'company_id,job_number' })
-        .then(({ error }) => { if (error) console.error('[Scheduler] Failed to save job options:', error.message); });
-    }, 600);
-    return () => clearTimeout(t);
-  }, [jobsState, companyId]);
+    setJobsState(prev => {
+      const seen = new Set(initialJobs.map(j => j.jobNumber));
+      const extras = prev.filter(j => !seen.has(j.jobNumber));
+      return [...initialJobs, ...extras];
+    });
+  }, [initialJobs]);
 
   // ── Persist blocks to Supabase whenever they change (debounced 600 ms) ─────
   useEffect(() => {
@@ -2012,7 +1639,6 @@ export default function Scheduler({
       duration_days: b.durationDays,
       type:          b.type,
       extended:      b.extended,
-      equipment_ids: b.equipmentIds ?? [],
     }));
 
     const currentIds = new Set(blocksToSave.map(b => b.id));
@@ -2079,14 +1705,6 @@ export default function Scheduler({
         if (error) console.error('[Scheduler] Failed to load employees:', error.message);
         else if (data) setEmployeeList(data as SchedulerEmployee[]);
       });
-  }, [companyId]);
-
-  // Fetch equipment via scheduleService so the board shares the same list as ResourcesManager
-  useEffect(() => {
-    if (!companyId) return;
-    scheduleService.getEquipment()
-      .then(data => setEquipmentList(data.map(e => ({ id: e.id, name: e.name, hourly_rate: e.hourlyRate }))))
-      .catch(err => console.error('[Scheduler] Failed to load equipment:', err));
   }, [companyId]);
 
   // Per-view geometry. Day view uses wide, roomy columns over a short horizon so
@@ -2172,7 +1790,6 @@ export default function Scheduler({
   const [showAddModal,      setShowAddModal]      = useState(false);
   const [showImportModal,   setShowImportModal]   = useState(false);
   const [showManageCrews,   setShowManageCrews]   = useState(false);
-  const [showManageJobs,    setShowManageJobs]    = useState(false);
 
   // Toolbar popover: the mobile overflow menu.
   const [showOverflow,      setShowOverflow]      = useState(false);
@@ -2189,10 +1806,6 @@ export default function Scheduler({
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, [showOverflow]);
-
-  // Block-equipment modal
-  const [equipModalBlockId, setEquipModalBlockId] = useState<string | null>(null);
-  const [equipDragOverBlockId, setEquipDragOverBlockId] = useState<string | null>(null);
 
   // Pending overlap-conflict confirmation (drag-move)
   const [pendingMove, setPendingMove] = useState<{
@@ -2360,13 +1973,6 @@ export default function Scheduler({
       flagSettled(blockId);
     }
   }, [dayWidth, viewStart, dragOffsetDays, dispatchWithHistory, flagSettled]);
-
-  // ── Equipment assignment (drop onto a block / manage via the block modal) ────
-
-  const handleEquipDropOnBlock = useCallback((blockId: string, equipmentId: string) => {
-    dispatchWithHistory({ type: 'ASSIGN_EQUIPMENT', blockId, equipmentId });
-    setEquipDragOverBlockId(null);
-  }, [dispatchWithHistory]);
 
   // ── Touch-drag handlers (mobile edit mode) ───────────────────────────────────
 
@@ -2849,15 +2455,6 @@ export default function Scheduler({
               <Users className="w-3.5 h-3.5" /><span className="hidden lg:inline"> Crews</span>
             </button>
           )}
-          {isAdmin && (
-            <button
-              onClick={() => setShowManageJobs(true)}
-              title="Manage jobs"
-              className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-slate-200 text-xs font-semibold rounded-lg transition-colors border border-white/10"
-            >
-              <Briefcase className="w-3.5 h-3.5" /><span className="hidden lg:inline"> Jobs</span>
-            </button>
-          )}
           <button
             onClick={() => setShowImportModal(true)}
             aria-label="Import schedule from spreadsheet"
@@ -2893,14 +2490,6 @@ export default function Scheduler({
                     className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-brand/10 hover:text-brand transition-colors"
                   >
                     <Users className="w-4 h-4 shrink-0" /> Manage Crews
-                  </button>
-                )}
-                {isAdmin && (
-                  <button
-                    onClick={() => { setShowManageJobs(true); setShowOverflow(false); }}
-                    className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-brand/10 hover:text-brand transition-colors"
-                  >
-                    <Briefcase className="w-4 h-4 shrink-0" /> Manage Jobs
                   </button>
                 )}
                 <button
@@ -3342,7 +2931,6 @@ export default function Scheduler({
                     }));
                     if (left + width < 0 || left > totalGridWidth) return null;
                     const job = jobsState.find(j => j.jobNumber === block.jobNumber);
-                    const eqCount = (block.equipmentIds ?? []).length;
                     return (
                       <JobBlock
                         key={block.id}
@@ -3358,12 +2946,6 @@ export default function Scheduler({
                         isAdmin={isAdmin}
                         editMode={editMode}
                         onDelete={() => dispatchWithHistory({ type: 'DELETE_BLOCK', id: block.id })}
-                        equipmentCount={eqCount}
-                        isEquipDragOver={equipDragOverBlockId === block.id}
-                        onEquipmentDrop={equipId => handleEquipDropOnBlock(block.id, equipId)}
-                        onEquipmentDragOver={() => setEquipDragOverBlockId(block.id)}
-                        onEquipmentDragLeave={() => setEquipDragOverBlockId(null)}
-                        onEquipmentClick={() => setEquipModalBlockId(block.id)}
                         onDragStart={e => handleDragStart(e, block)}
                         onDragEnd={handleDragEnd}
                         onTouchStart={e => handleBlockTouchStart(e, block, color)}
@@ -3638,31 +3220,6 @@ export default function Scheduler({
         />
       )}
 
-      {showManageJobs && (
-        <ManageJobsModal
-          jobs={jobsState}
-          onUpdate={setJobsState}
-          onClose={() => setShowManageJobs(false)}
-        />
-      )}
-
-      {equipModalBlockId && (() => {
-        const eqBlock = blocks.find(b => b.id === equipModalBlockId);
-        if (!eqBlock) return null;
-        const eqJob  = jobsState.find(j => j.jobNumber === eqBlock.jobNumber);
-        const eqCrew = crewsState.find(c => c.id === eqBlock.crewId);
-        return (
-          <BlockEquipmentModal
-            block={eqBlock}
-            job={eqJob}
-            crew={eqCrew}
-            equipmentList={equipmentList}
-            onAssign={equipmentId => dispatchWithHistory({ type: 'ASSIGN_EQUIPMENT', blockId: equipModalBlockId, equipmentId })}
-            onUnassign={equipmentId => dispatchWithHistory({ type: 'UNASSIGN_EQUIPMENT', blockId: equipModalBlockId, equipmentId })}
-            onClose={() => setEquipModalBlockId(null)}
-          />
-        );
-      })()}
     </div>
   );
 }

--- a/components/scheduling/invoicePdf.ts
+++ b/components/scheduling/invoicePdf.ts
@@ -27,7 +27,7 @@ export interface InvoicePdfArgs {
   totals: CostTotals;
   invoiceNumber: string;
   invoiceDate: Date;
-  dueDate: Date;
+  dueDate?: Date;
   branding: InvoiceSettings;
   employees: Employee[];
   equipment: Equipment[];
@@ -80,7 +80,7 @@ export function generateInvoicePdf(args: InvoicePdfArgs): void {
   text(slate300); pdf.setFont('helvetica', 'normal'); pdf.setFontSize(8);
   pdf.text(`# ${invoiceNumber}`, rightX, cardTop + 18, { align: 'right' });
   pdf.text(`Date: ${invoiceDate.toLocaleDateString('en-US')}`, rightX, cardTop + 24, { align: 'right' });
-  pdf.text(`Due:  ${dueDate.toLocaleDateString('en-US')}`, rightX, cardTop + 30, { align: 'right' });
+  if (dueDate) pdf.text(`Due:  ${dueDate.toLocaleDateString('en-US')}`, rightX, cardTop + 30, { align: 'right' });
 
   // ── Bill-to ────────────────────────────────────────────────────────────────
   let cursorY = cardTop + cardH + 8;

--- a/preview/main.tsx
+++ b/preview/main.tsx
@@ -27,15 +27,15 @@ const jobs: JobOption[] = [
   { jobNumber: 'J-2046', location: '8 Quarry Rd, Cedar Park',        estimatedDays: 2 },
 ];
 const blocks: ScheduleBlock[] = [
-  { id: 'b1', crewId: 'c1', jobNumber: 'J-2041', startDate: addDays(-3), durationDays: 5, type: 'job', extended: false, equipmentIds: ['e1', 'e2'] },
+  { id: 'b1', crewId: 'c1', jobNumber: 'J-2041', startDate: addDays(-3), durationDays: 5, type: 'job', extended: false },
   { id: 'b2', crewId: 'c1', jobNumber: 'J-2042', startDate: addDays(3),  durationDays: 3, type: 'job', extended: false },
   { id: 'b3', crewId: 'c2', jobNumber: 'J-2043', startDate: addDays(-1), durationDays: 7, type: 'job', extended: true },
-  { id: 'b4', crewId: 'c2', jobNumber: 'J-2044', startDate: addDays(8),  durationDays: 4, type: 'job', extended: false, equipmentIds: ['e3'] },
+  { id: 'b4', crewId: 'c2', jobNumber: 'J-2044', startDate: addDays(8),  durationDays: 4, type: 'job', extended: false },
   { id: 'd1', crewId: 'c3', jobNumber: 'Delay – 2 days', startDate: addDays(0), durationDays: 2, type: 'delay', extended: false },
-  { id: 'b5', crewId: 'c3', jobNumber: 'J-2045', startDate: addDays(2),  durationDays: 6, type: 'job', extended: false, equipmentIds: ['e1', 'e4', 'e2'] },
+  { id: 'b5', crewId: 'c3', jobNumber: 'J-2045', startDate: addDays(2),  durationDays: 6, type: 'job', extended: false },
   { id: 'b6', crewId: 'c4', jobNumber: 'J-2046', startDate: addDays(1),  durationDays: 2, type: 'job', extended: false },
   { id: 'b7', crewId: 'c4', jobNumber: 'J-2042', startDate: addDays(5),  durationDays: 3, type: 'job', extended: false },
-  { id: 'b8', crewId: 'c5', jobNumber: 'J-2043', startDate: addDays(-2), durationDays: 4, type: 'job', extended: false, equipmentIds: ['e5'] },
+  { id: 'b8', crewId: 'c5', jobNumber: 'J-2043', startDate: addDays(-2), durationDays: 4, type: 'job', extended: false },
   { id: 'b9', crewId: 'c5', jobNumber: 'J-2041', startDate: addDays(4),  durationDays: 5, type: 'job', extended: false },
 ];
 

--- a/services/jobInvoiceService.ts
+++ b/services/jobInvoiceService.ts
@@ -1,0 +1,65 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Job Invoice Service — Supabase CRUD for Job Hub invoicing.
+//
+// Invoices here are keyed to the dig-ticket `jobs` table (uuid id), stored in
+// `job_invoices`. This is separate from the service-job `invoices` table used by
+// the Operations module. Tenant isolation is enforced by RLS
+// (get_user_company_id()); callers still pass companyId on insert.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { supabase } from '../lib/supabaseClient.ts';
+import { JobInvoice, JobInvoiceData } from './schedulingTypes.ts';
+
+const EMPTY_DATA: JobInvoiceData = { customerName: '', address: '', employees: [], equipment: [], materials: [] };
+
+const mapInvoice = (row: Record<string, unknown>): JobInvoice => ({
+  id:             Number(row.id ?? 0),
+  companyId:      String(row.company_id ?? ''),
+  jobId:          String(row.job_id ?? ''),
+  invoiceNumber:  String(row.invoice_number ?? ''),
+  date:           row.date != null ? String(row.date) : null,
+  dueDate:        row.due_date != null ? String(row.due_date) : null,
+  laborTotal:     Number(row.labor_total ?? 0),
+  equipmentTotal: Number(row.equipment_total ?? 0),
+  materialTotal:  Number(row.material_total ?? 0),
+  grandTotal:     Number(row.grand_total ?? 0),
+  data:           { ...EMPTY_DATA, ...((row.data as Partial<JobInvoiceData>) ?? {}) },
+  createdAt:      row.created_at ? new Date(row.created_at as string).getTime() : Date.now(),
+});
+
+export const jobInvoiceService = {
+  async listByJob(jobId: string): Promise<JobInvoice[]> {
+    const { data, error } = await supabase
+      .from('job_invoices')
+      .select('*')
+      .eq('job_id', jobId)
+      .order('created_at', { ascending: false });
+    if (error) throw error;
+    return (data ?? []).map(r => mapInvoice(r as Record<string, unknown>));
+  },
+
+  async create(companyId: string, inv: Omit<JobInvoice, 'id' | 'companyId' | 'createdAt'>): Promise<JobInvoice> {
+    const { data, error } = await supabase
+      .from('job_invoices')
+      .insert({
+        company_id:      companyId,
+        job_id:          inv.jobId,
+        invoice_number:  inv.invoiceNumber,
+        date:            inv.date,
+        due_date:        inv.dueDate,
+        labor_total:     inv.laborTotal,
+        equipment_total: inv.equipmentTotal,
+        material_total:  inv.materialTotal,
+        grand_total:     inv.grandTotal,
+        data:            inv.data,
+      })
+      .select().single();
+    if (error) throw error;
+    return mapInvoice(data as Record<string, unknown>);
+  },
+
+  async delete(id: number): Promise<void> {
+    const { error } = await supabase.from('job_invoices').delete().eq('id', id);
+    if (error) throw error;
+  },
+};

--- a/services/schedulingTypes.ts
+++ b/services/schedulingTypes.ts
@@ -113,6 +113,31 @@ export interface Invoice {
   data: Record<string, unknown>;
 }
 
+// ── Job Hub invoicing (keyed to the dig-ticket jobs table, uuid id) ─────────
+
+// Line-item payload stored on job_invoices.data. Reuses the WorkLogEntry shape
+// (employees/equipment/materials) so it feeds straight into generateInvoicePdf,
+// plus the captured bill-to fields.
+export interface JobInvoiceData extends WorkLogEntry {
+  customerName: string;
+  address: string;
+}
+
+export interface JobInvoice {
+  id: number;
+  companyId: string;
+  jobId: string;            // dig-ticket jobs.id (uuid)
+  invoiceNumber: string;
+  date: string | null;
+  dueDate: string | null;
+  laborTotal: number;
+  equipmentTotal: number;
+  materialTotal: number;
+  grandTotal: number;
+  data: JobInvoiceData;
+  createdAt: number;
+}
+
 // ── Scheduler board entities (UUID-string ids) ──────────────────────────────
 
 export interface Crew {
@@ -120,14 +145,6 @@ export interface Crew {
   companyId: string;
   name: string;
   memberIds: number[];
-}
-
-export interface ScheduleJobOption {
-  id: number;
-  companyId: string;
-  jobNumber: string;
-  location: string;
-  estimatedDays: number;
 }
 
 export interface ScheduleBlock {
@@ -139,5 +156,4 @@ export interface ScheduleBlock {
   durationDays: number;
   type: 'job' | 'delay';
   extended: boolean;
-  equipmentIds: string[];
 }

--- a/supabase/migrations/20260630000000_add_job_invoices.sql
+++ b/supabase/migrations/20260630000000_add_job_invoices.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- Migration: Job Hub invoicing + retire scheduler equipment/job-options
+--
+-- Part A — invoicing moves from the scheduling board into the Job Hub, so the
+-- equipment-assignment and ad-hoc "job options" features that were bolted onto
+-- the scheduling board are abandoned. Drop their now-unused storage.
+--
+-- Part B — add `job_invoices`, keyed to the dig-ticket `jobs` table (uuid id).
+-- This is intentionally a separate table from the service-job `invoices` table
+-- (which is keyed to `service_jobs`, a bigint id) created in
+-- 20260611000000_add_scheduling.sql. RLS reuses get_user_company_id().
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Part A. Retire scheduler equipment + job-options storage
+-- ---------------------------------------------------------------------------
+ALTER TABLE IF EXISTS schedule_blocks DROP COLUMN IF EXISTS equipment_ids;
+DROP TABLE IF EXISTS schedule_job_options;
+
+-- ---------------------------------------------------------------------------
+-- Part B. JOB INVOICES (keyed to dig-ticket jobs.id, uuid)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS job_invoices (
+  id              BIGSERIAL PRIMARY KEY,
+  company_id      UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  job_id          UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  invoice_number  TEXT NOT NULL DEFAULT '',
+  date            TIMESTAMPTZ,
+  due_date        TIMESTAMPTZ,
+  labor_total     NUMERIC(12,2) NOT NULL DEFAULT 0,
+  equipment_total NUMERIC(12,2) NOT NULL DEFAULT 0,
+  material_total  NUMERIC(12,2) NOT NULL DEFAULT 0,
+  grand_total     NUMERIC(12,2) NOT NULL DEFAULT 0,
+  -- { customerName, address, employees[], equipment[], materials[] }
+  data            JSONB NOT NULL DEFAULT '{}',
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+ALTER TABLE job_invoices ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "job_invoices_select" ON job_invoices;
+CREATE POLICY "job_invoices_select" ON job_invoices FOR SELECT USING (company_id = get_user_company_id());
+DROP POLICY IF EXISTS "job_invoices_insert" ON job_invoices;
+CREATE POLICY "job_invoices_insert" ON job_invoices FOR INSERT WITH CHECK (company_id = get_user_company_id());
+DROP POLICY IF EXISTS "job_invoices_update" ON job_invoices;
+CREATE POLICY "job_invoices_update" ON job_invoices FOR UPDATE USING (company_id = get_user_company_id());
+DROP POLICY IF EXISTS "job_invoices_delete" ON job_invoices;
+CREATE POLICY "job_invoices_delete" ON job_invoices FOR DELETE USING (company_id = get_user_company_id());
+CREATE INDEX IF NOT EXISTS job_invoices_company_idx ON job_invoices (company_id);
+CREATE INDEX IF NOT EXISTS job_invoices_job_idx ON job_invoices (job_id);


### PR DESCRIPTION
## Summary

Moves invoicing out of the scheduling board and into the **Job Hub**, where invoices are created per dig-ticket job and pre-filled from the data the hub already aggregates (logged crew hours + rates, equipment on site, materials).

## Part A — Strip equipment + job-options from the scheduling board
`components/scheduling/Scheduler.tsx`
- Removed equipment assignment to blocks: `BlockEquipmentModal`, the drag/drop-onto-block, the wrench badge, equipment loading (`scheduleService.getEquipment`) and persistence (`equipment_ids`).
- Removed the ad-hoc **Manage Jobs** list and `schedule_job_options` load/upsert. Board jobs now come solely from DigTrackPro's dig-ticket jobs; the CSV-import path is preserved.
- The board itself (crews scheduled over time) is unchanged.

## Part B — Create-invoice-from-job in the Job Hub
- **New table** `job_invoices` keyed to `jobs.id` (uuid), with company-scoped RLS, plus a migration that also drops `schedule_blocks.equipment_ids` and `schedule_job_options`.
- **`JobInvoice` type + `jobInvoiceService`** CRUD (list by job, create, delete).
- **`JobInvoiceModal`**: editable crew/equipment/material line items seeded from the job's tracked data; add-from-catalog pickers (existing Employees + Inventory); subtotal + grand total; saved history (reopen / re-download / delete); branded PDF via the existing `generateInvoicePdf`. Status lifecycle (draft/sent/paid) intentionally omitted.
- **`JobHub`**: admin **Invoice** action wired to the modal with a saved-count badge.

## Notes
- The old service-job `InvoiceView` under Operations is left untouched (independent; the new flow doesn't depend on it).
- Invoice branding is still edited in the Operations invoice-settings panel; the Job Hub PDF reads it and falls back to defaults if unset.

## Migration
`supabase/migrations/20260630000000_add_job_invoices.sql` creates `job_invoices` and **drops** `schedule_blocks.equipment_ids` + the `schedule_job_options` table (abandoned scaffolding — irreversible). Applied separately by the maintainer.

## Verification
- `npx tsc --noEmit` passes.
- `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHtMH7pJQvYTg33rdJ7KX8)_