### PR TITLE
PDF editor: left-align annotation tools; open downloads/views in a new tab

### DIFF
--- a/components/PdfMarkupEditor.tsx
+++ b/components/PdfMarkupEditor.tsx
@@ -1741,8 +1741,10 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
     setIsSaving(false);
   }, [pendingAnnotations]);
 
-  // Download a flattened copy of the PDF with all current markups burned in
-  // as vector graphics (same renderer the Job Hub download menu uses).
+  // Open a flattened copy of the PDF (all current markups burned in as vector
+  // graphics) in a new browser tab for viewing — the same renderer the Job Hub
+  // download menu uses. The tab is opened synchronously inside this click
+  // handler so popup blockers don't kill it before the blob is ready.
   const handleExport = useCallback(async () => {
     const bytes = pdfBytesRef.current;
     if (!bytes || isExporting) return;
@@ -1753,19 +1755,28 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
       return;
     }
     setIsExporting(true);
+    const win = window.open('', '_blank');
     try {
       const out = await flattenAnnotationsIntoPdf(bytes, marks, scaleInfo ?? null);
       // pdf-lib returns a Uint8Array; copy into a fresh buffer so Blob gets a clean ArrayBuffer.
       const blob = new Blob([out.slice()], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
       const base = print.fileName.replace(/\.pdf$/i, '');
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `${base} (marked up).pdf`;
-      document.body.appendChild(link);
-      link.click();
-      setTimeout(() => { document.body.removeChild(link); URL.revokeObjectURL(url); }, 1000);
+      if (win) {
+        win.location.href = url;
+      } else {
+        // Popup blocked — fall back to a direct download so the export isn't lost.
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${base} (marked up).pdf`;
+        document.body.appendChild(link);
+        link.click();
+        setTimeout(() => document.body.removeChild(link), 1000);
+      }
+      // Keep the object URL alive long enough for the new tab to load it.
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
     } catch (e: unknown) {
+      if (win) win.close();
       setActionErr('Export failed: ' + (e instanceof Error ? e.message : 'unknown error'));
     } finally {
       setIsExporting(false);
@@ -2790,7 +2801,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         <button onClick={handleExport}
           disabled={isLoadingPdf || !!pdfError || isExporting}
           className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[10px] font-black uppercase tracking-wider transition-all shrink-0 min-h-[44px] bg-brand text-slate-900 hover:brightness-110 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed"
-          title="Download a copy of this PDF with the markups burned in">
+          title="Open a copy of this PDF with the markups burned in, in a new tab">
           {isExporting ? (
             <>
               <span className="w-3.5 h-3.5 border-2 border-slate-900/40 border-t-slate-900 rounded-full animate-spin" />
@@ -2969,19 +2980,7 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
         <div className="flex items-center gap-3 px-3 py-2 border-b border-white/10 bg-slate-900/40 shrink-0 min-h-[52px] overflow-x-auto">
           {selectedAnn ? (
             <>
-              <span className="text-[9px] text-slate-400 font-bold uppercase tracking-widest shrink-0">
-                {selectedAnn.toolType.replace(/_/g, ' ')} selected
-                {selectedAnn.toolType === 'callout' && getHandlesNorm(selectedAnn).length >= 2
-                  ? ' — drag amber dot to repoint arrow · blue dot to move text box · green dot to rotate'
-                  : getHandlesNorm(selectedAnn).some(h => h.isRotateHandle) && getHandlesNorm(selectedAnn).some(h => !h.isMoveHandle && !h.isRotateHandle && !h.isEdgeHandle)
-                    ? ' — blue corners to resize · sky diamonds for single-axis · purple dot to move · green dot to rotate (hold Shift for 15° snap)'
-                    : getHandlesNorm(selectedAnn).some(h => h.isRotateHandle)
-                      ? ' — drag purple dot to move · green dot to rotate (hold Shift for 15° snap)'
-                      : ''}
-              </span>
-
               {/* Color picker for selected annotation */}
-              <div className="w-px h-6 bg-white/10 shrink-0" />
               <span className="text-[9px] text-slate-400 font-black uppercase tracking-widest shrink-0">Color</span>
               <div className="flex items-center gap-1 shrink-0">
                 {COLORS.map(c => (
@@ -3142,6 +3141,18 @@ export const PdfMarkupEditor: React.FC<PdfMarkupEditorProps> = ({
                   Delete <span className="opacity-50 font-normal normal-case">⌫</span>
                 </button>
               )}
+
+              {/* Desktop interaction hint — pushed to the far right so the tools sit on the left */}
+              <span className="text-[9px] text-slate-400 font-bold uppercase tracking-widest shrink-0 ml-auto pl-3">
+                {selectedAnn.toolType.replace(/_/g, ' ')} selected
+                {selectedAnn.toolType === 'callout' && getHandlesNorm(selectedAnn).length >= 2
+                  ? ' — drag amber dot to repoint arrow · blue dot to move text box · green dot to rotate'
+                  : getHandlesNorm(selectedAnn).some(h => h.isRotateHandle) && getHandlesNorm(selectedAnn).some(h => !h.isMoveHandle && !h.isRotateHandle && !h.isEdgeHandle)
+                    ? ' — blue corners to resize · sky diamonds for single-axis · purple dot to move · green dot to rotate (hold Shift for 15° snap)'
+                    : getHandlesNorm(selectedAnn).some(h => h.isRotateHandle)
+                      ? ' — drag purple dot to move · green dot to rotate (hold Shift for 15° snap)'
+                      : ''}
+              </span>
             </>
           ) : (
             <span className="text-[9px] text-slate-500 font-bold uppercase tracking-widest">Tap any annotation to select it · Switch to Select to adjust handles · Esc to deselect</span>

--- a/components/pdfExport.tsx
+++ b/components/pdfExport.tsx
@@ -11,33 +11,31 @@ import {
 } from './PdfMarkupEditor.tsx';
 
 // ─────────────────────────────────────────────────────────────
-// PDF download helpers — the original file, or a flattened copy
-// with the saved markup drawn into each page as vector graphics.
-// The original page content (text, line work) is left untouched,
-// so the flattened copy stays searchable and crisp at any zoom.
+// PDF open/view helpers — open the original file, or a flattened
+// copy with the saved markup drawn into each page as vector
+// graphics, in a new browser tab. The original page content (text,
+// line work) is left untouched, so the flattened copy stays
+// searchable and crisp at any zoom.
 // ─────────────────────────────────────────────────────────────
 
-const isMobile = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-
+// Direct download fallback for when a new tab can't be opened (popup blocked).
 const triggerDownload = (href: string, fileName: string) => {
   const link = document.createElement('a');
   link.href = href;
   link.download = fileName;
-  if (isMobile()) {
-    link.style.display = 'none';
-    document.body.appendChild(link);
-    link.click();
-    setTimeout(() => document.body.removeChild(link), 100);
-  } else {
-    link.click();
-  }
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  setTimeout(() => document.body.removeChild(link), 100);
 };
 
-// Download the print exactly as it was uploaded (no annotations).
-export const downloadPrintOriginal = (print: JobPrint) => {
+// Open the print exactly as it was uploaded (no annotations) in a new tab.
+export const openPrintOriginal = (print: JobPrint) => {
   if (!print.url) return;
   const baseUrl = print.url.split('?')[0];
-  triggerDownload(`${baseUrl}?download=${encodeURIComponent(print.fileName)}`, print.fileName);
+  const win = window.open(baseUrl, '_blank', 'noopener,noreferrer');
+  // Popup blocked — fall back to a direct download so the file isn't lost.
+  if (!win) triggerDownload(`${baseUrl}?download=${encodeURIComponent(print.fileName)}`, print.fileName);
 };
 
 // Same dual-path loading the markup editor uses: authenticated storage
@@ -409,11 +407,25 @@ const annotatedFileName = (fileName: string) => {
   return `${stem} (markup).pdf`;
 };
 
-export const downloadPrintWithMarkup = async (print: JobPrint) => {
-  const blob = await buildAnnotatedPdfBlob(print);
-  const url = URL.createObjectURL(blob);
-  triggerDownload(url, annotatedFileName(print.fileName));
-  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+// Open a flattened copy (markup burned in) in a new tab. The caller opens the
+// tab synchronously inside the click handler and passes it in, so the popup
+// isn't blocked while the blob is being built.
+export const openPrintWithMarkup = async (print: JobPrint, targetWindow?: Window | null) => {
+  const win = targetWindow ?? window.open('', '_blank');
+  try {
+    const blob = await buildAnnotatedPdfBlob(print);
+    const url = URL.createObjectURL(blob);
+    if (win) {
+      win.location.href = url;
+    } else {
+      // Popup blocked — fall back to a direct download.
+      triggerDownload(url, annotatedFileName(print.fileName));
+    }
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  } catch (e) {
+    if (win) win.close();
+    throw e;
+  }
 };
 
 // ─────────────────────────────────────────────────────────────
@@ -449,10 +461,13 @@ export const PrintDownloadMenu: React.FC<PrintDownloadMenuProps> = ({
 
   const handleWithMarkup = async () => {
     setOpen(false);
+    // Open the tab synchronously (inside the click) so the popup isn't blocked.
+    const win = window.open('', '_blank');
     setExporting(true);
     try {
-      await downloadPrintWithMarkup(print);
+      await openPrintWithMarkup(print, win);
     } catch (e: unknown) {
+      if (win) win.close();
       alert('Export failed: ' + (e instanceof Error ? e.message : 'unknown error'));
     } finally {
       setExporting(false);
@@ -469,7 +484,7 @@ export const PrintDownloadMenu: React.FC<PrintDownloadMenuProps> = ({
         onClick={() => setOpen(v => !v)}
         disabled={exporting || !print.url}
         className={buttonClassName}
-        title="Download this PDF"
+        title="Open this PDF in a new tab"
       >
         <Download size={iconSize} className="shrink-0" />
         {exporting ? 'Preparing…' : label}
@@ -478,7 +493,7 @@ export const PrintDownloadMenu: React.FC<PrintDownloadMenuProps> = ({
         <div className={`absolute right-0 bottom-full mb-1 z-30 min-w-[190px] rounded-xl border shadow-xl overflow-hidden ${
           isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'
         }`}>
-          <button onClick={() => { setOpen(false); downloadPrintOriginal(print); }} className={itemClass}>
+          <button onClick={() => { setOpen(false); openPrintOriginal(print); }} className={itemClass}>
             Original PDF
           </button>
           <button onClick={handleWithMarkup} className={`${itemClass} border-t ${isDarkMode ? 'border-white/10' : 'border-slate-100'}`}>


### PR DESCRIPTION
## Summary

Two PDF-editor changes requested from the tablet:

### 1. Annotation tools moved to the left
In the markup editor's selected-annotation bar, the desktop interaction hint (`… blue corners to resize · sky diamonds … green dot to rotate`) used to sit on the far left, pushing the Color / Width / Rotate / etc. controls to the right. The controls are now on the left where you reach them first, and the hint is pushed to the far right (`ml-auto`). Hint text is unchanged.

### 2. Downloads / views open in a new tab
PDF actions now open the document in a new browser tab for viewing instead of forcing a file download:
- Editor **Download** button (flattened + markup) opens in a new tab.
- Job Hub download menu (**Original PDF** / **Flattened + Markup**) opens in a new tab.
- Job Hub **View** already opened in a new tab — now consistent.

For the async paths (building the flattened PDF), the tab is opened synchronously inside the click handler so popup blockers don't kill it, with a fallback to a direct download if the popup is blocked.

## Files
- `components/PdfMarkupEditor.tsx` — reorder selected-annotation bar; `handleExport` opens flattened PDF in a new tab.
- `components/pdfExport.tsx` — `openPrintOriginal` / `openPrintWithMarkup` (renamed from `download*`) open in a new tab; `PrintDownloadMenu` updated.

## Testing
- `npm run build` (vite) passes.
- No new TypeScript errors in the two changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGa7Fv6DyDpx9QNXYvfUg

---
_Generated by [Claude Code](https://claude.ai/code/session_016JGa7Fv6DyDpx9QNXYvfUg)_