### PR TITLE
Add notes and utility type to no-show and refresh alert emails

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import PhotoManager from './components/PhotoManager.tsx';
 import CalendarView from './components/CalendarView.tsx';
 import TeamManagement from './components/TeamManagement.tsx';
 import NoShowForm from './components/NoShowForm.tsx';
+import RefreshRequestForm from './components/RefreshRequestForm.tsx';
 import TicketNotesModal from './components/TicketNotesModal.tsx';
 import Login from './components/Login.tsx';
 import CompanyRegistration from './components/CompanyRegistration.tsx';
@@ -94,6 +95,7 @@ const App: React.FC = () => {
   // Bumped whenever the Job form closes so the Job Hub re-reads cost-code assignments.
   const [jobFormVersion, setJobFormVersion] = useState(0);
   const [noShowTicket, setNoShowTicket] = useState<DigTicket | null>(null);
+  const [refreshTicket, setRefreshTicket] = useState<DigTicket | null>(null);
   const [notesTicket, setNotesTicket] = useState<DigTicket | null>(null);
   const [digConfirmTicket, setDigConfirmTicket] = useState<DigTicket | null>(null);
   const [ticketMode, setTicketMode] = useState<'regular' | 'inbound' | 'equipment'>('regular');
@@ -515,7 +517,7 @@ const App: React.FC = () => {
     } else if (ticket) {
       const adminEmails = await apiService.getAlertEmails(sessionUser.companyId);
       if (adminEmails.length > 0) {
-        apiService.sendAlertEmail('no_show', ticket, record.author, adminEmails).catch(err => console.warn('Email alert failed:', err));
+        apiService.sendAlertEmail('no_show', ticket, record.author, adminEmails, { utilities: record.utilities, notes: record.notes }).catch(err => console.warn('Email alert failed:', err));
       }
     }
     initApp();
@@ -543,22 +545,38 @@ const App: React.FC = () => {
   const handleRefreshRequest = async (ticket: DigTicket, e: React.MouseEvent) => {
     e.stopPropagation();
     if (ticket.refreshRequested) {
+      // Already requested — clear it (no email, no form needed).
       if (!confirm(`Clear the Refresh Request for Ticket #${ticket.ticketNo}?`)) return;
+      try {
+        const saved = await apiService.saveTicket({ ...ticket, refreshRequested: false });
+        setTickets(prev => prev.map(t => t.id === saved.id ? saved : t));
+      } catch (error: any) {
+        alert('Refresh request failed: ' + error.message);
+      }
+      return;
     }
+    // New request — collect utility type and notes before sending the alert.
+    setRefreshTicket(ticket);
+  };
+
+  const handleSubmitRefreshRequest = async (utilities: string[], notes: string) => {
+    if (!refreshTicket) return;
+    const ticket = refreshTicket;
     try {
-      const updated = { ...ticket, refreshRequested: !ticket.refreshRequested };
-      const saved = await apiService.saveTicket(updated);
+      const saved = await apiService.saveTicket({ ...ticket, refreshRequested: true });
       setTickets(prev => prev.map(t => t.id === saved.id ? saved : t));
-      if (!ticket.refreshRequested) {
-        if (!sessionUser?.companyId) {
-          console.warn('Email alert skipped: no company ID on session user');
-        } else {
-          const adminEmails = await apiService.getAlertEmails(sessionUser.companyId);
-          if (adminEmails.length > 0) {
-            apiService.sendAlertEmail('refresh', ticket, sessionUser?.name || '', adminEmails).catch(err => console.warn('Email alert failed:', err));
-          }
+      if (!sessionUser?.companyId) {
+        console.warn('Email alert skipped: no company ID on session user');
+      } else {
+        const adminEmails = await apiService.getAlertEmails(sessionUser.companyId);
+        if (adminEmails.length > 0) {
+          apiService.sendAlertEmail('refresh', ticket, sessionUser?.name || '', adminEmails, {
+            utilities: utilities.length > 0 ? utilities : undefined,
+            notes: notes.trim() || undefined,
+          }).catch(err => console.warn('Email alert failed:', err));
         }
       }
+      setRefreshTicket(null);
     } catch (error: any) {
       alert('Refresh request failed: ' + error.message);
     }
@@ -1290,6 +1308,7 @@ const App: React.FC = () => {
       {selectedJobSummary && <JobSummaryModal job={selectedJobSummary} onClose={() => setSelectedJobSummary(null)} onEdit={() => { setEditingJob(selectedJobSummary); setShowJobForm(true); setSelectedJobSummary(null); }} onDelete={() => { apiService.deleteJob(selectedJobSummary.id).then(() => initApp()); setSelectedJobSummary(null); }} onToggleComplete={async () => { await apiService.saveJob({ ...selectedJobSummary, isComplete: !selectedJobSummary.isComplete }); initApp(); }} onViewMedia={() => { setMediaFolderFilter(selectedJobSummary.jobNumber); handleNavigate('photos'); }} onViewMarkup={() => { setShowMarkup(selectedJobSummary); setSelectedJobSummary(null); }} isDarkMode={isDarkMode} />}
       {showMarkup && <JobPrintMarkup job={showMarkup} isAdmin={isAdmin} sessionUser={sessionUser} onClose={() => setShowMarkup(null)} isDarkMode={isDarkMode} />}
       {noShowTicket && <NoShowForm ticket={noShowTicket} userName={sessionUser?.name || ''} onSave={handleSaveNoShow} onDelete={async () => { await apiService.deleteNoShow(noShowTicket.id); initApp(); return true; }} onClose={() => setNoShowTicket(null)} isDarkMode={isDarkMode} />}
+      {refreshTicket && <RefreshRequestForm ticket={refreshTicket} onSubmit={handleSubmitRefreshRequest} onClose={() => setRefreshTicket(null)} isDarkMode={isDarkMode} />}
       {notesTicket && <TicketNotesModal ticket={notesTicket} userName={sessionUser?.name || ''} isAdmin={isAdmin} onClose={() => { setNotesTicket(null); apiService.getNotes().then(setNotes).catch((err) => console.error('Failed to refresh notes:', err)); }} isDarkMode={isDarkMode} />}
       {digConfirmTicket && (
         <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-md z-[200] flex items-center justify-center p-4">

--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import CalendarView from './components/CalendarView.tsx';
 import TeamManagement from './components/TeamManagement.tsx';
 import NoShowForm from './components/NoShowForm.tsx';
 import RefreshRequestForm from './components/RefreshRequestForm.tsx';
+import ConfirmDialog from './components/ConfirmDialog.tsx';
 import TicketNotesModal from './components/TicketNotesModal.tsx';
 import Login from './components/Login.tsx';
 import CompanyRegistration from './components/CompanyRegistration.tsx';
@@ -97,6 +98,7 @@ const App: React.FC = () => {
   const [noShowTicket, setNoShowTicket] = useState<DigTicket | null>(null);
   const [refreshTicket, setRefreshTicket] = useState<DigTicket | null>(null);
   const [notesTicket, setNotesTicket] = useState<DigTicket | null>(null);
+  const [confirmDialog, setConfirmDialog] = useState<{ message: string; confirmLabel?: string; onConfirm: () => void | Promise<void> } | null>(null);
   const [digConfirmTicket, setDigConfirmTicket] = useState<DigTicket | null>(null);
   const [ticketMode, setTicketMode] = useState<'regular' | 'inbound' | 'equipment'>('regular');
   const [snoozedDigConfirmIds, setSnoozedDigConfirmIds] = useState<Set<string>>(new Set());
@@ -492,15 +494,25 @@ const App: React.FC = () => {
     if (company?.id === id) setCompany({ ...company, inventoryEnabled });
   };
 
-  const handleToggleArchive = async (ticket: DigTicket, e: React.MouseEvent) => {
+  const applyArchiveToggle = async (ticket: DigTicket, willArchive: boolean) => {
+    const updated = { ...ticket, isArchived: willArchive };
+    const saved = await apiService.saveTicket(updated);
+    setTickets(prev => prev.map(t => t.id === saved.id ? saved : t));
+  };
+
+  const handleToggleArchive = (ticket: DigTicket, e: React.MouseEvent) => {
     e.stopPropagation();
     const willArchive = !ticket.isArchived;
-    if (willArchive && !confirm(`Archive Ticket #${ticket.ticketNo}?`)) return;
-    try {
-      const updated = { ...ticket, isArchived: willArchive };
-      const saved = await apiService.saveTicket(updated);
-      setTickets(prev => prev.map(t => t.id === saved.id ? saved : t));
-    } catch (error: any) { alert("Archive failed: " + error.message); }
+    if (!willArchive) {
+      // Un-archiving needs no confirmation.
+      applyArchiveToggle(ticket, false).catch((error: any) => alert('Archive failed: ' + error.message));
+      return;
+    }
+    setConfirmDialog({
+      message: `Archive Ticket #${ticket.ticketNo}?`,
+      confirmLabel: 'Archive',
+      onConfirm: () => applyArchiveToggle(ticket, true),
+    });
   };
 
   const sendAdminNotification = (title: string, body: string) => {
@@ -542,17 +554,18 @@ const App: React.FC = () => {
     await apiService.testAlertEmail(firstEmail);
   };
 
-  const handleRefreshRequest = async (ticket: DigTicket, e: React.MouseEvent) => {
+  const handleRefreshRequest = (ticket: DigTicket, e: React.MouseEvent) => {
     e.stopPropagation();
     if (ticket.refreshRequested) {
-      // Already requested — clear it (no email, no form needed).
-      if (!confirm(`Clear the Refresh Request for Ticket #${ticket.ticketNo}?`)) return;
-      try {
-        const saved = await apiService.saveTicket({ ...ticket, refreshRequested: false });
-        setTickets(prev => prev.map(t => t.id === saved.id ? saved : t));
-      } catch (error: any) {
-        alert('Refresh request failed: ' + error.message);
-      }
+      // Already requested — confirm and clear it (no email, no form needed).
+      setConfirmDialog({
+        message: `Clear the Refresh Request for Ticket #${ticket.ticketNo}?`,
+        confirmLabel: 'Clear Refresh',
+        onConfirm: async () => {
+          const saved = await apiService.saveTicket({ ...ticket, refreshRequested: false });
+          setTickets(prev => prev.map(t => t.id === saved.id ? saved : t));
+        },
+      });
       return;
     }
     // New request — collect utility type and notes before sending the alert.
@@ -1309,6 +1322,7 @@ const App: React.FC = () => {
       {showMarkup && <JobPrintMarkup job={showMarkup} isAdmin={isAdmin} sessionUser={sessionUser} onClose={() => setShowMarkup(null)} isDarkMode={isDarkMode} />}
       {noShowTicket && <NoShowForm ticket={noShowTicket} userName={sessionUser?.name || ''} onSave={handleSaveNoShow} onDelete={async () => { await apiService.deleteNoShow(noShowTicket.id); initApp(); return true; }} onClose={() => setNoShowTicket(null)} isDarkMode={isDarkMode} />}
       {refreshTicket && <RefreshRequestForm ticket={refreshTicket} onSubmit={handleSubmitRefreshRequest} onClose={() => setRefreshTicket(null)} isDarkMode={isDarkMode} />}
+      {confirmDialog && <ConfirmDialog message={confirmDialog.message} confirmLabel={confirmDialog.confirmLabel} onConfirm={confirmDialog.onConfirm} onClose={() => setConfirmDialog(null)} isDarkMode={isDarkMode} />}
       {notesTicket && <TicketNotesModal ticket={notesTicket} userName={sessionUser?.name || ''} isAdmin={isAdmin} onClose={() => { setNotesTicket(null); apiService.getNotes().then(setNotes).catch((err) => console.error('Failed to refresh notes:', err)); }} isDarkMode={isDarkMode} />}
       {digConfirmTicket && (
         <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-md z-[200] flex items-center justify-center p-4">

--- a/components/ConfirmDialog.tsx
+++ b/components/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+
+interface ConfirmDialogProps {
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void | Promise<void>;
+  onClose: () => void;
+  isDarkMode?: boolean;
+}
+
+// A pure-React confirmation dialog used in place of window.confirm(), which is
+// suppressed in sandboxed contexts (e.g. Vercel preview iframes) and would make
+// confirm-gated actions silently do nothing. Errors are shown inline instead of
+// via window.alert (also suppressed in those contexts).
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({ message, confirmLabel = 'Confirm', cancelLabel = 'Cancel', onConfirm, onClose, isDarkMode }) => {
+  const [isBusy, setIsBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    setIsBusy(true);
+    setError(null);
+    try {
+      await onConfirm();
+      onClose();
+    } catch (err: any) {
+      setError(err?.message || 'Something went wrong. Please try again.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-slate-950/70 backdrop-blur-sm z-[190] flex justify-center items-center p-4">
+      <div className={`w-full max-w-sm rounded-2xl shadow-2xl overflow-hidden border animate-in ${isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'}`}>
+        <div className="p-6 space-y-5">
+          <p className={`text-[13px] font-bold text-center ${isDarkMode ? 'text-slate-200' : 'text-slate-900'}`}>{message}</p>
+          {error && <p className="text-[10px] font-bold text-center text-rose-500">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={isBusy}
+              onClick={onClose}
+              className={`flex-1 py-3.5 rounded-xl font-black text-[10px] uppercase tracking-widest transition-all active:scale-[0.98] disabled:opacity-50 ${isDarkMode ? 'bg-white/5 text-slate-300 hover:bg-white/10' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'}`}
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              disabled={isBusy}
+              onClick={handleConfirm}
+              className="flex-1 bg-emerald-600 text-white py-3.5 rounded-xl font-black text-[10px] uppercase tracking-widest shadow-xl shadow-emerald-600/20 transition-all active:scale-[0.98] disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {isBusy ? (
+                <>
+                  <div className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  Working...
+                </>
+              ) : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/components/NoShowForm.tsx
+++ b/components/NoShowForm.tsx
@@ -17,6 +17,7 @@ const UTILITIES = ['All', 'Power', 'Gas', 'Telecom', 'City/Village', 'Private'];
 const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDelete, onClose, isDarkMode }) => {
   // Store selections as an object where key is utility and value is company name
   const [selections, setSelections] = useState<Record<string, string>>({});
+  const [notes, setNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [existingRecord, setExistingRecord] = useState<NoShowRecord | null>(null);
@@ -106,6 +107,7 @@ const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDel
         jobNumber: ticket.jobNumber,
         utilities: selectedKeys,
         companies: companiesInfo,
+        notes: notes.trim() || undefined,
         author: userName,
         timestamp: Date.now(),
       };
@@ -194,6 +196,13 @@ const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDel
                     </div>
                   )}
 
+                  {existingRecord.notes && (
+                    <div className="space-y-1 pt-1">
+                      <p className={`text-[9px] font-black uppercase tracking-tight ${isDarkMode ? 'text-slate-400' : 'text-slate-900'}`}>Notes</p>
+                      <p className={`text-[11px] font-bold italic ${isDarkMode ? 'text-slate-300' : 'text-slate-900'}`}>"{existingRecord.notes}"</p>
+                    </div>
+                  )}
+
                   <div className={`pt-2 border-t flex items-center justify-between ${isDarkMode ? 'border-rose-500/10' : 'border-rose-200'}`}>
                      <p className={`text-[9px] font-bold uppercase ${isDarkMode ? 'text-slate-400' : 'text-slate-950'}`}>Logged By: <span className="font-black text-rose-600">{existingRecord.author}</span></p>
                   </div>
@@ -261,6 +270,17 @@ const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDel
                   );
                 })}
               </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className={`text-[10px] font-black uppercase tracking-widest ${isDarkMode ? 'text-slate-400' : 'text-slate-950'}`}>Notes <span className="opacity-50">(optional)</span></p>
+              <textarea
+                rows={3}
+                placeholder="Add any details for the admin (access issues, contractor info, etc.)..."
+                className={`w-full px-4 py-2.5 border rounded-xl text-[11px] font-bold outline-none focus:ring-4 focus:ring-rose-500/10 transition-all resize-none ${isDarkMode ? 'bg-white/5 border-white/10 text-white placeholder:text-slate-600' : 'bg-slate-50 border-slate-300 text-slate-900 placeholder:text-slate-500'}`}
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+              />
             </div>
 
             <div className="pt-2">

--- a/components/NoShowForm.tsx
+++ b/components/NoShowForm.tsx
@@ -20,6 +20,8 @@ const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDel
   const [notes, setNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+  const [clearError, setClearError] = useState<string | null>(null);
   const [existingRecord, setExistingRecord] = useState<NoShowRecord | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -121,15 +123,14 @@ const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDel
     }
   };
 
+  // Runs the actual clear after in-modal confirmation. We deliberately avoid
+  // window.confirm/alert here: in sandboxed contexts (e.g. a Vercel preview
+  // iframe) those are suppressed and the click would silently do nothing.
   const handleClearNoShow = async () => {
     if (!onDelete) return;
-    
-    // Explicit confirmation as requested by user
-    if (!window.confirm(`Clear the No Show alert for Ticket #${ticket.ticketNo}? This incident will be resolved and archived.`)) {
-      return;
-    }
 
     setIsDeleting(true);
+    setClearError(null);
     try {
       // Calling onDelete (handleRemoveNoShow in App.tsx)
       const success = await onDelete();
@@ -137,7 +138,7 @@ const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDel
         onClose();
       }
     } catch (err: any) {
-      alert("Error clearing no-show: " + err.message);
+      setClearError(err?.message || 'Failed to clear the no-show. Please try again.');
     } finally {
       setIsDeleting(false);
     }
@@ -210,19 +211,47 @@ const NoShowForm: React.FC<NoShowFormProps> = ({ ticket, userName, onSave, onDel
             </div>
 
             <div className="space-y-3">
-               <button
-                  type="button"
-                  disabled={isDeleting}
-                  onClick={handleClearNoShow}
-                  className="w-full bg-slate-900 dark:bg-white text-white dark:text-slate-900 py-3.5 rounded-xl font-black text-[10px] uppercase tracking-widest shadow-xl transition-all active:scale-[0.98] hover:bg-emerald-600 hover:text-white dark:hover:bg-emerald-600 flex items-center justify-center gap-2"
-                >
-                  {isDeleting ? (
-                    <>
-                      <div className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                      Clearing...
-                    </>
-                  ) : 'Clear No Show Alert'}
-                </button>
+               {!confirmingClear ? (
+                 <button
+                    type="button"
+                    onClick={() => { setClearError(null); setConfirmingClear(true); }}
+                    className="w-full bg-slate-900 dark:bg-white text-white dark:text-slate-900 py-3.5 rounded-xl font-black text-[10px] uppercase tracking-widest shadow-xl transition-all active:scale-[0.98] hover:bg-emerald-600 hover:text-white dark:hover:bg-emerald-600 flex items-center justify-center gap-2"
+                  >
+                    Clear No Show Alert
+                  </button>
+               ) : (
+                 <div className="space-y-3">
+                    <p className={`text-[10px] font-bold text-center px-2 ${isDarkMode ? 'text-slate-300' : 'text-slate-900'}`}>
+                      Clear the No Show alert for Ticket #{ticket.ticketNo}? This incident will be resolved and archived.
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        disabled={isDeleting}
+                        onClick={() => setConfirmingClear(false)}
+                        className={`flex-1 py-3.5 rounded-xl font-black text-[10px] uppercase tracking-widest transition-all active:scale-[0.98] disabled:opacity-50 ${isDarkMode ? 'bg-white/5 text-slate-300 hover:bg-white/10' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'}`}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        disabled={isDeleting}
+                        onClick={handleClearNoShow}
+                        className="flex-1 bg-emerald-600 text-white py-3.5 rounded-xl font-black text-[10px] uppercase tracking-widest shadow-xl shadow-emerald-600/20 transition-all active:scale-[0.98] disabled:opacity-50 flex items-center justify-center gap-2"
+                      >
+                        {isDeleting ? (
+                          <>
+                            <div className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                            Clearing...
+                          </>
+                        ) : 'Confirm Clear'}
+                      </button>
+                    </div>
+                 </div>
+               )}
+                {clearError && (
+                  <p className="text-[10px] font-bold text-center px-2 text-rose-500">{clearError}</p>
+                )}
                 <p className={`text-[9px] font-bold uppercase tracking-tighter text-center px-4 ${isDarkMode ? 'text-slate-400' : 'text-slate-950'}`}>Clicking clear will resolve the status and archive this specific incident log from the vault.</p>
             </div>
           </div>

--- a/components/RefreshRequestForm.tsx
+++ b/components/RefreshRequestForm.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { DigTicket } from '../types.ts';
+
+interface RefreshRequestFormProps {
+  ticket: DigTicket;
+  onSubmit: (utilities: string[], notes: string) => Promise<void>;
+  onClose: () => void;
+  isDarkMode?: boolean;
+}
+
+const UTILITIES = ['All', 'Power', 'Gas', 'Telecom', 'City/Village', 'Private'];
+
+const RefreshRequestForm: React.FC<RefreshRequestFormProps> = ({ ticket, onSubmit, onClose, isDarkMode }) => {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [notes, setNotes] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const toggleUtility = (utility: string) => {
+    setSelected(prev => {
+      if (utility === 'All') {
+        return prev.includes('All') ? [] : ['All'];
+      }
+      const withoutAll = prev.filter(u => u !== 'All');
+      return withoutAll.includes(utility)
+        ? withoutAll.filter(u => u !== utility)
+        : [...withoutAll, utility];
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await onSubmit(selected, notes);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-slate-950/70 backdrop-blur-sm z-[180] flex justify-center items-center p-4">
+      <div className={`w-full max-w-md rounded-2xl shadow-2xl overflow-hidden border animate-in ${isDarkMode ? 'bg-[#1e293b] border-white/10' : 'bg-white border-slate-200'}`}>
+        <div className="px-6 py-4 border-b flex justify-between items-center bg-amber-50/50">
+          <div className="flex items-center gap-2">
+            <div className="bg-amber-500 p-1.5 rounded-lg shadow-lg shadow-amber-500/20">
+              <svg className="w-3.5 h-3.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
+            </div>
+            <h2 className={`text-sm font-black uppercase tracking-widest ${isDarkMode ? 'text-amber-500' : 'text-amber-600'}`}>
+              Request Refresh
+            </h2>
+          </div>
+          <button onClick={onClose} className="p-1 opacity-50 hover:opacity-100 transition-opacity">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          <div className="space-y-4">
+            <p className={`text-[10px] font-black uppercase tracking-widest mb-2 ${isDarkMode ? 'text-slate-400' : 'text-slate-950'}`}>Which utilities need a refresh? <span className="opacity-50">(optional)</span></p>
+
+            <div className="space-y-2">
+              {UTILITIES.map(u => {
+                const isSelected = selected.includes(u);
+                return (
+                  <button
+                    key={u}
+                    type="button"
+                    onClick={() => toggleUtility(u)}
+                    className={`w-full flex items-center justify-between px-4 py-3 rounded-xl border text-[10px] font-black uppercase tracking-widest transition-all ${
+                      isSelected
+                        ? 'bg-amber-500 border-amber-500 text-white shadow-lg shadow-amber-500/20'
+                        : isDarkMode ? 'bg-white/5 border-white/5 text-slate-400 hover:border-white/10' : 'bg-slate-50 border-slate-300 text-slate-900 hover:border-slate-400'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className={`w-4 h-4 rounded flex items-center justify-center border ${isSelected ? 'bg-white border-white' : 'bg-transparent border-current opacity-30'}`}>
+                        {isSelected && <svg className="w-2.5 h-2.5 text-amber-500" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" /></svg>}
+                      </div>
+                      {u}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className={`text-[10px] font-black uppercase tracking-widest ${isDarkMode ? 'text-slate-400' : 'text-slate-950'}`}>Notes <span className="opacity-50">(optional)</span></p>
+            <textarea
+              rows={3}
+              placeholder="Add any details for the admin (why a refresh is needed, contacts, etc.)..."
+              className={`w-full px-4 py-2.5 border rounded-xl text-[11px] font-bold outline-none focus:ring-4 focus:ring-amber-500/10 transition-all resize-none ${isDarkMode ? 'bg-white/5 border-white/10 text-white placeholder:text-slate-600' : 'bg-slate-50 border-slate-300 text-slate-900 placeholder:text-slate-500'}`}
+              value={notes}
+              onChange={e => setNotes(e.target.value)}
+            />
+          </div>
+
+          <div className="pt-2">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full bg-amber-500 text-white py-3.5 rounded-xl font-black text-[10px] uppercase tracking-widest shadow-xl shadow-amber-500/20 disabled:opacity-50 transition-all active:scale-[0.98]"
+            >
+              {isSubmitting ? 'Sending Request...' : 'Send Refresh Request'}
+            </button>
+            <div className="flex justify-between items-center mt-6 opacity-40">
+              <span className={`text-[8px] font-black uppercase tracking-tighter ${isDarkMode ? 'text-slate-400' : 'text-slate-950'}`}>ID: {ticket.ticketNo}</span>
+              <span className={`text-[8px] font-black uppercase tracking-tighter ${isDarkMode ? 'text-slate-400' : 'text-slate-950'}`}>JOB: {ticket.jobNumber}</span>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default RefreshRequestForm;

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -632,8 +632,12 @@ export const apiService = {
   },
 
   async deleteNoShow(ticketId: string): Promise<void> {
-    await supabase.from('no_shows').delete().eq('ticket_id', ticketId);
-    await supabase.from('tickets').update({ no_show_requested: false }).eq('id', ticketId);
+    // Surface failures instead of swallowing them — a silent RLS/permission
+    // error here previously left the alert un-clearable with no feedback.
+    const { error: delError } = await supabase.from('no_shows').delete().eq('ticket_id', ticketId);
+    if (delError) throw delError;
+    const { error: updError } = await supabase.from('tickets').update({ no_show_requested: false }).eq('id', ticketId);
+    if (updError) throw updError;
   },
 
   async getJobPrints(jobNumber: string): Promise<JobPrint[]> {

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -176,9 +176,10 @@ create table if not exists no_shows (
     company_id uuid references companies(id) not null,
     ticket_id uuid references tickets(id) on delete cascade, 
     job_number text, 
-    utilities text[], 
-    companies text, 
-    author text, 
+    utilities text[],
+    companies text,
+    notes text,
+    author text,
     timestamp bigint
 );
 
@@ -616,11 +617,16 @@ export const apiService = {
   async getNoShows(): Promise<NoShowRecord[]> {
     const { data, error } = await supabase.from('no_shows').select('*');
     if (error) return [];
-    return (data || []).map(n => ({ id: n.id, ticketId: n.ticket_id, companyId: n.company_id, jobNumber: n.job_number, utilities: n.utilities || [], companies: n.companies || '', author: n.author || '', timestamp: Number(n.timestamp) }));
+    return (data || []).map(n => ({ id: n.id, ticketId: n.ticket_id, companyId: n.company_id, jobNumber: n.job_number, utilities: n.utilities || [], companies: n.companies || '', notes: n.notes || undefined, author: n.author || '', timestamp: Number(n.timestamp) }));
   },
 
   async addNoShow(noShow: NoShowRecord): Promise<void> {
-    const { error } = await supabase.from('no_shows').insert([{ id: noShow.id, company_id: noShow.companyId, ticket_id: noShow.ticketId, job_number: noShow.jobNumber, utilities: noShow.utilities, companies: noShow.companies, author: noShow.author, timestamp: noShow.timestamp }]);
+    const baseRow = { id: noShow.id, company_id: noShow.companyId, ticket_id: noShow.ticketId, job_number: noShow.jobNumber, utilities: noShow.utilities, companies: noShow.companies, author: noShow.author, timestamp: noShow.timestamp };
+    let { error } = await supabase.from('no_shows').insert([{ ...baseRow, notes: noShow.notes ?? null }]);
+    // Gracefully degrade if the `notes` column hasn't been migrated yet.
+    if (error && /notes/i.test(error.message) && (error.code === 'PGRST204' || /column/i.test(error.message))) {
+      ({ error } = await supabase.from('no_shows').insert([baseRow]));
+    }
     if (error) throw error;
     await supabase.from('tickets').update({ no_show_requested: true }).eq('id', noShow.ticketId);
   },

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1115,7 +1115,8 @@ export const apiService = {
     type: 'no_show' | 'refresh',
     ticket: DigTicket,
     actor: string,
-    adminEmails: string[]
+    adminEmails: string[],
+    options?: { utilities?: string[]; notes?: string }
   ): Promise<void> {
     if (adminEmails.length === 0) return;
     const { data, error } = await supabase.functions.invoke('send-alert-email', {
@@ -1128,6 +1129,8 @@ export const apiService = {
         state: ticket.state,
         expires: ticket.expires,
         actor,
+        utilities: options?.utilities,
+        notes: options?.notes,
         adminEmails,
       },
     });

--- a/supabase/functions/send-alert-email/index.ts
+++ b/supabase/functions/send-alert-email/index.ts
@@ -18,6 +18,8 @@ interface AlertPayload {
   state?: string;
   expires?: string;
   actor: string;
+  utilities?: string[];
+  notes?: string;
   adminEmails: string[];
 }
 
@@ -28,7 +30,7 @@ Deno.serve(async (req) => {
 
   try {
     const payload: AlertPayload = await req.json();
-    const { type, ticketNo, jobNumber, street, city, state, expires, actor, adminEmails } = payload;
+    const { type, ticketNo, jobNumber, street, city, state, expires, actor, utilities, notes, adminEmails } = payload;
 
     const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
     const FROM_EMAIL = Deno.env.get('RESEND_FROM_EMAIL');
@@ -63,6 +65,18 @@ Deno.serve(async (req) => {
 
     const locationParts = [street, city, state].filter(Boolean).join(', ');
 
+    // Escape any user-supplied text before interpolating into the HTML email.
+    const escapeHtml = (value: string) =>
+      value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+    const utilitiesLabel = (utilities ?? []).filter(Boolean).map(escapeHtml).join(', ');
+    const notesText = (notes ?? '').trim();
+
     const htmlBody = `<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
@@ -86,6 +100,10 @@ Deno.serve(async (req) => {
           <td style="padding:10px 0;border-bottom:1px solid #f1f5f9;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:0.12em;color:#94a3b8;">Job #</td>
           <td style="padding:10px 0;border-bottom:1px solid #f1f5f9;font-size:13px;font-weight:700;color:#0f172a;font-family:monospace;">${jobNumber}</td>
         </tr>
+        ${utilitiesLabel ? `<tr>
+          <td style="padding:10px 0;border-bottom:1px solid #f1f5f9;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:0.12em;color:#94a3b8;">Utility Type</td>
+          <td style="padding:10px 0;border-bottom:1px solid #f1f5f9;font-size:13px;font-weight:700;color:#0f172a;">${utilitiesLabel}</td>
+        </tr>` : ''}
         <tr>
           <td style="padding:10px 0;border-bottom:1px solid #f1f5f9;font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:0.12em;color:#94a3b8;">Location</td>
           <td style="padding:10px 0;border-bottom:1px solid #f1f5f9;font-size:13px;font-weight:600;color:#334155;">${locationParts || '—'}</td>
@@ -95,6 +113,10 @@ Deno.serve(async (req) => {
           <td style="padding:10px 0;font-size:13px;font-weight:600;color:#334155;">${expires}</td>
         </tr>` : ''}
       </table>
+      ${notesText ? `<div style="margin-top:24px;padding:16px;background:#fffbeb;border-radius:8px;border:1px solid #fde68a;">
+        <p style="margin:0 0 6px;font-size:10px;color:#b45309;font-weight:800;text-transform:uppercase;letter-spacing:0.1em;">Notes</p>
+        <p style="margin:0;font-size:13px;line-height:1.5;color:#334155;white-space:pre-wrap;">${escapeHtml(notesText)}</p>
+      </div>` : ''}
       <div style="margin-top:24px;padding:14px 16px;background:#f8fafc;border-radius:8px;border:1px solid #e2e8f0;">
         <p style="margin:0;font-size:10px;color:#94a3b8;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;">
           Log in to DigTrack Pro to view the full ticket and take action.

--- a/supabase/migrations/20260725000000_add_notes_to_no_shows.sql
+++ b/supabase/migrations/20260725000000_add_notes_to_no_shows.sql
@@ -1,0 +1,4 @@
+-- Add an optional free-text notes column to no_shows.
+-- Notes are entered by the foreman/user when logging a no show and are
+-- included in the alert email alongside the utility type(s).
+alter table public.no_shows add column if not exists notes text;

--- a/types.ts
+++ b/types.ts
@@ -219,6 +219,7 @@ export interface NoShowRecord {
   jobNumber: string;
   utilities: string[];
   companies: string;
+  notes?: string;
   author: string;
   timestamp: number;
 }


### PR DESCRIPTION
No-show and refresh alert emails now include the utility type(s) and any
free-text notes the foreman/user enters:

- send-alert-email edge function: render a "Utility Type" row and a "Notes"
  block, with HTML-escaping for user-supplied text
- apiService.sendAlertEmail: accept optional { utilities, notes } and forward
  them in the function payload
- No Show form: add an optional notes field; carry utilities + notes into the
  alert email (and surface notes in the incident log)
- Refresh request: add a RefreshRequestForm modal to collect utility type +
  notes before sending the alert, instead of a bare toggle

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UGeh8DecjZaFmhUcbedYLi