### PR TITLE
Let foremen invoice their own jobs and save crew/equipment templates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1197,6 +1197,7 @@ const App: React.FC = () => {
               jobs={jobs}
               companyId={sessionUser.companyId}
               isAdmin={isAdmin}
+              sessionUser={sessionUser}
               isDarkMode={isDarkMode}
               schedulingEnabled={isSchedulingEnabled}
               timeTrackingEnabled={isTimeTrackingEnabled}

--- a/components/JobHub.tsx
+++ b/components/JobHub.tsx
@@ -3,7 +3,7 @@ import {
   Search, Plus, FileText, Upload, Clock, Package, Users, Truck,
   CalendarDays, Activity, Trash2, Pencil, CheckCircle2, RotateCcw, X, Receipt,
 } from 'lucide-react';
-import { Job, DigTicket, TicketStatus, InventoryItem, InventoryItemType, InventoryMovement, JobPrint } from '../types.ts';
+import { Job, DigTicket, TicketStatus, InventoryItem, InventoryItemType, InventoryMovement, JobPrint, User } from '../types.ts';
 import { getTicketStatus, getStatusColor, formatDateStr } from '../utils/dateUtils.ts';
 import { apiService } from '../services/apiService.ts';
 import { scheduleService } from '../services/scheduleService.ts';
@@ -19,6 +19,7 @@ interface JobHubProps {
   tickets: DigTicket[];
   companyId: string;
   isAdmin: boolean;
+  sessionUser: User;
   isDarkMode?: boolean;
   schedulingEnabled?: boolean;
   timeTrackingEnabled?: boolean;
@@ -63,7 +64,7 @@ const HEALTH_DOT: Record<string, string> = {
 };
 
 export const JobHub: React.FC<JobHubProps> = ({
-  jobs, tickets, companyId, isAdmin, isDarkMode,
+  jobs, tickets, companyId, isAdmin, sessionUser, isDarkMode,
   schedulingEnabled, timeTrackingEnabled, inventoryEnabled, refreshKey,
   onCreateJob, onEditJob, onDeleteJob, onToggleComplete, onUpdateJob, onOpenMarkup, onViewDoc, onViewMedia,
 }) => {
@@ -241,6 +242,14 @@ export const JobHub: React.FC<JobHubProps> = ({
 
   // ── derived detail data for the selected job ────────────────────────────────
   const empById = useMemo(() => new Map(employees.map(e => [e.id, e])), [employees]);
+
+  // The employee record linked to the current login — lets a foreman (login
+  // linked to an employee flagged isForeman) invoice their own crew/equipment.
+  const isForeman = useMemo(
+    () => employees.some(e => e.profileId === sessionUser.id && e.isForeman),
+    [employees, sessionUser.id],
+  );
+  const canInvoice = isAdmin || isForeman;
 
   const detail = useMemo(() => {
     if (!selectedJob) return null;
@@ -449,20 +458,26 @@ export const JobHub: React.FC<JobHubProps> = ({
                       )}
                     </div>
                   </div>
-                  {isAdmin && (
+                  {(canInvoice || isAdmin) && (
                     <div className="flex flex-wrap items-center gap-2">
-                      <button onClick={() => setShowInvoice(true)} className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-brand/10 text-brand text-[10px] font-black uppercase tracking-widest hover:bg-brand/20 transition-all">
-                        <Receipt size={13} /> Invoice{invoiceCount > 0 ? ` (${invoiceCount})` : ''}
-                      </button>
-                      <button onClick={() => onEditJob(selectedJob)} className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-[10px] font-black uppercase tracking-widest transition-all ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>
-                        <Pencil size={13} /> Edit
-                      </button>
-                      <button onClick={() => onToggleComplete(selectedJob)} className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-[10px] font-black uppercase tracking-widest transition-all ${selectedJob.isComplete ? (isDarkMode ? 'bg-white/10' : 'bg-slate-100') : 'bg-emerald-500 text-white'}`}>
-                        {selectedJob.isComplete ? <><RotateCcw size={13} /> Reopen</> : <><CheckCircle2 size={13} /> Complete</>}
-                      </button>
-                      <button onClick={() => onDeleteJob(selectedJob)} className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[10px] font-black uppercase tracking-widest bg-rose-500/10 text-rose-500 hover:bg-rose-500 hover:text-white transition-all">
-                        <Trash2 size={13} />
-                      </button>
+                      {canInvoice && (
+                        <button onClick={() => setShowInvoice(true)} className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-brand/10 text-brand text-[10px] font-black uppercase tracking-widest hover:bg-brand/20 transition-all">
+                          <Receipt size={13} /> Invoice{invoiceCount > 0 ? ` (${invoiceCount})` : ''}
+                        </button>
+                      )}
+                      {isAdmin && (
+                        <>
+                          <button onClick={() => onEditJob(selectedJob)} className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-[10px] font-black uppercase tracking-widest transition-all ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>
+                            <Pencil size={13} /> Edit
+                          </button>
+                          <button onClick={() => onToggleComplete(selectedJob)} className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-[10px] font-black uppercase tracking-widest transition-all ${selectedJob.isComplete ? (isDarkMode ? 'bg-white/10' : 'bg-slate-100') : 'bg-emerald-500 text-white'}`}>
+                            {selectedJob.isComplete ? <><RotateCcw size={13} /> Reopen</> : <><CheckCircle2 size={13} /> Complete</>}
+                          </button>
+                          <button onClick={() => onDeleteJob(selectedJob)} className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[10px] font-black uppercase tracking-widest bg-rose-500/10 text-rose-500 hover:bg-rose-500 hover:text-white transition-all">
+                            <Trash2 size={13} />
+                          </button>
+                        </>
+                      )}
                     </div>
                   )}
                 </div>
@@ -728,6 +743,8 @@ export const JobHub: React.FC<JobHubProps> = ({
           job={selectedJob}
           companyId={companyId}
           isDarkMode={isDarkMode}
+          isAdmin={isAdmin}
+          ownerProfileId={sessionUser.id}
           prefill={{
             // Crew: aggregate logged hours per employee, rate from the employee record.
             crew: Array.from(

--- a/components/JobInvoiceModal.tsx
+++ b/components/JobInvoiceModal.tsx
@@ -31,6 +31,55 @@ type CrewLine = WorkLogEntry['employees'][number];
 type EquipLine = WorkLogEntry['equipment'][number];
 type MatLine = WorkLogEntry['materials'][number];
 
+const equipLabel = (e: Equipment) =>
+  [e.unitNumber ? `#${e.unitNumber}` : null, e.name, e.equipmentType ? `(${e.equipmentType})` : null].filter(Boolean).join(' ');
+
+// Live-searchable equipment combobox: filters the catalog (by unit #, name, or
+// type) as the user types, falling back to the full sorted list when idle.
+// Defined at module scope (not inline in JobInvoiceModal) so its identity is
+// stable across renders — otherwise every keystroke elsewhere in the modal
+// would remount this and drop focus/typed text.
+const EquipmentPicker: React.FC<{
+  value: string;
+  catalog: Equipment[];
+  inputCls: string;
+  isDarkMode?: boolean;
+  onSelect: (id: string) => void;
+}> = ({ value, catalog, inputCls, isDarkMode, onSelect }) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const selected = catalog.find(c => c.id === value);
+  const q = query.trim().toLowerCase();
+  const filtered = q ? catalog.filter(c => equipLabel(c).toLowerCase().includes(q)) : catalog;
+
+  return (
+    <div className="relative flex-1">
+      <input
+        value={open ? query : (selected ? equipLabel(selected) : (value ? `Equipment #${value}` : ''))}
+        onChange={e => { setQuery(e.target.value); if (!open) setOpen(true); }}
+        onFocus={() => { setQuery(''); setOpen(true); }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        placeholder="Search equipment…"
+        className={`${inputCls} w-full`}
+      />
+      {open && (
+        <div className={`absolute z-20 mt-1 w-full max-h-52 overflow-y-auto rounded-lg border shadow-xl ${isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'}`}>
+          {filtered.length === 0 ? (
+            <p className={`px-3 py-2 text-[11px] italic ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>No matches</p>
+          ) : filtered.map(c => (
+            <button key={c.id} type="button"
+              onMouseDown={e => e.preventDefault()}
+              onClick={() => { onSelect(c.id); setOpen(false); setQuery(''); }}
+              className={`w-full text-left px-3 py-1.5 text-[11px] font-bold transition-colors hover:bg-brand/10 ${c.id === value ? 'text-brand' : ''}`}>
+              {equipLabel(c)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 interface PrefillData {
   crew: CrewLine[];
   equipment: EquipLine[];
@@ -125,7 +174,10 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
       setEmployees(emps);
       setEquipCatalog(items
         .filter(i => i.itemType === InventoryItemType.EQUIPMENT)
-        .map(i => ({ id: i.id, companyId: i.companyId, name: i.unitNumber ? `#${i.unitNumber} ${i.name}` : i.name, hourlyRate: i.hourlyRate ?? 0 })));
+        .map(i => ({
+          id: i.id, companyId: i.companyId, name: i.name, hourlyRate: i.hourlyRate ?? 0,
+          unitNumber: i.unitNumber, equipmentType: i.equipmentType,
+        })));
       setMatCatalog(items.filter(i => i.itemType === InventoryItemType.MATERIAL));
       if (settings) setBranding(settings);
       setHistory(invs);
@@ -147,7 +199,17 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   }, [job.id, companyId]);
 
   const empName = (id: number) => employees.find(e => e.id === id)?.name ?? `Employee #${id}`;
-  const equipName = (id: string) => equipCatalog.find(e => e.id === id)?.name ?? `Equipment #${id}`;
+
+  // Equipment picker options, sorted by unit number ascending (numeric); items
+  // without a unit number sort after those that have one.
+  const sortedEquipCatalog = useMemo(() => [...equipCatalog].sort((a, b) => {
+    const an = a.unitNumber ? parseFloat(a.unitNumber) : NaN;
+    const bn = b.unitNumber ? parseFloat(b.unitNumber) : NaN;
+    if (!Number.isNaN(an) && !Number.isNaN(bn)) return an - bn;
+    if (!Number.isNaN(an)) return -1;
+    if (!Number.isNaN(bn)) return 1;
+    return a.name.localeCompare(b.name);
+  }), [equipCatalog]);
 
   // Re-pull crew lines from the time entries whose work day falls in [workFrom, workTo],
   // grouped by employee with hours summed and rate from the employee record.
@@ -411,15 +473,18 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
           {/* Equipment */}
           <div>
             <SectionHead icon={<Truck size={14} />} title="Equipment" addLabel="Add equipment"
-              onAdd={() => setEquipment(prev => [...prev, { equipmentId: equipCatalog[0]?.id ?? '', hours: 0, rate: equipCatalog[0]?.hourlyRate ?? 0 }])} />
+              onAdd={() => setEquipment(prev => [...prev, { equipmentId: sortedEquipCatalog[0]?.id ?? '', hours: 0, rate: sortedEquipCatalog[0]?.hourlyRate ?? 0 }])} />
             {equipment.length === 0 ? <p className={`text-[11px] italic ${subtle}`}>No equipment lines.</p> : (
               <div className="space-y-1.5">
                 {equipment.map((eq, i) => (
                   <div key={i} className="flex items-center gap-2">
-                    <select value={eq.equipmentId} onChange={e => setEquipment(prev => prev.map((x, j) => j === i ? { ...x, equipmentId: e.target.value, rate: x.rate || (equipCatalog.find(c => c.id === e.target.value)?.hourlyRate ?? 0) } : x))} className={`${inputCls} flex-1`}>
-                      {equipCatalog.length === 0 && <option value={eq.equipmentId}>{equipName(eq.equipmentId)}</option>}
-                      {equipCatalog.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
-                    </select>
+                    <EquipmentPicker
+                      value={eq.equipmentId}
+                      catalog={sortedEquipCatalog}
+                      inputCls={inputCls}
+                      isDarkMode={isDarkMode}
+                      onSelect={id => setEquipment(prev => prev.map((x, j) => j === i ? { ...x, equipmentId: id, rate: x.rate || (equipCatalog.find(c => c.id === id)?.hourlyRate ?? 0) } : x))}
+                    />
                     {numInput(eq.hours, n => setEquipment(prev => prev.map((x, j) => j === i ? { ...x, hours: n } : x)))}
                     <span className={`text-[9px] ${subtle}`}>hrs ×</span>
                     {numInput(eq.rate, n => setEquipment(prev => prev.map((x, j) => j === i ? { ...x, rate: n } : x)))}

--- a/components/JobInvoiceModal.tsx
+++ b/components/JobInvoiceModal.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText, Clock } from 'lucide-react';
+import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText, Clock, LayoutTemplate } from 'lucide-react';
 import { Job, InventoryItem, InventoryItemType } from '../types.ts';
 import {
-  Employee, Equipment, ServiceJob, WorkLog, WorkLogEntry, InvoiceSettings, JobInvoice, JobInvoiceData,
+  Employee, Equipment, ServiceJob, WorkLog, WorkLogEntry, InvoiceSettings, JobInvoice, JobInvoiceData, JobInvoiceTemplate,
 } from '../services/schedulingTypes.ts';
 import { generateInvoicePdf } from './scheduling/invoicePdf.ts';
 import { computeTotals } from './scheduling/costUtils.ts';
 import { jobInvoiceService } from '../services/jobInvoiceService.ts';
+import { jobInvoiceTemplateService } from '../services/jobInvoiceTemplateService.ts';
 import { scheduleService } from '../services/scheduleService.ts';
 import { apiService } from '../services/apiService.ts';
 import { timeTrackingService } from '../services/timeTrackingService.ts';
@@ -45,6 +46,11 @@ interface JobInvoiceModalProps {
   companyId: string;
   isDarkMode?: boolean;
   prefill: PrefillData;
+  // Only admins may delete an already-saved invoice; a foreman can still create,
+  // view and download them.
+  isAdmin: boolean;
+  // Current login's profile id — owner of any templates it saves.
+  ownerProfileId: string;
   onClose: () => void;
   onSaved?: () => void;
 }
@@ -64,7 +70,7 @@ const DEFAULT_BRANDING = (companyId: string): InvoiceSettings => ({
 const toISODate = (d: Date) => d.toISOString().slice(0, 10);
 
 export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
-  job, companyId, isDarkMode, prefill, onClose, onSaved,
+  job, companyId, isDarkMode, prefill, isAdmin, ownerProfileId, onClose, onSaved,
 }) => {
   // ── editable line items (seeded from the job's tracked data) ────────────────
   const [crew, setCrew] = useState<CrewLine[]>(prefill.crew);
@@ -94,6 +100,12 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   const [history, setHistory] = useState<JobInvoice[]>([]);
   const [saving, setSaving] = useState(false);
 
+  // ── crew/equipment templates (quick-add) ─────────────────────────────────────
+  const [templates, setTemplates] = useState<JobInvoiceTemplate[]>([]);
+  const [showTemplateForm, setShowTemplateForm] = useState(false);
+  const [templateName, setTemplateName] = useState('');
+  const [savingTemplate, setSavingTemplate] = useState(false);
+
   const card = isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200';
   const subtle = isDarkMode ? 'text-slate-400' : 'text-slate-500';
   const inputCls = `px-2 py-1.5 rounded-lg border text-[11px] font-bold outline-none focus:ring-4 focus:ring-brand/10 ${isDarkMode ? 'bg-white/5 border-white/10 text-white' : 'bg-slate-50 border-slate-200 text-slate-900'}`;
@@ -101,12 +113,13 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   useEffect(() => {
     let alive = true;
     (async () => {
-      const [emps, items, settings, invs, entries] = await Promise.all([
+      const [emps, items, settings, invs, entries, tmpls] = await Promise.all([
         scheduleService.getEmployees().catch(() => [] as Employee[]),
         apiService.getInventoryItems().catch(() => [] as InventoryItem[]),
         scheduleService.getInvoiceSettings().catch(() => null),
         jobInvoiceService.listByJob(job.id).catch(() => [] as JobInvoice[]),
         timeTrackingService.listEntries().catch(() => [] as TimeEntry[]),
+        jobInvoiceTemplateService.list().catch(() => [] as JobInvoiceTemplate[]),
       ]);
       if (!alive) return;
       setEmployees(emps);
@@ -116,6 +129,7 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
       setMatCatalog(items.filter(i => i.itemType === InventoryItemType.MATERIAL));
       if (settings) setBranding(settings);
       setHistory(invs);
+      setTemplates(tmpls);
 
       // Authoritative time entries for this dig job, fetched directly.
       const digEntries = entries.filter(e => e.jobKind === 'dig' && e.jobRef === job.id);
@@ -143,6 +157,56 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
       return (!workFrom || d >= workFrom) && (!workTo || d <= workTo);
     });
     setCrew(aggregateCrew(inRange, employees, crew));
+  };
+
+  // ── templates ───────────────────────────────────────────────────────────────
+  // Add any crew/equipment lines from a template that aren't already on the
+  // invoice. Names and rates are resolved fresh from the live catalogs.
+  const applyTemplate = (t: JobInvoiceTemplate) => {
+    setCrew(prev => {
+      const have = new Set(prev.map(c => c.employeeId));
+      const additions: CrewLine[] = t.employeeIds
+        .filter(id => !have.has(id))
+        .map(id => ({ employeeId: id, hours: 0, rate: employees.find(e => e.id === id)?.hourlyRate ?? 0 }));
+      return [...prev, ...additions];
+    });
+    setEquipment(prev => {
+      const have = new Set(prev.map(e => e.equipmentId));
+      const additions: EquipLine[] = t.equipmentIds
+        .filter(id => !have.has(id))
+        .map(id => ({ equipmentId: id, hours: 0, rate: equipCatalog.find(c => c.id === id)?.hourlyRate ?? 0 }));
+      return [...prev, ...additions];
+    });
+  };
+
+  const handleSaveTemplate = async () => {
+    const name = templateName.trim();
+    if (!name) return;
+    setSavingTemplate(true);
+    try {
+      const saved = await jobInvoiceTemplateService.create(
+        companyId, ownerProfileId, name,
+        Array.from(new Set(crew.map(c => c.employeeId))),
+        Array.from(new Set(equipment.map(e => e.equipmentId))),
+      );
+      setTemplates(prev => [...prev, saved].sort((a, b) => a.name.localeCompare(b.name)));
+      setTemplateName('');
+      setShowTemplateForm(false);
+    } catch (err: any) {
+      alert('Failed to save template: ' + (err?.message ?? err));
+    } finally {
+      setSavingTemplate(false);
+    }
+  };
+
+  const deleteTemplate = async (t: JobInvoiceTemplate) => {
+    if (!confirm(`Delete template "${t.name}"?`)) return;
+    try {
+      await jobInvoiceTemplateService.delete(t.id);
+      setTemplates(prev => prev.filter(x => x.id !== t.id));
+    } catch (err: any) {
+      alert('Failed to delete template: ' + (err?.message ?? err));
+    }
   };
 
   // ── totals ──────────────────────────────────────────────────────────────────
@@ -261,6 +325,48 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
             </div>
           </div>
 
+          {/* Crew + equipment templates */}
+          <div className={`rounded-2xl border p-4 ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                <span className="text-brand"><LayoutTemplate size={14} /></span>
+                <h4 className={`text-[10px] font-black uppercase tracking-[0.18em] ${subtle}`}>My Crew &amp; Equipment Templates</h4>
+              </div>
+              <button onClick={() => setShowTemplateForm(v => !v)} className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-brand/10 text-brand text-[9px] font-black uppercase tracking-widest hover:bg-brand/20">
+                <Plus size={11} /> Save Current
+              </button>
+            </div>
+            {showTemplateForm && (
+              <div className="flex items-center gap-2 mb-3">
+                <input value={templateName} onChange={e => setTemplateName(e.target.value)} placeholder="Template name (e.g. Crew A + Excavator)" className={`${inputCls} flex-1`} />
+                <button onClick={handleSaveTemplate} disabled={savingTemplate || !templateName.trim()} className="px-3 py-1.5 rounded-lg bg-brand text-[#0f172a] text-[9px] font-black uppercase tracking-widest disabled:opacity-50">
+                  {savingTemplate ? 'Saving…' : 'Save'}
+                </button>
+              </div>
+            )}
+            {templates.length === 0 ? (
+              <p className={`text-[11px] italic ${subtle}`}>No saved templates yet. Build your crew and equipment lines below, then save them here for quick reuse next time.</p>
+            ) : (
+              <div className="space-y-1.5">
+                {templates.map(t => (
+                  <div key={t.id} className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-[11px] font-bold truncate">{t.name}</p>
+                      <p className={`text-[9px] font-semibold ${subtle}`}>
+                        {t.employeeIds.length} crew · {t.equipmentIds.length} equipment
+                        {isAdmin ? ` · ${employees.find(e => e.profileId === t.ownerProfileId)?.name ?? 'Unknown foreman'}` : ''}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <button onClick={() => applyTemplate(t)} className="px-2.5 py-1 rounded-lg bg-brand/10 text-brand text-[9px] font-black uppercase tracking-widest hover:bg-brand/20">Apply</button>
+                      <button onClick={() => deleteTemplate(t)} className="text-rose-500 hover:text-rose-600"><Trash2 size={13} /></button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
           {/* Crew labor */}
           <div>
             <SectionHead icon={<Users size={14} />} title="Crew Labor" addLabel="Add crew"
@@ -376,7 +482,9 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
                     </div>
                     <div className="flex items-center gap-1.5 shrink-0">
                       <button onClick={() => downloadSaved(inv)} className="p-1.5 rounded-lg bg-brand/10 text-brand hover:bg-brand/20" aria-label="Download"><Download size={13} /></button>
-                      <button onClick={() => deleteSaved(inv)} className="p-1.5 rounded-lg text-rose-500 hover:bg-rose-500/10" aria-label="Delete"><Trash2 size={13} /></button>
+                      {isAdmin && (
+                        <button onClick={() => deleteSaved(inv)} className="p-1.5 rounded-lg text-rose-500 hover:bg-rose-500/10" aria-label="Delete"><Trash2 size={13} /></button>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/components/JobInvoiceModal.tsx
+++ b/components/JobInvoiceModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText, Clock, LayoutTemplate } from 'lucide-react';
+import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText, Clock, LayoutTemplate, ListChecks } from 'lucide-react';
 import { Job, InventoryItem, InventoryItemType } from '../types.ts';
 import {
   Employee, Equipment, ServiceJob, WorkLog, WorkLogEntry, InvoiceSettings, JobInvoice, JobInvoiceData, JobInvoiceTemplate,
@@ -155,6 +155,12 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   const [templateName, setTemplateName] = useState('');
   const [savingTemplate, setSavingTemplate] = useState(false);
 
+  // ── bulk-select checklists (add many crew/equipment lines at once) ──────────
+  const [showCrewPicker, setShowCrewPicker] = useState(false);
+  const [crewPickIds, setCrewPickIds] = useState<Set<number>>(new Set());
+  const [showEquipPicker, setShowEquipPicker] = useState(false);
+  const [equipPickIds, setEquipPickIds] = useState<Set<string>>(new Set());
+
   const card = isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200';
   const subtle = isDarkMode ? 'text-slate-400' : 'text-slate-500';
   const inputCls = `px-2 py-1.5 rounded-lg border text-[11px] font-bold outline-none focus:ring-4 focus:ring-brand/10 ${isDarkMode ? 'bg-white/5 border-white/10 text-white' : 'bg-slate-50 border-slate-200 text-slate-900'}`;
@@ -271,6 +277,42 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
     }
   };
 
+  // ── bulk-select checklists ─────────────────────────────────────────────────
+  const toggleCrewPick = (id: number) => setCrewPickIds(prev => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  });
+  const toggleEquipPick = (id: string) => setEquipPickIds(prev => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  });
+
+  const addSelectedCrew = () => {
+    setCrew(prev => {
+      const have = new Set(prev.map(c => c.employeeId));
+      const additions: CrewLine[] = Array.from(crewPickIds)
+        .filter(id => !have.has(id))
+        .map(id => ({ employeeId: id, hours: 0, rate: employees.find(e => e.id === id)?.hourlyRate ?? 0 }));
+      return [...prev, ...additions];
+    });
+    setCrewPickIds(new Set());
+    setShowCrewPicker(false);
+  };
+
+  const addSelectedEquipment = () => {
+    setEquipment(prev => {
+      const have = new Set(prev.map(e => e.equipmentId));
+      const additions: EquipLine[] = Array.from(equipPickIds)
+        .filter(id => !have.has(id))
+        .map(id => ({ equipmentId: id, hours: 0, rate: equipCatalog.find(c => c.id === id)?.hourlyRate ?? 0 }));
+      return [...prev, ...additions];
+    });
+    setEquipPickIds(new Set());
+    setShowEquipPicker(false);
+  };
+
   // ── totals ──────────────────────────────────────────────────────────────────
   const entry: WorkLogEntry = useMemo(() => ({ employees: crew, equipment, materials }), [crew, equipment, materials]);
   const totals = useMemo(() => computeTotals([{ id: 0, jobId: 0, date: invoiceDate, notes: '', data: entry }], []), [entry, invoiceDate]);
@@ -341,15 +383,25 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   };
 
   // ── line-item editors ─────────────────────────────────────────────────────
-  const SectionHead: React.FC<{ icon: React.ReactNode; title: string; onAdd: () => void; addLabel: string }> = ({ icon, title, onAdd, addLabel }) => (
+  const SectionHead: React.FC<{
+    icon: React.ReactNode; title: string; onAdd: () => void; addLabel: string;
+    onSecondary?: () => void; secondaryLabel?: string;
+  }> = ({ icon, title, onAdd, addLabel, onSecondary, secondaryLabel }) => (
     <div className="flex items-center justify-between mb-2">
       <div className="flex items-center gap-2">
         <span className="text-brand">{icon}</span>
         <h4 className={`text-[10px] font-black uppercase tracking-[0.18em] ${subtle}`}>{title}</h4>
       </div>
-      <button onClick={onAdd} className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-brand/10 text-brand text-[9px] font-black uppercase tracking-widest hover:bg-brand/20">
-        <Plus size={11} /> {addLabel}
-      </button>
+      <div className="flex items-center gap-1.5">
+        {onSecondary && (
+          <button onClick={onSecondary} className={`flex items-center gap-1 px-2.5 py-1 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>
+            <ListChecks size={11} /> {secondaryLabel}
+          </button>
+        )}
+        <button onClick={onAdd} className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-brand/10 text-brand text-[9px] font-black uppercase tracking-widest hover:bg-brand/20">
+          <Plus size={11} /> {addLabel}
+        </button>
+      </div>
     </div>
   );
 
@@ -432,7 +484,29 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
           {/* Crew labor */}
           <div>
             <SectionHead icon={<Users size={14} />} title="Crew Labor" addLabel="Add crew"
-              onAdd={() => setCrew(prev => [...prev, { employeeId: employees[0]?.id ?? 0, hours: 0, rate: employees[0]?.hourlyRate ?? 0 }])} />
+              onAdd={() => setCrew(prev => [...prev, { employeeId: employees[0]?.id ?? 0, hours: 0, rate: employees[0]?.hourlyRate ?? 0 }])}
+              secondaryLabel="Select Multiple" onSecondary={() => setShowCrewPicker(v => !v)} />
+            {showCrewPicker && (
+              <div className={`mb-3 p-3 rounded-xl border ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
+                <div className="max-h-48 overflow-y-auto space-y-0.5 mb-2">
+                  {employees.length === 0 ? (
+                    <p className={`text-[11px] italic ${subtle}`}>No employees found.</p>
+                  ) : employees.map(e => (
+                    <label key={e.id} className="flex items-center gap-2 py-1 cursor-pointer">
+                      <input type="checkbox" checked={crewPickIds.has(e.id)} onChange={() => toggleCrewPick(e.id)} className="w-4 h-4 accent-brand rounded shrink-0" />
+                      <span className="text-[11px] font-bold flex-1 truncate">{e.name}</span>
+                      <span className={`text-[9px] font-semibold ${subtle}`}>{e.role}</span>
+                    </label>
+                  ))}
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                  <button onClick={() => { setShowCrewPicker(false); setCrewPickIds(new Set()); }} className={`px-3 py-1.5 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>Cancel</button>
+                  <button onClick={addSelectedCrew} disabled={crewPickIds.size === 0} className="px-3 py-1.5 rounded-lg bg-brand text-[#0f172a] text-[9px] font-black uppercase tracking-widest disabled:opacity-40">
+                    Add Selected ({crewPickIds.size})
+                  </button>
+                </div>
+              </div>
+            )}
             {/* Work-date range: pull employees + hours logged within the window. */}
             <div className={`flex flex-wrap items-end gap-2 mb-3 p-3 rounded-xl border ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
               <div className="space-y-1">
@@ -473,7 +547,28 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
           {/* Equipment */}
           <div>
             <SectionHead icon={<Truck size={14} />} title="Equipment" addLabel="Add equipment"
-              onAdd={() => setEquipment(prev => [...prev, { equipmentId: sortedEquipCatalog[0]?.id ?? '', hours: 0, rate: sortedEquipCatalog[0]?.hourlyRate ?? 0 }])} />
+              onAdd={() => setEquipment(prev => [...prev, { equipmentId: sortedEquipCatalog[0]?.id ?? '', hours: 0, rate: sortedEquipCatalog[0]?.hourlyRate ?? 0 }])}
+              secondaryLabel="Select Multiple" onSecondary={() => setShowEquipPicker(v => !v)} />
+            {showEquipPicker && (
+              <div className={`mb-3 p-3 rounded-xl border ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
+                <div className="max-h-48 overflow-y-auto space-y-0.5 mb-2">
+                  {sortedEquipCatalog.length === 0 ? (
+                    <p className={`text-[11px] italic ${subtle}`}>No equipment found.</p>
+                  ) : sortedEquipCatalog.map(c => (
+                    <label key={c.id} className="flex items-center gap-2 py-1 cursor-pointer">
+                      <input type="checkbox" checked={equipPickIds.has(c.id)} onChange={() => toggleEquipPick(c.id)} className="w-4 h-4 accent-brand rounded shrink-0" />
+                      <span className="text-[11px] font-bold flex-1 truncate">{equipLabel(c)}</span>
+                    </label>
+                  ))}
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                  <button onClick={() => { setShowEquipPicker(false); setEquipPickIds(new Set()); }} className={`px-3 py-1.5 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>Cancel</button>
+                  <button onClick={addSelectedEquipment} disabled={equipPickIds.size === 0} className="px-3 py-1.5 rounded-lg bg-brand text-[#0f172a] text-[9px] font-black uppercase tracking-widest disabled:opacity-40">
+                    Add Selected ({equipPickIds.size})
+                  </button>
+                </div>
+              </div>
+            )}
             {equipment.length === 0 ? <p className={`text-[11px] italic ${subtle}`}>No equipment lines.</p> : (
               <div className="space-y-1.5">
                 {equipment.map((eq, i) => (

--- a/components/JobInvoiceModal.tsx
+++ b/components/JobInvoiceModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText, Clock, LayoutTemplate, ListChecks } from 'lucide-react';
+import { X, Plus, Trash2, Download, Save, Users, Truck, Package, FileText, Clock, LayoutTemplate } from 'lucide-react';
 import { Job, InventoryItem, InventoryItemType } from '../types.ts';
 import {
   Employee, Equipment, ServiceJob, WorkLog, WorkLogEntry, InvoiceSettings, JobInvoice, JobInvoiceData, JobInvoiceTemplate,
@@ -72,6 +72,50 @@ const EquipmentPicker: React.FC<{
               onClick={() => { onSelect(c.id); setOpen(false); setQuery(''); }}
               className={`w-full text-left px-3 py-1.5 text-[11px] font-bold transition-colors hover:bg-brand/10 ${c.id === value ? 'text-brand' : ''}`}>
               {equipLabel(c)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const employeeLabel = (e: Employee) => (e.role ? `${e.name} (${e.role})` : e.name);
+
+// Live-searchable employee combobox, mirroring EquipmentPicker above.
+const EmployeePicker: React.FC<{
+  value: number;
+  catalog: Employee[];
+  inputCls: string;
+  isDarkMode?: boolean;
+  onSelect: (id: number) => void;
+}> = ({ value, catalog, inputCls, isDarkMode, onSelect }) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const selected = catalog.find(c => c.id === value);
+  const q = query.trim().toLowerCase();
+  const filtered = q ? catalog.filter(c => employeeLabel(c).toLowerCase().includes(q)) : catalog;
+
+  return (
+    <div className="relative flex-1">
+      <input
+        value={open ? query : (selected ? employeeLabel(selected) : (value ? `Employee #${value}` : ''))}
+        onChange={e => { setQuery(e.target.value); if (!open) setOpen(true); }}
+        onFocus={() => { setQuery(''); setOpen(true); }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        placeholder="Search crew…"
+        className={`${inputCls} w-full`}
+      />
+      {open && (
+        <div className={`absolute z-20 mt-1 w-full max-h-52 overflow-y-auto rounded-lg border shadow-xl ${isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'}`}>
+          {filtered.length === 0 ? (
+            <p className={`px-3 py-2 text-[11px] italic ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>No matches</p>
+          ) : filtered.map(c => (
+            <button key={c.id} type="button"
+              onMouseDown={e => e.preventDefault()}
+              onClick={() => { onSelect(c.id); setOpen(false); setQuery(''); }}
+              className={`w-full text-left px-3 py-1.5 text-[11px] font-bold transition-colors hover:bg-brand/10 ${c.id === value ? 'text-brand' : ''}`}>
+              {employeeLabel(c)}
             </button>
           ))}
         </div>
@@ -158,8 +202,10 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   // ── bulk-select checklists (add many crew/equipment lines at once) ──────────
   const [showCrewPicker, setShowCrewPicker] = useState(false);
   const [crewPickIds, setCrewPickIds] = useState<Set<number>>(new Set());
+  const [crewSearch, setCrewSearch] = useState('');
   const [showEquipPicker, setShowEquipPicker] = useState(false);
   const [equipPickIds, setEquipPickIds] = useState<Set<string>>(new Set());
+  const [equipSearch, setEquipSearch] = useState('');
 
   const card = isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200';
   const subtle = isDarkMode ? 'text-slate-400' : 'text-slate-500';
@@ -204,8 +250,6 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
     return () => { alive = false; };
   }, [job.id, companyId]);
 
-  const empName = (id: number) => employees.find(e => e.id === id)?.name ?? `Employee #${id}`;
-
   // Equipment picker options, sorted by unit number ascending (numeric); items
   // without a unit number sort after those that have one.
   const sortedEquipCatalog = useMemo(() => [...equipCatalog].sort((a, b) => {
@@ -216,6 +260,19 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
     if (!Number.isNaN(bn)) return 1;
     return a.name.localeCompare(b.name);
   }), [equipCatalog]);
+
+  // Live-filtered options for the bulk-add checklists.
+  const crewPickOptions = useMemo(() => {
+    const q = crewSearch.trim().toLowerCase();
+    if (!q) return employees;
+    return employees.filter(e => e.name.toLowerCase().includes(q) || e.role.toLowerCase().includes(q));
+  }, [employees, crewSearch]);
+
+  const equipPickOptions = useMemo(() => {
+    const q = equipSearch.trim().toLowerCase();
+    if (!q) return sortedEquipCatalog;
+    return sortedEquipCatalog.filter(c => equipLabel(c).toLowerCase().includes(q));
+  }, [sortedEquipCatalog, equipSearch]);
 
   // Re-pull crew lines from the time entries whose work day falls in [workFrom, workTo],
   // grouped by employee with hours summed and rate from the employee record.
@@ -383,25 +440,15 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
   };
 
   // ── line-item editors ─────────────────────────────────────────────────────
-  const SectionHead: React.FC<{
-    icon: React.ReactNode; title: string; onAdd: () => void; addLabel: string;
-    onSecondary?: () => void; secondaryLabel?: string;
-  }> = ({ icon, title, onAdd, addLabel, onSecondary, secondaryLabel }) => (
+  const SectionHead: React.FC<{ icon: React.ReactNode; title: string; onAdd: () => void; addLabel: string }> = ({ icon, title, onAdd, addLabel }) => (
     <div className="flex items-center justify-between mb-2">
       <div className="flex items-center gap-2">
         <span className="text-brand">{icon}</span>
         <h4 className={`text-[10px] font-black uppercase tracking-[0.18em] ${subtle}`}>{title}</h4>
       </div>
-      <div className="flex items-center gap-1.5">
-        {onSecondary && (
-          <button onClick={onSecondary} className={`flex items-center gap-1 px-2.5 py-1 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>
-            <ListChecks size={11} /> {secondaryLabel}
-          </button>
-        )}
-        <button onClick={onAdd} className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-brand/10 text-brand text-[9px] font-black uppercase tracking-widest hover:bg-brand/20">
-          <Plus size={11} /> {addLabel}
-        </button>
-      </div>
+      <button onClick={onAdd} className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-brand/10 text-brand text-[9px] font-black uppercase tracking-widest hover:bg-brand/20">
+        <Plus size={11} /> {addLabel}
+      </button>
     </div>
   );
 
@@ -483,15 +530,15 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
 
           {/* Crew labor */}
           <div>
-            <SectionHead icon={<Users size={14} />} title="Crew Labor" addLabel="Add crew"
-              onAdd={() => setCrew(prev => [...prev, { employeeId: employees[0]?.id ?? 0, hours: 0, rate: employees[0]?.hourlyRate ?? 0 }])}
-              secondaryLabel="Select Multiple" onSecondary={() => setShowCrewPicker(v => !v)} />
+            <SectionHead icon={<Users size={14} />} title="Crew Labor" addLabel="Add Crew"
+              onAdd={() => setShowCrewPicker(v => !v)} />
             {showCrewPicker && (
               <div className={`mb-3 p-3 rounded-xl border ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
+                <input value={crewSearch} onChange={e => setCrewSearch(e.target.value)} placeholder="Search by name or role…" className={`${inputCls} w-full mb-2`} />
                 <div className="max-h-48 overflow-y-auto space-y-0.5 mb-2">
-                  {employees.length === 0 ? (
-                    <p className={`text-[11px] italic ${subtle}`}>No employees found.</p>
-                  ) : employees.map(e => (
+                  {crewPickOptions.length === 0 ? (
+                    <p className={`text-[11px] italic ${subtle}`}>No matches.</p>
+                  ) : crewPickOptions.map(e => (
                     <label key={e.id} className="flex items-center gap-2 py-1 cursor-pointer">
                       <input type="checkbox" checked={crewPickIds.has(e.id)} onChange={() => toggleCrewPick(e.id)} className="w-4 h-4 accent-brand rounded shrink-0" />
                       <span className="text-[11px] font-bold flex-1 truncate">{e.name}</span>
@@ -500,7 +547,7 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
                   ))}
                 </div>
                 <div className="flex items-center justify-end gap-2">
-                  <button onClick={() => { setShowCrewPicker(false); setCrewPickIds(new Set()); }} className={`px-3 py-1.5 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>Cancel</button>
+                  <button onClick={() => { setShowCrewPicker(false); setCrewPickIds(new Set()); setCrewSearch(''); }} className={`px-3 py-1.5 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>Cancel</button>
                   <button onClick={addSelectedCrew} disabled={crewPickIds.size === 0} className="px-3 py-1.5 rounded-lg bg-brand text-[#0f172a] text-[9px] font-black uppercase tracking-widest disabled:opacity-40">
                     Add Selected ({crewPickIds.size})
                   </button>
@@ -529,10 +576,13 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
               <div className="space-y-1.5">
                 {crew.map((c, i) => (
                   <div key={i} className="flex items-center gap-2">
-                    <select value={c.employeeId} onChange={e => setCrew(prev => prev.map((x, j) => j === i ? { ...x, employeeId: Number(e.target.value), rate: x.rate || (employees.find(em => em.id === Number(e.target.value))?.hourlyRate ?? 0) } : x))} className={`${inputCls} flex-1`}>
-                      {employees.length === 0 && <option value={c.employeeId}>{empName(c.employeeId)}</option>}
-                      {employees.map(e => <option key={e.id} value={e.id}>{e.name}</option>)}
-                    </select>
+                    <EmployeePicker
+                      value={c.employeeId}
+                      catalog={employees}
+                      inputCls={inputCls}
+                      isDarkMode={isDarkMode}
+                      onSelect={id => setCrew(prev => prev.map((x, j) => j === i ? { ...x, employeeId: id, rate: x.rate || (employees.find(em => em.id === id)?.hourlyRate ?? 0) } : x))}
+                    />
                     {numInput(c.hours, n => setCrew(prev => prev.map((x, j) => j === i ? { ...x, hours: n } : x)))}
                     <span className={`text-[9px] ${subtle}`}>hrs ×</span>
                     {numInput(c.rate, n => setCrew(prev => prev.map((x, j) => j === i ? { ...x, rate: n } : x)))}
@@ -546,15 +596,15 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
 
           {/* Equipment */}
           <div>
-            <SectionHead icon={<Truck size={14} />} title="Equipment" addLabel="Add equipment"
-              onAdd={() => setEquipment(prev => [...prev, { equipmentId: sortedEquipCatalog[0]?.id ?? '', hours: 0, rate: sortedEquipCatalog[0]?.hourlyRate ?? 0 }])}
-              secondaryLabel="Select Multiple" onSecondary={() => setShowEquipPicker(v => !v)} />
+            <SectionHead icon={<Truck size={14} />} title="Equipment" addLabel="Add Equipment"
+              onAdd={() => setShowEquipPicker(v => !v)} />
             {showEquipPicker && (
               <div className={`mb-3 p-3 rounded-xl border ${isDarkMode ? 'bg-white/5 border-white/10' : 'bg-slate-50 border-slate-200'}`}>
+                <input value={equipSearch} onChange={e => setEquipSearch(e.target.value)} placeholder="Search by unit #, name, or type…" className={`${inputCls} w-full mb-2`} />
                 <div className="max-h-48 overflow-y-auto space-y-0.5 mb-2">
-                  {sortedEquipCatalog.length === 0 ? (
-                    <p className={`text-[11px] italic ${subtle}`}>No equipment found.</p>
-                  ) : sortedEquipCatalog.map(c => (
+                  {equipPickOptions.length === 0 ? (
+                    <p className={`text-[11px] italic ${subtle}`}>No matches.</p>
+                  ) : equipPickOptions.map(c => (
                     <label key={c.id} className="flex items-center gap-2 py-1 cursor-pointer">
                       <input type="checkbox" checked={equipPickIds.has(c.id)} onChange={() => toggleEquipPick(c.id)} className="w-4 h-4 accent-brand rounded shrink-0" />
                       <span className="text-[11px] font-bold flex-1 truncate">{equipLabel(c)}</span>
@@ -562,7 +612,7 @@ export const JobInvoiceModal: React.FC<JobInvoiceModalProps> = ({
                   ))}
                 </div>
                 <div className="flex items-center justify-end gap-2">
-                  <button onClick={() => { setShowEquipPicker(false); setEquipPickIds(new Set()); }} className={`px-3 py-1.5 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>Cancel</button>
+                  <button onClick={() => { setShowEquipPicker(false); setEquipPickIds(new Set()); setEquipSearch(''); }} className={`px-3 py-1.5 rounded-lg border text-[9px] font-black uppercase tracking-widest ${isDarkMode ? 'border-white/10 hover:bg-white/5' : 'border-slate-200 hover:bg-slate-50'}`}>Cancel</button>
                   <button onClick={addSelectedEquipment} disabled={equipPickIds.size === 0} className="px-3 py-1.5 rounded-lg bg-brand text-[#0f172a] text-[9px] font-black uppercase tracking-widest disabled:opacity-40">
                     Add Selected ({equipPickIds.size})
                   </button>

--- a/services/jobInvoiceTemplateService.ts
+++ b/services/jobInvoiceTemplateService.ts
@@ -1,0 +1,54 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Job Invoice Template Service — Supabase CRUD for foreman crew/equipment
+// templates used to quickly build a Job Hub invoice.
+//
+// RLS on job_invoice_templates already scopes visibility: a foreman only sees
+// their own templates, an admin sees every template in their company. `list()`
+// relies on that — no need to branch on role client-side.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { supabase } from '../lib/supabaseClient.ts';
+import { JobInvoiceTemplate } from './schedulingTypes.ts';
+
+const mapTemplate = (row: Record<string, unknown>): JobInvoiceTemplate => ({
+  id:             Number(row.id ?? 0),
+  companyId:      String(row.company_id ?? ''),
+  ownerProfileId: String(row.owner_profile_id ?? ''),
+  name:           String(row.name ?? ''),
+  employeeIds:    ((row.employee_ids as unknown[]) ?? []).map(Number),
+  equipmentIds:   ((row.equipment_ids as unknown[]) ?? []).map(String),
+  createdAt:      row.created_at ? new Date(row.created_at as string).getTime() : Date.now(),
+});
+
+export const jobInvoiceTemplateService = {
+  async list(): Promise<JobInvoiceTemplate[]> {
+    const { data, error } = await supabase
+      .from('job_invoice_templates')
+      .select('*')
+      .order('name');
+    if (error) throw error;
+    return (data ?? []).map(r => mapTemplate(r as Record<string, unknown>));
+  },
+
+  async create(
+    companyId: string, ownerProfileId: string, name: string, employeeIds: number[], equipmentIds: string[],
+  ): Promise<JobInvoiceTemplate> {
+    const { data, error } = await supabase
+      .from('job_invoice_templates')
+      .insert({
+        company_id:       companyId,
+        owner_profile_id: ownerProfileId,
+        name,
+        employee_ids:     employeeIds,
+        equipment_ids:    equipmentIds,
+      })
+      .select().single();
+    if (error) throw error;
+    return mapTemplate(data as Record<string, unknown>);
+  },
+
+  async delete(id: number): Promise<void> {
+    const { error } = await supabase.from('job_invoice_templates').delete().eq('id', id);
+    if (error) throw error;
+  },
+};

--- a/services/schedulingTypes.ts
+++ b/services/schedulingTypes.ts
@@ -138,6 +138,19 @@ export interface JobInvoice {
   createdAt: number;
 }
 
+// A foreman's saved crew + equipment set for quickly building an invoice.
+// Stores only IDs — names/rates are always resolved from the live employees /
+// inventory_items catalogs when the template is applied.
+export interface JobInvoiceTemplate {
+  id: number;
+  companyId: string;
+  ownerProfileId: string;
+  name: string;
+  employeeIds: number[];
+  equipmentIds: string[];
+  createdAt: number;
+}
+
 // ── Scheduler board entities (UUID-string ids) ──────────────────────────────
 
 export interface Crew {

--- a/supabase/migrations/20260701000000_add_job_invoice_templates.sql
+++ b/supabase/migrations/20260701000000_add_job_invoice_templates.sql
@@ -1,0 +1,97 @@
+-- =============================================================================
+-- Migration: Foreman invoice templates + tighten job_invoices mutate policies
+--
+-- Part A — job_invoice_templates lets a foreman save a named set of crew +
+-- equipment (just the IDs, so applying a template always resolves current
+-- names/rates from the live employees/inventory_items lists — never a stale
+-- snapshot). One foreman can save many templates. Mirrors the ownership
+-- pattern already used by time_clock_crews (20260619000000_add_foreman_crews.sql):
+-- the owning foreman manages their own rows, admins manage every row in the
+-- company so they can view/reuse any foreman's templates.
+--
+-- Part B — job_invoices UPDATE/DELETE were previously open to any company
+-- member (get_user_company_id() only). Now that foremen can create invoices
+-- from the Job Hub, restrict mutation of already-saved invoices to admins so
+-- a foreman can submit an invoice but not edit or delete it afterward.
+-- SELECT/INSERT stay company-wide (foremen still need to create + view them).
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Part A. FOREMAN INVOICE TEMPLATES
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS job_invoice_templates (
+  id               BIGSERIAL PRIMARY KEY,
+  company_id       UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  owner_profile_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  name             TEXT NOT NULL DEFAULT 'My Template',
+  -- References into the live employees / inventory_items catalogs. Names and
+  -- rates are always resolved at apply-time, never stored here.
+  employee_ids     BIGINT[] NOT NULL DEFAULT '{}',
+  equipment_ids    TEXT[] NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS job_invoice_templates_company_idx ON job_invoice_templates (company_id);
+CREATE INDEX IF NOT EXISTS job_invoice_templates_owner_idx ON job_invoice_templates (owner_profile_id);
+
+ALTER TABLE job_invoice_templates ENABLE ROW LEVEL SECURITY;
+
+-- A foreman can read/write only their own templates (and only within their company).
+DROP POLICY IF EXISTS "job_invoice_templates_owner_manage" ON job_invoice_templates;
+CREATE POLICY "job_invoice_templates_owner_manage" ON job_invoice_templates
+  FOR ALL TO authenticated
+  USING (owner_profile_id = auth.uid() AND company_id = get_user_company_id())
+  WITH CHECK (owner_profile_id = auth.uid() AND company_id = get_user_company_id());
+
+-- Admins (ADMIN / SUPER_ADMIN) can read/write any template in their company so
+-- they can apply a foreman's template when building an invoice themselves.
+DROP POLICY IF EXISTS "job_invoice_templates_admin_manage" ON job_invoice_templates;
+CREATE POLICY "job_invoice_templates_admin_manage" ON job_invoice_templates
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = job_invoice_templates.company_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = job_invoice_templates.company_id)
+    )
+  );
+
+GRANT ALL ON job_invoice_templates TO authenticated;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Part B. RESTRICT job_invoices UPDATE/DELETE TO ADMINS
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "job_invoices_update" ON job_invoices;
+CREATE POLICY "job_invoices_update" ON job_invoices
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = job_invoices.company_id)
+    )
+  );
+
+DROP POLICY IF EXISTS "job_invoices_delete" ON job_invoices;
+CREATE POLICY "job_invoices_delete" ON job_invoices
+  FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('ADMIN', 'SUPER_ADMIN')
+        AND (p.role = 'SUPER_ADMIN' OR p.company_id = job_invoices.company_id)
+    )
+  );


### PR DESCRIPTION
Foremen (employees flagged is_foreman) can now open the Job Hub Invoice
modal to build and save an invoice for jobs, using a new
job_invoice_templates table to store reusable crew + equipment sets.
Templates store only employee/equipment IDs so applying one always pulls
current names and rates from the live employees/inventory lists. Each
foreman only sees their own templates; admins see every template in the
company. Admin-only actions on the job (Edit, Complete, Delete) and
deleting a saved invoice remain restricted to admins, enforced both in
the UI and via RLS on job_invoices.